### PR TITLE
feat(svelte): delegate runtime compilation to rsvelte

### DIFF
--- a/.claude/skills/framework-adapters/SKILL.md
+++ b/.claude/skills/framework-adapters/SKILL.md
@@ -200,10 +200,14 @@ implements, exposing EXACTLY four compiler-domain ops:
   `VerterCompileResult` INTERNALLY then re-expresses it neutrally
   (`vue_result_to_runtime_bundle`); it leaves `main.body_code = None` so the
   host assembles the `_sfc_main` module from the block fields
-  (`assemble_vue_main_module`). A carrier that projects ONLY an IDE surface
-  (Svelte today) returns a bundle with no runtime surface
-  (`has_runtime_surface() == false`) carrying just the `tsx` — the host
-  populates `CachedTsx` and emits NO `Main` virtual node. Framework-PRIVATE
+  (`assemble_vue_main_module`). Svelte delegates runtime parse/analyze/emit to
+  the pinned `rsvelte_core::toolchain` facade through the private
+  `svelte::rsvelte_bridge`; the bridge returns rsvelte's self-contained ESM in
+  `main.body_code` for client or server targets and translates CSS, maps,
+  warnings, and failures into neutral carrier DTOs. rsvelte types never cross
+  the bridge, and a runtime failure carries a typed `runtime_refusal` reason
+  while the independent Verter IDE projection still completes.
+  Framework-PRIVATE
   resolved inputs (Vue's `external_types` / `prop_constness` /
   `style_v_bind_vars`) ride OPAQUELY on `RuntimeCompileOptions.framework_extras`
   (`Arc<dyn Any>`, downcast to `vue_bridge::VueRuntimeCompileExtras`) so Vue's
@@ -287,8 +291,8 @@ the shared compile produces the WHOLE artifact set (every virtual node + the
 IDE `CachedTsx`) in one pass, and the demand is checked AFTER the shared result
 (warm-hit + cold). `ensure_ide_compiled(canonical, profile) -> Result<bool>`
 is the EXPLICIT IDE-ensure path: it resolves through `CompileDemand::Ide`
-(NEVER requests `VirtualNodeKind::Main`), so a Main-less carrier (Svelte)
-populates its `CachedTsx` and succeeds without a runtime `Main`. `get_ide`
+(NEVER requests `VirtualNodeKind::Main`), so IDE production is not coupled to
+runtime-module availability. `get_ide`
 stays a PURE cached read (`peek_tsx`) — it NEVER computes on read. Both pinned
 by the static guards `get_ide_is_a_pure_cached_read_no_compute` and
 `ensure_ide_compiled_never_requests_virtual_node_main`. Exposed on WASM + NAPI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,9 +286,21 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "bitvec"
@@ -526,6 +538,20 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "serde",
+ "static_assertions",
+ "zmij",
 ]
 
 [[package]]
@@ -1489,6 +1515,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,10 +1585,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.17"
+name = "itertools"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -1723,9 +1772,31 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "mime"
@@ -1867,6 +1938,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,7 +2019,23 @@ checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
 dependencies = [
  "cfg-if",
  "owo-colors",
- "oxc-miette-derive",
+ "oxc-miette-derive 2.7.1",
+ "textwrap",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "oxc-miette"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0df30faa68797917ca4263e7a2f889ec829e4da2dcb3d6dc752f7a494180f3"
+dependencies = [
+ "cfg-if",
+ "memchr",
+ "owo-colors",
+ "oxc-miette-derive 3.0.1",
  "textwrap",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -1957,6 +2054,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc-miette-derive"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc072d11d45ebe7801459b4e829184ba0934d68027fdc51d327335b53a95a49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "oxc_allocator"
 version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,8 +2072,22 @@ checksum = "e54dd7c5eb0fa364f0b7ca09109f21cede0ae5f72001163170d954d62a0e4e86"
 dependencies = [
  "allocator-api2 0.2.21",
  "hashbrown 0.17.1",
- "oxc_data_structures",
+ "oxc_data_structures 0.126.0",
  "rustc-hash 2.1.2",
+]
+
+[[package]]
+name = "oxc_allocator"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ffd0bdf76f7272e208a4f55740d309f303a104f198bf4902a7377ae33e0a34"
+dependencies = [
+ "allocator-api2 0.2.21",
+ "hashbrown 0.17.1",
+ "oxc_data_structures 0.141.0",
+ "oxc_estree 0.141.0",
+ "rustc-hash 2.1.2",
+ "serde",
 ]
 
 [[package]]
@@ -1975,15 +2097,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7391676b3f06b7cb8e720ec06daf052395bb7516a8b647992ce5a21ea997989"
 dependencies = [
  "bitflags",
- "oxc_allocator",
- "oxc_ast_macros",
- "oxc_data_structures",
- "oxc_diagnostics",
- "oxc_estree",
- "oxc_regular_expression",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_allocator 0.126.0",
+ "oxc_ast_macros 0.126.0",
+ "oxc_data_structures 0.126.0",
+ "oxc_diagnostics 0.126.0",
+ "oxc_estree 0.126.0",
+ "oxc_regular_expression 0.126.0",
+ "oxc_span 0.126.0",
+ "oxc_str 0.126.0",
+ "oxc_syntax 0.126.0",
+]
+
+[[package]]
+name = "oxc_ast"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4a9979cd3cebde3db75fafa713d72e6e891827c29e3ed11d005791052456d9"
+dependencies = [
+ "bitflags",
+ "oxc_allocator 0.141.0",
+ "oxc_ast_macros 0.141.0",
+ "oxc_data_structures 0.141.0",
+ "oxc_diagnostics 0.141.0",
+ "oxc_estree 0.141.0",
+ "oxc_regular_expression 0.141.0",
+ "oxc_span 0.141.0",
+ "oxc_str 0.141.0",
+ "oxc_syntax 0.141.0",
 ]
 
 [[package]]
@@ -1999,15 +2139,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_ast_macros"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0adbaf016626ad630020c2d5f9078809aeb115966a9268b313e920c98e58040"
+dependencies = [
+ "phf 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "oxc_ast_visit"
 version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67e09457c976c28b5f7b28673ad5526c10e0b74cee3d7befccea7a85c6f960a"
 dependencies = [
- "oxc_allocator",
- "oxc_ast",
- "oxc_span",
- "oxc_syntax",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_span 0.126.0",
+ "oxc_syntax 0.126.0",
+]
+
+[[package]]
+name = "oxc_ast_visit"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95874e8d4c97ee55054ae50746347fc6d018d0bed9e4f40fef483eb4cf22825a"
+dependencies = [
+ "oxc_allocator 0.141.0",
+ "oxc_ast 0.141.0",
+ "oxc_span 0.141.0",
+ "oxc_syntax 0.141.0",
+]
+
+[[package]]
+name = "oxc_codegen"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3adfd793b0d006c599af1fe8975751cbf425df22c04d55e50691febd3f978fc"
+dependencies = [
+ "bitflags",
+ "cow-utils",
+ "dragonbox_ecma",
+ "itoa",
+ "oxc_allocator 0.141.0",
+ "oxc_ast 0.141.0",
+ "oxc_data_structures 0.141.0",
+ "oxc_index 5.0.0",
+ "oxc_semantic 0.141.0",
+ "oxc_sourcemap 8.1.2",
+ "oxc_span 0.141.0",
+ "oxc_str 0.141.0",
+ "oxc_syntax 0.141.0",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -2017,13 +2203,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdea5ebbfe376448e83f9749828f31a0ad9b85a1b01e31f70597565b74f809a"
 
 [[package]]
+name = "oxc_data_structures"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c41eb52557e3255ebacd0d0b5406d1c8703a59cb5300938940b91de41a46f"
+
+[[package]]
 name = "oxc_diagnostics"
 version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5ac2365c7cf9255776ceb41310c90d9e636586cf291ae9c0df50028f559837b"
 dependencies = [
  "cow-utils",
- "oxc-miette",
+ "oxc-miette 2.7.1",
+ "percent-encoding",
+]
+
+[[package]]
+name = "oxc_diagnostics"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d355bdf332e8412c7e7e061bf53ac3bf71956225722e8ce1b9428402d97e9db"
+dependencies = [
+ "cow-utils",
+ "oxc-miette 3.0.1",
  "percent-encoding",
 ]
 
@@ -2034,13 +2237,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "651a4509f2de47c7e49fc3a78e136e821062c4d97d2544c6336dda0f4513cfc6"
 dependencies = [
  "cow-utils",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
- "oxc_allocator",
- "oxc_ast",
- "oxc_regular_expression",
- "oxc_span",
- "oxc_syntax",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_regular_expression 0.126.0",
+ "oxc_span 0.126.0",
+ "oxc_syntax 0.126.0",
+]
+
+[[package]]
+name = "oxc_ecmascript"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3729826d5e8e50b6788c79ae3c5f18b6d4b372fb1d5a926813c0edfa69ee5831"
+dependencies = [
+ "num-bigint 0.5.1",
+ "num-traits",
+ "oxc_ast 0.141.0",
+ "oxc_span 0.141.0",
+ "oxc_syntax 0.141.0",
 ]
 
 [[package]]
@@ -2048,6 +2264,17 @@ name = "oxc_estree"
 version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891d31bbe5e6c3a849a2db7de16015076f0d83f42110ace1fdfd7d2e886b97c"
+
+[[package]]
+name = "oxc_estree"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aec60e099d4c904848f51e2737f290c665be0ed66fb295def44f2e91891b604"
+dependencies = [
+ "dragonbox_ecma",
+ "itoa",
+ "oxc_data_structures 0.141.0",
+]
 
 [[package]]
 name = "oxc_index"
@@ -2060,6 +2287,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_index"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
+dependencies = [
+ "nonmax",
+ "rayon",
+ "serde",
+]
+
+[[package]]
 name = "oxc_parser"
 version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,17 +2306,41 @@ dependencies = [
  "bitflags",
  "cow-utils",
  "memchr",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
- "oxc_allocator",
- "oxc_ast",
- "oxc_data_structures",
- "oxc_diagnostics",
- "oxc_ecmascript",
- "oxc_regular_expression",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_data_structures 0.126.0",
+ "oxc_diagnostics 0.126.0",
+ "oxc_ecmascript 0.126.0",
+ "oxc_regular_expression 0.126.0",
+ "oxc_span 0.126.0",
+ "oxc_str 0.126.0",
+ "oxc_syntax 0.126.0",
+ "rustc-hash 2.1.2",
+ "seq-macro",
+]
+
+[[package]]
+name = "oxc_parser"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc8f483bbfae70f4f7c9a90c4a4a3a165685c2d929e0765e35db6db1ac825c32"
+dependencies = [
+ "bitflags",
+ "cow-utils",
+ "memchr",
+ "num-bigint 0.5.1",
+ "num-traits",
+ "oxc_allocator 0.141.0",
+ "oxc_ast 0.141.0",
+ "oxc_data_structures 0.141.0",
+ "oxc_diagnostics 0.141.0",
+ "oxc_ecmascript 0.141.0",
+ "oxc_regular_expression 0.141.0",
+ "oxc_span 0.141.0",
+ "oxc_str 0.141.0",
+ "oxc_syntax 0.141.0",
  "rustc-hash 2.1.2",
  "seq-macro",
 ]
@@ -2090,12 +2352,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "896df45fde44d336df10d3cab46c0cc58697ffa69d446ca4a1b278b8c582972a"
 dependencies = [
  "bitflags",
- "oxc_allocator",
- "oxc_ast_macros",
- "oxc_diagnostics",
- "oxc_span",
- "oxc_str",
+ "oxc_allocator 0.126.0",
+ "oxc_ast_macros 0.126.0",
+ "oxc_diagnostics 0.126.0",
+ "oxc_span 0.126.0",
+ "oxc_str 0.126.0",
  "phf 0.13.1",
+ "rustc-hash 2.1.2",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_regular_expression"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a41b057cf6d615e5736e80eddf9f611827fc0927bc1a7f33b4b10e171cfae4d"
+dependencies = [
+ "bitflags",
+ "oxc_allocator 0.141.0",
+ "oxc_ast_macros 0.141.0",
+ "oxc_diagnostics 0.141.0",
+ "oxc_span 0.141.0",
+ "oxc_str 0.141.0",
+ "phf 0.14.0",
  "rustc-hash 2.1.2",
  "unicode-id-start",
 ]
@@ -2108,17 +2387,40 @@ checksum = "2a86e300b37fa6524265f85cbce20c3ce2b83f15ab0af7a96793421064fc8a5a"
 dependencies = [
  "itertools 0.14.0",
  "memchr",
- "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_diagnostics",
- "oxc_ecmascript",
- "oxc_index",
- "oxc_span",
- "oxc_str",
- "oxc_syntax",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_ast_visit 0.126.0",
+ "oxc_diagnostics 0.126.0",
+ "oxc_ecmascript 0.126.0",
+ "oxc_index 4.1.0",
+ "oxc_span 0.126.0",
+ "oxc_str 0.126.0",
+ "oxc_syntax 0.126.0",
  "rustc-hash 2.1.2",
  "self_cell",
+]
+
+[[package]]
+name = "oxc_semantic"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdfab481b9838e23958cfd03638fcb14672be7ca1a3a23d9a87c1a47a00c7cd8"
+dependencies = [
+ "itertools 0.15.0",
+ "memchr",
+ "oxc_allocator 0.141.0",
+ "oxc_ast 0.141.0",
+ "oxc_ast_visit 0.141.0",
+ "oxc_data_structures 0.141.0",
+ "oxc_diagnostics 0.141.0",
+ "oxc_ecmascript 0.141.0",
+ "oxc_index 5.0.0",
+ "oxc_span 0.141.0",
+ "oxc_str 0.141.0",
+ "oxc_syntax 0.141.0",
+ "rustc-hash 2.1.2",
+ "self_cell",
+ "smallvec",
 ]
 
 [[package]]
@@ -2135,17 +2437,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_sourcemap"
+version = "8.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b415102a94b483bbd76d13e850fe87961197e5795c79a8523ebec5d82025f94f"
+dependencies = [
+ "base64-simd 0.8.0",
+ "json-escape-simd",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "oxc_span"
 version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5778776c8d0ed52822841324e0dd08c024a3fc1e6dd45895e129dbb14f33f2a"
 dependencies = [
- "compact_str",
- "oxc-miette",
- "oxc_allocator",
- "oxc_ast_macros",
- "oxc_estree",
- "oxc_str",
+ "compact_str 0.9.0",
+ "oxc-miette 2.7.1",
+ "oxc_allocator 0.126.0",
+ "oxc_ast_macros 0.126.0",
+ "oxc_estree 0.126.0",
+ "oxc_str 0.126.0",
+]
+
+[[package]]
+name = "oxc_span"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adc1cfe13a710b2c948ffd26470351a8f0e44b6d5f72e9f8d62dcd2dbab500a"
+dependencies = [
+ "compact_str 0.10.0",
+ "oxc-miette 3.0.1",
+ "oxc_allocator 0.141.0",
+ "oxc_ast_macros 0.141.0",
+ "oxc_estree 0.141.0",
+ "oxc_str 0.141.0",
+ "serde",
 ]
 
 [[package]]
@@ -2154,10 +2484,23 @@ version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc120670ba73a00a9d1412de98ac63b2907551707fe4063d96ee2e44cc75ab56"
 dependencies = [
- "compact_str",
+ "compact_str 0.9.0",
  "hashbrown 0.17.1",
- "oxc_allocator",
- "oxc_estree",
+ "oxc_allocator 0.126.0",
+ "oxc_estree 0.126.0",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7423b8162376b5dd53e6431d6b25a4917048cbd10429778e9d4ae7701062e239"
+dependencies = [
+ "compact_str 0.10.0",
+ "hashbrown 0.17.1",
+ "oxc_allocator 0.141.0",
+ "oxc_estree 0.141.0",
+ "serde",
 ]
 
 [[package]]
@@ -2170,13 +2513,34 @@ dependencies = [
  "cow-utils",
  "dragonbox_ecma",
  "nonmax",
- "oxc_allocator",
- "oxc_ast_macros",
- "oxc_estree",
- "oxc_index",
- "oxc_span",
- "oxc_str",
+ "oxc_allocator 0.126.0",
+ "oxc_ast_macros 0.126.0",
+ "oxc_estree 0.126.0",
+ "oxc_index 4.1.0",
+ "oxc_span 0.126.0",
+ "oxc_str 0.126.0",
  "phf 0.13.1",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_syntax"
+version = "0.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d6a9cea50ff9fa2c17bdb1dec8ab69d0e934015b2ba1414040da7f8db822154"
+dependencies = [
+ "bitflags",
+ "cow-utils",
+ "dragonbox_ecma",
+ "nonmax",
+ "oxc_allocator 0.141.0",
+ "oxc_ast_macros 0.141.0",
+ "oxc_estree 0.141.0",
+ "oxc_index 5.0.0",
+ "oxc_span 0.141.0",
+ "oxc_str 0.141.0",
+ "phf 0.14.0",
+ "serde",
  "unicode-id-start",
 ]
 
@@ -2306,6 +2670,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_macros 0.14.0",
+ "phf_shared 0.14.0",
+ "serde",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,6 +2711,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.14.0",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,6 +2747,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
+dependencies = [
+ "phf_generator 0.14.0",
+ "phf_shared 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2773,15 @@ name = "phf_shared"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -2676,6 +3083,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,6 +3272,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsvelte_core"
+version = "0.9.4"
+source = "git+https://github.com/baseballyama/rsvelte?rev=805ea90f75697a942819fb1dd7c2ad648933acd9#805ea90f75697a942819fb1dd7c2ad648933acd9"
+dependencies = [
+ "bumpalo",
+ "compact_str 0.10.0",
+ "im",
+ "indexmap",
+ "itoa",
+ "lazy_static",
+ "memchr",
+ "miette",
+ "oxc_allocator 0.141.0",
+ "oxc_ast 0.141.0",
+ "oxc_ast_visit 0.141.0",
+ "oxc_codegen",
+ "oxc_diagnostics 0.141.0",
+ "oxc_parser 0.141.0",
+ "oxc_semantic 0.141.0",
+ "oxc_span 0.141.0",
+ "oxc_syntax 0.141.0",
+ "regex",
+ "rsvelte_esrap",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sourcemap",
+ "string_wizard",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rsvelte_esrap"
+version = "0.7.11"
+source = "git+https://github.com/baseballyama/rsvelte?rev=805ea90f75697a942819fb1dd7c2ad648933acd9#805ea90f75697a942819fb1dd7c2ad648933acd9"
+dependencies = [
+ "oxc_allocator 0.141.0",
+ "oxc_ast 0.141.0",
+ "oxc_span 0.141.0",
+ "oxc_syntax 0.141.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,6 +3490,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3172,6 +3633,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,9 +3650,12 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smawk"
@@ -3243,6 +3717,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_wizard"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3329e20c442a41a696da22dd806277d00c1918921c5866a144e70d8e891afc7"
+dependencies = [
+ "memchr",
+ "oxc_index 5.0.0",
+ "oxc_sourcemap 7.0.0",
+ "regex",
+ "rustc-hash 2.1.2",
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3264,6 +3752,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3306,7 +3805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -3821,9 +4320,9 @@ dependencies = [
 name = "verter_actions"
 version = "0.0.1-beta.3"
 dependencies = [
- "oxc_allocator",
- "oxc_parser",
- "oxc_span",
+ "oxc_allocator 0.126.0",
+ "oxc_parser 0.126.0",
+ "oxc_span 0.126.0",
  "serde",
  "serde_json",
  "verter_diagnostics",
@@ -3845,10 +4344,10 @@ name = "verter_audit"
 version = "0.0.1-beta.3"
 dependencies = [
  "clap",
- "oxc_allocator",
- "oxc_ast",
- "oxc_parser",
- "oxc_span",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_parser 0.126.0",
+ "oxc_span 0.126.0",
  "parking_lot",
  "serde",
  "serde_json",
@@ -3865,10 +4364,10 @@ dependencies = [
  "criterion",
  "glob",
  "hotpath",
- "oxc_allocator",
- "oxc_ast",
- "oxc_parser",
- "oxc_span",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_parser 0.126.0",
+ "oxc_span 0.126.0",
  "rayon",
  "serde",
  "serde_json",
@@ -3899,19 +4398,20 @@ dependencies = [
  "lazy_static",
  "lightningcss",
  "memchr",
- "num-bigint",
- "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_diagnostics",
- "oxc_parser",
- "oxc_semantic",
- "oxc_sourcemap",
- "oxc_span",
- "oxc_syntax",
+ "num-bigint 0.4.6",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_ast_visit 0.126.0",
+ "oxc_diagnostics 0.126.0",
+ "oxc_parser 0.126.0",
+ "oxc_semantic 0.126.0",
+ "oxc_sourcemap 7.0.0",
+ "oxc_span 0.126.0",
+ "oxc_syntax 0.126.0",
  "phf 0.13.1",
  "proc-macro2",
  "quote",
+ "rsvelte_core",
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
@@ -3949,7 +4449,7 @@ dependencies = [
 name = "verter_dx_baseline"
 version = "0.0.1-beta.3"
 dependencies = [
- "oxc_sourcemap",
+ "oxc_sourcemap 7.0.0",
  "serde",
  "serde_json",
  "tempfile",
@@ -4000,11 +4500,11 @@ dependencies = [
  "glob",
  "hotpath",
  "lru",
- "oxc_allocator",
- "oxc_ast",
- "oxc_parser",
- "oxc_sourcemap",
- "oxc_span",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_parser 0.126.0",
+ "oxc_sourcemap 7.0.0",
+ "oxc_span 0.126.0",
  "parking_lot",
  "paste",
  "schemars",
@@ -4099,7 +4599,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "oxc_allocator",
+ "oxc_allocator 0.126.0",
  "prost",
  "rustc-hash 2.1.2",
  "serde",
@@ -4169,13 +4669,13 @@ dependencies = [
  "hotpath",
  "lazy_static",
  "memchr",
- "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_diagnostics",
- "oxc_parser",
- "oxc_span",
- "oxc_syntax",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_ast_visit 0.126.0",
+ "oxc_diagnostics 0.126.0",
+ "oxc_parser 0.126.0",
+ "oxc_span 0.126.0",
+ "oxc_syntax 0.126.0",
  "phf 0.13.1",
  "rustc-hash 2.1.2",
  "serde",
@@ -4245,11 +4745,11 @@ dependencies = [
  "bitflags",
  "criterion",
  "hotpath",
- "oxc_allocator",
- "oxc_ast",
- "oxc_ast_visit",
- "oxc_parser",
- "oxc_span",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_ast_visit 0.126.0",
+ "oxc_parser 0.126.0",
+ "oxc_span 0.126.0",
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
@@ -4277,10 +4777,10 @@ dependencies = [
  "dashmap 6.2.1",
  "hotpath",
  "indexmap",
- "oxc_allocator",
- "oxc_ast",
- "oxc_parser",
- "oxc_span",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_parser 0.126.0",
+ "oxc_span 0.126.0",
  "parking_lot",
  "proc-macro2",
  "prost",
@@ -4352,7 +4852,7 @@ dependencies = [
 name = "verter_span"
 version = "0.0.1-beta.3"
 dependencies = [
- "oxc_span",
+ "oxc_span 0.126.0",
  "serde",
  "serde_json",
 ]
@@ -4361,7 +4861,7 @@ dependencies = [
 name = "verter_svelte_conformance"
 version = "0.0.1-beta.3"
 dependencies = [
- "oxc_allocator",
+ "oxc_allocator 0.126.0",
  "serde",
  "serde_json",
  "syn 2.0.117",
@@ -4375,8 +4875,8 @@ version = "0.0.1-beta.3"
 dependencies = [
  "base64",
  "clap",
- "oxc_allocator",
- "oxc_sourcemap",
+ "oxc_allocator 0.126.0",
+ "oxc_sourcemap 7.0.0",
  "rayon",
  "serde",
  "serde_json",
@@ -4425,10 +4925,10 @@ dependencies = [
 name = "verter_type_expr_oxc"
 version = "0.0.1-beta.3"
 dependencies = [
- "oxc_allocator",
- "oxc_ast",
- "oxc_parser",
- "oxc_span",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_parser 0.126.0",
+ "oxc_span 0.126.0",
  "serde",
  "verter_span",
  "verter_type_expr",
@@ -4455,11 +4955,11 @@ name = "verter_vue_conformance"
 version = "0.0.1-beta.3"
 dependencies = [
  "hex",
- "oxc_allocator",
- "oxc_ast",
- "oxc_parser",
- "oxc_semantic",
- "oxc_span",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_parser 0.126.0",
+ "oxc_semantic 0.126.0",
+ "oxc_span 0.126.0",
  "serde",
  "serde_json",
  "sha2",
@@ -4500,10 +5000,10 @@ dependencies = [
  "dashmap 6.2.1",
  "glob",
  "hotpath",
- "oxc_allocator",
- "oxc_ast",
- "oxc_parser",
- "oxc_span",
+ "oxc_allocator 0.126.0",
+ "oxc_ast 0.126.0",
+ "oxc_parser 0.126.0",
+ "oxc_span 0.126.0",
  "parking_lot",
  "rustc-hash 2.1.2",
  "serde",

--- a/crates/verter_compiler/Cargo.toml
+++ b/crates/verter_compiler/Cargo.toml
@@ -80,6 +80,7 @@ sha2 = { workspace = true }
 hex = "0.4.3"
 lightningcss = { workspace = true }
 phf = { version = "0.13.1", features = ["macros"] }
+rsvelte_core = { version = "=0.9.4", git = "https://github.com/baseballyama/rsvelte", rev = "805ea90f75697a942819fb1dd7c2ad648933acd9", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = "1.1"

--- a/crates/verter_compiler/src/framework_common/carrier_compiler.rs
+++ b/crates/verter_compiler/src/framework_common/carrier_compiler.rs
@@ -315,9 +315,8 @@ pub struct RuntimeCustomBlock {
 /// the framework-owned main body (when the carrier emits one directly), the
 /// block side-files, styles + custom blocks, the scope id, the IDE artifact
 /// (when requested in the same pass), template facts, and diagnostics. A
-/// carrier that cannot produce a runtime module (Svelte today) returns the
-/// bundle with `main.body_code = None` AND no block side-files — the host
-/// detects the absence of a runtime surface and populates only the IDE slot.
+/// carrier that cannot produce a runtime module returns the bundle with
+/// `main.body_code = None` and no block side-files.
 ///
 /// Not `Clone` — `RawTemplateData` is move-only, and the bundle is consumed
 /// once by the host's virtual-file population.
@@ -325,7 +324,7 @@ pub struct RuntimeCustomBlock {
 pub struct RuntimeCompileOutput {
     /// The framework-owned main module (body / map / lang). `body_code`
     /// `None` ⇒ the host assembles from the block fields (Vue) OR there is
-    /// no runtime surface (Svelte).
+    /// no runtime surface.
     pub main: RuntimeMainModule,
     /// The compiled `<script>` block, when present.
     pub script: Option<RuntimeScriptBlock>,
@@ -346,17 +345,15 @@ pub struct RuntimeCompileOutput {
     /// Diagnostics emitted during the runtime compile. The host lifts these
     /// into its `DiagnosticsSnapshot`; an error here fails the compile.
     pub diagnostics: Vec<RuntimeDiagnostic>,
-    /// Whether the carrier REFUSED to produce a runtime surface for an
-    /// unsupported construct (a fail-closed runtime outcome), DISTINCT from
+    /// The typed reason the carrier REFUSED to produce a runtime surface for
+    /// an unsupported construct (a fail-closed runtime outcome), distinct from
     /// "no runtime surface was requested / this carrier is IDE-only". A
     /// consumer REQUESTING the runtime artifact reads this to distinguish a
-    /// genuine unsupported-runtime refusal (no `Main`, the precise reason in
-    /// `diagnostics`) from a clean compile — so it cannot mistake an absent
-    /// `Main` for a successful runtime compile. The matching IDE artifact is
-    /// still produced (type-checking survives); the refusal diagnostics stay
-    /// NON-FATAL (`has_errors()` is false) so the IDE compile is not killed.
-    /// A carrier that emits a runtime surface (Vue) leaves this `false`.
-    pub runtime_surface_refused: bool,
+    /// genuine unsupported-runtime refusal from a clean compile without
+    /// parsing a framework-specific diagnostic code. The same diagnostic is
+    /// also present in [`Self::diagnostics`] for normal diagnostics delivery.
+    /// A carrier that emits a runtime surface leaves this `None`.
+    pub runtime_refusal: Option<RuntimeDiagnostic>,
     /// Whether the render function was inlined into `setup()` (Vue production
     /// topology). When true, `script` contains the complete component and
     /// `template` is `None` — host assembly must NOT attach a standalone
@@ -386,15 +383,18 @@ impl RuntimeCompileOutput {
             .any(|d| d.severity == RuntimeDiagnosticSeverity::Error)
     }
 
-    /// Whether the carrier REFUSED a runtime surface for an unsupported
-    /// construct (a fail-closed runtime outcome). A runtime-requesting consumer
-    /// uses this — together with `has_runtime_surface() == false` — to treat the
-    /// outcome as a runtime refusal rather than a successful compile, while the
-    /// IDE artifact (`tsx`) and the non-fatal diagnostics keep type-checking
-    /// alive. NEVER true on a clean compile (a refusal sets it AND omits `Main`).
+    /// Whether the carrier refused a runtime surface for an unsupported
+    /// construct.
     #[must_use]
     pub fn runtime_surface_refused(&self) -> bool {
-        self.runtime_surface_refused
+        self.runtime_refusal.is_some()
+    }
+
+    /// The framework-neutral refusal reason, when runtime compilation failed
+    /// closed.
+    #[must_use]
+    pub fn runtime_refusal(&self) -> Option<&RuntimeDiagnostic> {
+        self.runtime_refusal.as_ref()
     }
 }
 
@@ -463,10 +463,10 @@ pub trait CarrierCompiler: Send + Sync {
     /// The carrier owns the typed downcast and native compile and returns a
     /// neutral [`RuntimeCompileOutput`] re-expressing every field the host's
     /// runtime assembly + virtual-file population needs. A carrier that
-    /// cannot yet produce a runtime module for the requested target returns
-    /// a typed [`CompileUnsupported`]. A carrier whose framework projects
-    /// ONLY an IDE surface (Svelte today) returns a bundle whose `main`
-    /// body is absent and that carries the IDE artifact when `want_ide`.
+    /// cannot produce a runtime module for the requested target returns a
+    /// typed [`CompileUnsupported`]. A carrier that projects only an IDE
+    /// surface returns a bundle whose `main` body is absent and carries the
+    /// IDE artifact when `want_ide`.
     ///
     /// The adapter's codegen owns its own `CodeTransform` (the single
     /// source of truth for generated-code edits); the returned `code` /

--- a/crates/verter_compiler/src/framework_common/vue_bridge.rs
+++ b/crates/verter_compiler/src/framework_common/vue_bridge.rs
@@ -597,7 +597,7 @@ pub fn vue_result_to_runtime_bundle(
         diagnostics,
         // Vue always emits a runtime surface (or a genuine compile error); it never
         // fails closed on an unsupported runtime surface the way Svelte does.
-        runtime_surface_refused: false,
+        runtime_refusal: None,
         // The RESOLVED inline topology — the compiler already merged the
         // render into `setup()` when true, so host assembly takes the inline
         // branch (no render attach, no setup-return filter).

--- a/crates/verter_compiler/src/svelte/carrier.rs
+++ b/crates/verter_compiler/src/svelte/carrier.rs
@@ -357,7 +357,7 @@ impl CarrierCompiler for SvelteCarrierCompiler {
         source: &str,
         artifact: &FrameworkParseArtifact,
         opts: &RuntimeCompileOptions,
-        alloc: &oxc_allocator::Allocator,
+        _alloc: &oxc_allocator::Allocator,
     ) -> Result<RuntimeCompileOutput, CompileUnsupported> {
         // A foreign artifact (not a Svelte carrier) declines with the typed
         // answer — never a silent empty bundle.
@@ -367,158 +367,7 @@ impl CarrierCompiler for SvelteCarrierCompiler {
             });
         };
 
-        let mut bundle = RuntimeCompileOutput::default();
-
-        // The Svelte native RUNTIME compiler (source `.svelte` → JS importing
-        // `svelte/internal/client`). A SUPPORTED component populates
-        // `main.body_code` (the host emits the `Main` virtual node from it,
-        // `has_runtime_surface()` becoming true through registry routing); an
-        // UNSUPPORTED runtime surface FAILS CLOSED with a precise non-fatal
-        // diagnostic (carrying the surface + owning vertical) and produces NO
-        // runtime body — the IDE artifact is still produced so type-checking
-        // survives. SSR (`opts.ssr`) fails closed until the server backend lands.
-        let runtime_opts = super::runtime::SvelteRuntimeOptions {
-            filename: opts.filename.clone(),
-            name: None,
-            runes: None,
-            is_production: opts.is_production,
-            // The neutral `RuntimeCompileOptions` carries no dev-codegen request
-            // distinct from the §1.2 default (`is_production == false` is the
-            // canonical request shape, NOT a dev-codegen request), so the Svelte
-            // client backend always emits PRODUCTION output here. Dev-mode output is
-            // requested through a dedicated signal the neutral carrier does not carry,
-            // so `dev_codegen` stays false.
-            dev_codegen: false,
-            // Explicit carrier profile axis. An in-source
-            // `<svelte:options customElement>` value still wins over this
-            // compile option, matching official precedence.
-            custom_element: opts.custom_element,
-            // The RESOLVED Svelte cssHash override (from the host/session boundary,
-            // preserved byte-exact) threads verbatim into the style-plan scope class.
-            css_hash_override: opts.svelte_css_hash_override.clone(),
-            // The essential compile options resolve on the compiler surface
-            // (`SvelteRuntimeOptions`) + the inline `<svelte:options>` element. The
-            // neutral `RuntimeCompileOptions` carries no host/session channel for
-            // `namespace` / `fragments` / `preserveWhitespace` / `preserveComments` /
-            // `discloseVersion`, and the unsupported feature options are not on the
-            // neutral carrier — so they default here (an in-source `<svelte:options
-            // namespace / preserveWhitespace>` still applies via the resolver).
-            namespace: None,
-            fragments: None,
-            preserve_whitespace: None,
-            preserve_comments: None,
-            disclose_version: None,
-            accessors: None,
-            immutable: None,
-            hmr: None,
-            compatibility_component_api: None,
-        };
-        // `opts.source_map` is the neutral OUTPUT-axis map demand: it reaches
-        // the css RENDER through `compile_client`'s `want_source_map` (never
-        // a lowering option on `SvelteRuntimeOptions`).
-        match super::runtime::compile_client(
-            source,
-            parsed,
-            &runtime_opts,
-            alloc,
-            opts.ssr,
-            opts.source_map,
-        ) {
-            Ok(module) => {
-                bundle.main.body_code = Some(module.code);
-                bundle.main.source_map = module.source_map.unwrap_or_default();
-                bundle.main.lang = Some("js".to_string());
-                // The EXTERNAL scoped-css artifact (the official `compiled.css`
-                // — `{ code, map, hasGlobal }` + the scope hash): it publishes
-                // as the bundle's style block (the Svelte analogue of the Vue
-                // styles population). Injected-mode css is inlined in the
-                // module (no artifact), and a style-less component has none.
-                if let Some(css) = module.css {
-                    bundle.styles.push(
-                        crate::framework_common::carrier_compiler::RuntimeStyleBlock {
-                            code: css.code,
-                            source_map: css.source_map,
-                            lang: None,
-                            scope_hash: Some(css.hash),
-                            has_global: css.has_global,
-                        },
-                    );
-                }
-            }
-            Err(super::runtime::ClientCompileError::Unsupported(surface)) => {
-                // Fail closed: NO `Main` runtime node is produced, the bundle is
-                // marked `runtime_surface_refused` (the distinct typed signal a
-                // runtime-requesting consumer reads so it cannot mistake the absent
-                // `Main` for a successful runtime compile), and the precise
-                // `svelte-runtime-unsupported-<surface>` reason reaches the host
-                // `DiagnosticsSnapshot`. The diagnostic stays NON-FATAL (Warning) so
-                // the IDE projection below still compiles and type-checking survives.
-                bundle.runtime_surface_refused = true;
-                bundle.diagnostics.push(RuntimeDiagnostic {
-                    severity: RuntimeDiagnosticSeverity::Warning,
-                    code: surface.diagnostic_code().to_string(),
-                    message: surface.message(),
-                    span: Some(surface.span()),
-                });
-            }
-            Err(super::runtime::ClientCompileError::Lowering(errors)) => {
-                // A genuine lowering failure (a malformed construct) ALSO produces no
-                // `Main` — so it is a runtime refusal too: set `runtime_surface_refused`
-                // (the distinct typed signal) so a runtime-requesting consumer reads the
-                // failure EXPLICITLY rather than mistaking the absent `Main` for a clean
-                // IDE-only carrier. Each recorded problem is surfaced as a non-fatal
-                // diagnostic — the IDE projection still runs (it has its own error
-                // recovery).
-                bundle.runtime_surface_refused = true;
-                for diag in &errors.diagnostics {
-                    bundle.diagnostics.push(RuntimeDiagnostic {
-                        severity: RuntimeDiagnosticSeverity::Warning,
-                        code: diag.code.to_string(),
-                        message: diag.message.clone(),
-                        span: Some(diag.span),
-                    });
-                }
-            }
-            Err(super::runtime::ClientCompileError::GeneratedModuleInvalid { .. }) => {
-                bundle.runtime_surface_refused = true;
-                bundle.diagnostics.push(RuntimeDiagnostic {
-                    severity: RuntimeDiagnosticSeverity::Warning,
-                    code: "svelte-runtime-generated-module-invalid".to_string(),
-                    message: "The native Svelte backend generated invalid JavaScript; runtime output was refused."
-                        .to_string(),
-                    span: Some(Span::new(0, 0)),
-                });
-            }
-            Err(super::runtime::ClientCompileError::GeneratedSourceMapInvalid { .. }) => {
-                bundle.runtime_surface_refused = true;
-                bundle.diagnostics.push(RuntimeDiagnostic {
-                    severity: RuntimeDiagnosticSeverity::Warning,
-                    code: "svelte-runtime-generated-source-map-invalid".to_string(),
-                    message: "The native Svelte backend could not safely generate the client source map; runtime output was refused."
-                        .to_string(),
-                    span: Some(Span::new(0, 0)),
-                });
-            }
-            Err(super::runtime::ClientCompileError::OfficialReject(rejection)) => {
-                // The component is MALFORMED Svelte official ALSO compile-errors — fail
-                // closed (NO `Main`), mark `runtime_surface_refused`, and surface the
-                // typed official-reject diagnostic (the rule's stable code + a message
-                // naming the EXACT official code the rejection mirrors). The IDE
-                // projection below still runs (it owns its own error recovery), so a
-                // malformed component still type-checks while producing no runtime module.
-                bundle.runtime_surface_refused = true;
-                bundle.diagnostics.push(RuntimeDiagnostic {
-                    severity: RuntimeDiagnosticSeverity::Warning,
-                    code: rejection.rule.diagnostic_code().to_string(),
-                    message: format!(
-                        "{} (official `{}`)",
-                        rejection.rule.message(),
-                        rejection.official_code
-                    ),
-                    span: None,
-                });
-            }
-        }
+        let mut bundle = super::rsvelte_bridge::compile_runtime(source, opts);
 
         // The IDE projection is ALWAYS available (independent of the runtime
         // surface) so an unsupported-runtime component still type-checks. Its
@@ -674,7 +523,7 @@ mod tests {
         let map = oxc_sourcemap::OwnedSourceMap::from_json_string(&mapped.main.source_map)
             .expect("RuntimeMainModule.source_map is valid JSON");
         assert_eq!(map.get_file(), Some("Counter.svelte"));
-        assert_eq!(map.get_sources().collect::<Vec<_>>(), ["Counter.svelte"]);
+        assert_eq!(map.get_sources().collect::<Vec<_>>(), ["./Counter.svelte"]);
         assert_eq!(map.get_source_content(0), Some(source));
 
         let plain = compiler
@@ -817,11 +666,10 @@ mod tests {
         // compile. YET the IDE projection (`tsx`) is still produced and the
         // diagnostics stay NON-FATAL, so type-checking survives.
         let compiler = SvelteCarrierCompiler::default();
-        // A `{#snippet}` declaration is an unsupported runtime surface — the
-        // control-flow blocks (`{#if}`/…) ARE supported, so the refused example uses a
-        // construct that genuinely still fails closed.
-        let source =
-            "<script>let c = $state(true);</script>\n{#snippet foo()}<p>{c}</p>{/snippet}\n";
+        // A malformed closing block is rejected by rsvelte. The Verter carrier
+        // parse is recovery-oriented, so this reaches the runtime boundary and
+        // discriminates its fail-closed translation.
+        let source = "<script>let c = $state(true);</script>\n{#if c}<p>{c}</p>{/each}\n";
         let artifact = compiler.parse(source, &ParseOptions::default());
         let alloc = oxc_allocator::Allocator::default();
         let opts = RuntimeCompileOptions {
@@ -847,8 +695,8 @@ mod tests {
             bundle
                 .diagnostics
                 .iter()
-                .any(|d| d.code.starts_with("svelte-runtime-unsupported-")),
-            "the precise unsupported-surface diagnostic is present"
+                .any(|d| d.code.starts_with("rsvelte-")),
+            "the precise rsvelte diagnostic is present"
         );
         // The IDE survives: the `tsx` artifact is present and the refusal is
         // non-fatal (does not kill the IDE compile).
@@ -857,6 +705,29 @@ mod tests {
             !bundle.has_errors(),
             "the runtime refusal is non-fatal so the IDE survives"
         );
+    }
+
+    #[test]
+    fn compile_bundle_lifts_rsvelte_warnings_with_source_spans() {
+        let compiler = SvelteCarrierCompiler::default();
+        let source = "<img src=\"x\">";
+        let artifact = compiler.parse(source, &ParseOptions::default());
+        let alloc = oxc_allocator::Allocator::default();
+        let bundle = compiler
+            .compile_bundle(source, &artifact, &RuntimeCompileOptions::default(), &alloc)
+            .expect("a warning does not refuse runtime compilation");
+
+        assert!(
+            !bundle.runtime_surface_refused(),
+            "a compiler warning must not become a runtime refusal"
+        );
+        let warning = bundle
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "a11y_missing_attribute")
+            .expect("the rsvelte/Svelte warning must cross the neutral bridge");
+        assert_eq!(warning.severity, RuntimeDiagnosticSeverity::Warning);
+        assert_eq!(warning.span, Some(Span::new(0, source.len() as u32)));
     }
 
     #[test]

--- a/crates/verter_compiler/src/svelte/mod.rs
+++ b/crates/verter_compiler/src/svelte/mod.rs
@@ -9,7 +9,8 @@
 //!
 //! It performs NO type lowering (the thin-adapters guard). The IDE TSX
 //! projection ([`ide`]) is a pure syntactic transform via `CodeTransform` —
-//! never type resolution.
+//! never type resolution. Runtime compilation crosses the private
+//! [`rsvelte_bridge`] and returns only framework-neutral carrier DTOs.
 
 /// The shared Svelte `bind:` contract table — the SOURCE OF TRUTH for the wide
 /// binding family, consumed by BOTH the IDE projection ([`ide`]) and the runtime
@@ -23,6 +24,7 @@ mod bind_contract_tests;
 pub mod carrier;
 pub mod ide;
 pub mod parser;
+mod rsvelte_bridge;
 pub mod runtime;
 pub mod template_facts;
 

--- a/crates/verter_compiler/src/svelte/rsvelte_bridge.rs
+++ b/crates/verter_compiler/src/svelte/rsvelte_bridge.rs
@@ -1,0 +1,246 @@
+//! Translation between rsvelte's policy-free compiler facade and Verter's
+//! framework-neutral carrier bundle.
+//!
+//! This module is the only production code in Verter that names
+//! `rsvelte_core`. Cache admission, scheduling, source ownership, IDE
+//! projection, and type resolution stay on the Verter side of the boundary.
+
+use std::sync::Arc;
+
+use rsvelte_core::{
+    compiler::{AnalysisError, CssMode},
+    toolchain::{
+        RuntimeTarget, Toolchain, FACTS_ABI_VERSION, RUNTIME_ABI_VERSION, TOOLCHAIN_ABI_VERSION,
+    },
+    CompileError, CompileOptions,
+};
+use verter_span::Span;
+
+use crate::framework_common::{
+    RuntimeCompileOptions, RuntimeCompileOutput, RuntimeDiagnostic, RuntimeDiagnosticSeverity,
+    RuntimeStyleBlock,
+};
+
+const EXPECTED_TOOLCHAIN_ABI_VERSION: u32 = 1;
+const EXPECTED_RUNTIME_ABI_VERSION: u32 = 1;
+const EXPECTED_FACTS_ABI_VERSION: u32 = 2;
+const EXPECTED_RSVELTE_VERSION: &str = "0.9.4";
+const EXPECTED_SVELTE_VERSION: &str = "5.56.8";
+
+const _: () = {
+    assert!(TOOLCHAIN_ABI_VERSION == EXPECTED_TOOLCHAIN_ABI_VERSION);
+    assert!(RUNTIME_ABI_VERSION == EXPECTED_RUNTIME_ABI_VERSION);
+    assert!(FACTS_ABI_VERSION == EXPECTED_FACTS_ABI_VERSION);
+};
+
+/// Compile one runtime target through rsvelte and translate it into the
+/// carrier-neutral bundle consumed by the Verter host.
+pub(super) fn compile_runtime(source: &str, opts: &RuntimeCompileOptions) -> RuntimeCompileOutput {
+    let toolchain = Toolchain::new();
+    let fingerprint = toolchain.fingerprint();
+    if fingerprint.rsvelte_version != EXPECTED_RSVELTE_VERSION
+        || fingerprint.svelte_version != EXPECTED_SVELTE_VERSION
+    {
+        return incompatible_engine(fingerprint.rsvelte_version, fingerprint.svelte_version);
+    }
+
+    let mut compile_options = CompileOptions {
+        filename: opts.filename.clone(),
+        output_filename: opts.filename.clone(),
+        css_output_filename: opts.filename.clone(),
+        custom_element: opts.custom_element,
+        css: CssMode::External,
+        preserve_comments: opts.comments.unwrap_or(false),
+        enable_sourcemap: opts.source_map,
+        ..Default::default()
+    };
+    if let Some(scope_hash) = opts.svelte_css_hash_override.clone() {
+        compile_options.css_hash = Some(Arc::new(move |_| scope_hash.clone()));
+    }
+
+    let target = if opts.ssr {
+        RuntimeTarget::Server
+    } else {
+        RuntimeTarget::Client
+    };
+    let result = toolchain
+        .prepare(source, compile_options)
+        .and_then(|mut prepared| {
+            let scope_hash = prepared.facts().css_scope_hash.clone();
+            prepared
+                .compile(target)
+                .map(|compiled| (compiled, scope_hash))
+        });
+
+    match result {
+        Ok((compiled, scope_hash)) => {
+            let mut bundle = RuntimeCompileOutput::default();
+            bundle.main.body_code = Some(compiled.js.code);
+            bundle.main.source_map = compiled.js.map.unwrap_or_default();
+            bundle.main.lang = Some("js".to_string());
+            bundle.diagnostics = compiled
+                .warnings
+                .into_iter()
+                .map(|warning| RuntimeDiagnostic {
+                    severity: RuntimeDiagnosticSeverity::Warning,
+                    code: warning.code,
+                    message: warning.message,
+                    span: warning_span(source, warning.start, warning.end),
+                })
+                .collect();
+
+            if let Some(css) = compiled.css {
+                bundle.styles.push(RuntimeStyleBlock {
+                    code: css.code,
+                    source_map: if opts.source_map { css.map } else { None },
+                    lang: None,
+                    scope_hash,
+                    has_global: css.has_global,
+                });
+            }
+            bundle
+        }
+        Err(error) => {
+            let diagnostic = compile_error_diagnostic(&error);
+            RuntimeCompileOutput {
+                runtime_refusal: Some(diagnostic.clone()),
+                diagnostics: vec![diagnostic],
+                ..Default::default()
+            }
+        }
+    }
+}
+
+fn incompatible_engine(rsvelte_version: &str, svelte_version: &str) -> RuntimeCompileOutput {
+    let diagnostic = RuntimeDiagnostic {
+        severity: RuntimeDiagnosticSeverity::Warning,
+        code: "rsvelte-incompatible-engine".to_string(),
+        message: format!(
+            "Verter requires rsvelte {EXPECTED_RSVELTE_VERSION} targeting Svelte \
+             {EXPECTED_SVELTE_VERSION}, but loaded rsvelte {rsvelte_version} targeting \
+             Svelte {svelte_version}"
+        ),
+        span: None,
+    };
+    RuntimeCompileOutput {
+        runtime_refusal: Some(diagnostic.clone()),
+        diagnostics: vec![diagnostic],
+        ..Default::default()
+    }
+}
+
+fn compile_error_diagnostic(error: &CompileError) -> RuntimeDiagnostic {
+    let (code, span) = match error {
+        CompileError::Parse(parse) => {
+            let code = match parse {
+                rsvelte_core::error::ParseError::SvelteError { code, .. } => code.clone(),
+                _ => "parse-error".to_string(),
+            };
+            let (start, end) = parse.span();
+            (code, Some(span_from_usize(start, end)))
+        }
+        CompileError::Analysis(analysis) => {
+            let code = match analysis {
+                AnalysisError::ValidationWithCode { code, .. } => code.clone(),
+                AnalysisError::Scope(_) => "scope-error".to_string(),
+                AnalysisError::Validation(_) => "validation-error".to_string(),
+                AnalysisError::Css(_) => "css-error".to_string(),
+            };
+            (code, None)
+        }
+        CompileError::Transform(_) => ("transform-error".to_string(), None),
+    };
+    RuntimeDiagnostic {
+        severity: RuntimeDiagnosticSeverity::Warning,
+        code: format!("rsvelte-{code}"),
+        message: error.to_string(),
+        span,
+    }
+}
+
+fn warning_span(
+    source: &str,
+    start: Option<rsvelte_core::compiler::Position>,
+    end: Option<rsvelte_core::compiler::Position>,
+) -> Option<Span> {
+    let start = start?;
+    let end = end.unwrap_or_else(|| start.clone());
+    Some(Span::new(
+        utf16_offset_to_byte(source, start.character),
+        utf16_offset_to_byte(source, end.character),
+    ))
+}
+
+fn utf16_offset_to_byte(source: &str, wanted: usize) -> u32 {
+    let mut utf16_offset = 0;
+    for (byte_offset, character) in source.char_indices() {
+        if utf16_offset >= wanted {
+            return byte_offset as u32;
+        }
+        utf16_offset += character.len_utf16();
+    }
+    source.len() as u32
+}
+
+fn span_from_usize(start: usize, end: usize) -> Span {
+    Span::new(
+        u32::try_from(start).unwrap_or(u32::MAX),
+        u32::try_from(end).unwrap_or(u32::MAX),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_css_hash_matches_the_pinned_svelte_engine() {
+        let output = compile_runtime(
+            "<style>.card { color: blue }</style><div class=\"card\">ok</div>",
+            &RuntimeCompileOptions {
+                filename: Some("App.svelte".to_string()),
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            !output.runtime_surface_refused(),
+            "{:?}",
+            output.diagnostics
+        );
+        assert_eq!(
+            output.styles[0].scope_hash.as_deref(),
+            Some("svelte-n50uah")
+        );
+    }
+
+    #[test]
+    fn resolved_css_hash_override_crosses_the_bridge_verbatim() {
+        let output = compile_runtime(
+            "<style>.card { color: blue }</style><div class=\"card\">ok</div>",
+            &RuntimeCompileOptions {
+                filename: Some("App.svelte".to_string()),
+                svelte_css_hash_override: Some("scope-from-config".to_string()),
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            !output.runtime_surface_refused(),
+            "{:?}",
+            output.diagnostics
+        );
+        assert_eq!(
+            output.styles[0].scope_hash.as_deref(),
+            Some("scope-from-config")
+        );
+        assert!(
+            output
+                .main
+                .body_code
+                .as_deref()
+                .is_some_and(|code| { code.contains("scope-from-config") }),
+            "the runtime module and CSS artifact must share the resolved scope hash"
+        );
+    }
+}

--- a/crates/verter_compiler/src/svelte/runtime/component_scope_projection_conformance_tests.rs
+++ b/crates/verter_compiler/src/svelte/runtime/component_scope_projection_conformance_tests.rs
@@ -45,6 +45,7 @@ use crate::svelte::runtime::{compile_client, ClientCompileError, SvelteRuntimeOp
 use oxc_ast::ast::{BindingPattern, ObjectPropertyKind, Program, PropertyKey};
 use oxc_span::Span;
 use std::collections::{BTreeMap, BTreeSet};
+#[cfg(feature = "svelte-oracle")]
 use std::path::PathBuf;
 
 /// The vendored svelte transformation source, embedded HERMETICALLY (no filesystem
@@ -393,6 +394,7 @@ const HANDLER_COVERAGE: &[HandlerCoverage] = &[
 ];
 
 /// The workspace root (`CARGO_MANIFEST_DIR` is `crates/verter_compiler`).
+#[cfg(feature = "svelte-oracle")]
 fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -1176,50 +1178,8 @@ fn declared_roots_characterization_is_stable() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// (5) Oracle-version anchor + no-soft-carrier rail (kept verbatim).
+// (5) Legacy-oracle provenance + no-soft-carrier rail.
 // ─────────────────────────────────────────────────────────────────────────────
-
-/// Every `svelte@<version>` package KEY in `pnpm-lock.yaml` (a 2-space-indented
-/// `svelte@<version>:` line, distinct from `svelte-check@…` / `@sveltejs/…`; a peer-
-/// dependency suffix `svelte@<version>(…)` is stripped).
-fn locked_svelte_versions(lock: &str) -> Vec<String> {
-    let mut versions = Vec::new();
-    for line in lock.lines() {
-        let trimmed = line.trim_start();
-        if !trimmed.starts_with("svelte@") || !trimmed.ends_with(':') {
-            continue;
-        }
-        let rest = &trimmed["svelte@".len()..];
-        let Some(end) = rest.find(['(', ':']) else {
-            continue;
-        };
-        let version = rest[..end].to_string();
-        if !versions.contains(&version) {
-            versions.push(version);
-        }
-    }
-    versions
-}
-
-#[test]
-fn oracle_version_matches_locked_svelte() {
-    let lock_path = workspace_root().join("pnpm-lock.yaml");
-    let lock = std::fs::read_to_string(&lock_path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", lock_path.display()));
-    let locked = locked_svelte_versions(&lock);
-    assert!(
-        !locked.is_empty(),
-        "no `svelte@<version>` package key found in pnpm-lock.yaml — cannot verify the scope-view \
-         oracle pin"
-    );
-    assert!(
-        locked.iter().all(|v| v == SVELTE_ORACLE_VERSION),
-        "Svelte scope-view drift: SVELTE_ORACLE_VERSION = {SVELTE_ORACLE_VERSION:?} does NOT match \
-         the svelte version(s) pinned in pnpm-lock.yaml ({locked:?}). A svelte bump requires re-\
-         verifying the projection against the new release, re-vendoring the source, regenerating \
-         the name-parity corpus, and bumping this anchor + the vendored fixture name."
-    );
-}
 
 /// OPTIONAL provenance rail (gated under the `svelte-oracle` feature): the vendored
 /// `.js` matches the installed svelte source (LF-normalized). The DEFAULT run consumes

--- a/crates/verter_compiler/src/svelte/runtime/mod.rs
+++ b/crates/verter_compiler/src/svelte/runtime/mod.rs
@@ -1,10 +1,10 @@
-//! The Svelte runtime pre-lowering substrate.
+//! The native Svelte conformance compiler.
 //!
-//! This module owns the SHARED pre-lowering surface the client (`svelte/internal/client`)
-//! and server (`svelte/internal/server`) backends build on. It is physically
-//! separate from the IDE TSX projection ([`crate::svelte::ide`]) — the two
-//! codegen paths consume the same [`ParsedSvelte`](crate::svelte::ParsedSvelte)
-//! AST but never share code (the two-codegen-paths rule).
+//! This module owns Verter's native Svelte analysis and client-codegen surface.
+//! It is physically separate from the IDE TSX projection
+//! ([`crate::svelte::ide`]) and remains public for conformance tooling. The
+//! registered carrier runtime path is [`crate::svelte::rsvelte_bridge`], which
+//! supplies both client and server output through rsvelte.
 //!
 //! The pipeline is:
 //!
@@ -17,14 +17,12 @@
 //!   → client.rs  ClientModule        (the emitted `svelte/internal/client` JS)
 //! ```
 //!
-//! [`compile_client`] drives this end-to-end and is wired into the Svelte carrier's
-//! `compile_bundle` (`crate::svelte::carrier`): a supported runes component
-//! populates `bundle.main.body_code` (so `has_runtime_surface()` becomes true and
-//! the host emits the `Main` virtual node), and every unsupported surface FAILS
-//! CLOSED with a typed [`client::UnsupportedSvelteRuntimeSurface`] carrying its
-//! owning vertical. The expression / script emission routes its source-derived
-//! rewrites through [`CodeTransform`](crate::code_transform::CodeTransform); the
-//! synthesized helper scaffolding is unmapped.
+//! [`compile_client`] drives this end-to-end for native conformance consumers.
+//! Every unsupported surface fails closed with a typed
+//! [`client::UnsupportedSvelteRuntimeSurface`] carrying its owning vertical.
+//! Expression and script emission route source-derived rewrites through
+//! [`CodeTransform`](crate::code_transform::CodeTransform); synthesized helper
+//! scaffolding is unmapped.
 
 mod attr_lowering;
 mod bind_target;

--- a/crates/verter_compiler/tests/cases/mod.rs
+++ b/crates/verter_compiler/tests/cases/mod.rs
@@ -27,4 +27,5 @@ mod svelte_parse_parity_matrix;
 mod svelte_parser_recovery_routes_through_strict_facts;
 mod svelte_parser_strictness_fails_closed;
 mod svelte_refuse_by_default_guards;
+mod svelte_rsvelte_runtime_bridge;
 mod svelte_runtime_whitespace_entity_guards;

--- a/crates/verter_compiler/tests/cases/svelte_goldens_in_sync.rs
+++ b/crates/verter_compiler/tests/cases/svelte_goldens_in_sync.rs
@@ -1,8 +1,8 @@
 //! Svelte reference-drift hermetic guards.
 //!
 //! These guards run in the DEFAULT canonical suite and are FULLY HERMETIC:
-//! they read only committed files (the goldens + the lockfile + the generator
-//! pin constant). They NEVER shell `node`, NEVER load the live svelte
+//! they read only committed files (the goldens + the generator pin constant).
+//! They NEVER shell `node`, NEVER load the live svelte
 //! compiler, and NEVER require `pnpm install` — the default run
 //! (`cargo nextest run --workspace` + `cargo test -p verter_session --tests`)
 //! must stay node-free and compiler-free.
@@ -20,11 +20,10 @@
 //!   native-Svelte runtime codegen can rely on the goldens being loadable. A
 //!   missing / corrupt / structurally-invalid golden fails the guard. Pure
 //!   file reads — no node, no live compiler.
-//! - `svelte_lockfile_matches_oracle_pin` — asserts the resolved `svelte`
-//!   version in `pnpm-lock.yaml` EQUALS the `SVELTE_ORACLE_VERSION` pin
-//!   declared in `scripts/svelte-golden-lib.mjs` (the single JS pin authority
-//!   every Svelte golden generator imports). A `svelte` bump without a
-//!   re-pin (+ golden regen) fails — silent drift is impossible.
+//!
+//! The legacy native-codegen oracle may intentionally remain on an older
+//! Svelte patch than the rsvelte production backend. Its version is therefore
+//! tied to every committed golden, not to the application's runtime lock.
 
 use std::path::{Path, PathBuf};
 
@@ -65,28 +64,6 @@ fn oracle_pin_version(lib_src: &str) -> String {
         }
     }
     panic!("SVELTE_ORACLE_VERSION pin constant not found in svelte-golden-lib.mjs");
-}
-
-/// Extract the resolved `svelte` version from `pnpm-lock.yaml`. The lockfile
-/// `packages:` section lists `  svelte@<version>:` for the resolved version.
-/// We take the FIRST such entry (there is exactly one resolved `svelte`).
-fn lockfile_svelte_version(lock_src: &str) -> Option<String> {
-    for line in lock_src.lines() {
-        // Match a `  svelte@<version>:` package key. Guard against
-        // `@sveltejs/...` and scoped names by requiring the line (trimmed) to
-        // start with `svelte@`.
-        let t = line.trim();
-        if let Some(rest) = t.strip_prefix("svelte@") {
-            if let Some(version) = rest.strip_suffix(':') {
-                // A bare resolved package key has no parenthesised peer suffix
-                // and no `/` (which a path-style entry would carry).
-                if !version.contains('(') && !version.contains('/') && !version.is_empty() {
-                    return Some(version.to_string());
-                }
-            }
-        }
-    }
-    None
 }
 
 // ---------------------------------------------------------------------------
@@ -582,29 +559,6 @@ fn committed_svelte_goldens_are_structurally_valid() {
 }
 
 #[test]
-fn svelte_lockfile_matches_oracle_pin() {
-    let root = workspace_root();
-
-    let lib_src = std::fs::read_to_string(root.join("scripts/svelte-golden-lib.mjs"))
-        .expect("read svelte-golden-lib.mjs");
-    let pin = oracle_pin_version(&lib_src);
-
-    let lock_src =
-        std::fs::read_to_string(root.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
-    let resolved = lockfile_svelte_version(&lock_src)
-        .expect("a resolved `svelte@<version>:` entry in pnpm-lock.yaml");
-
-    assert_eq!(
-        resolved, pin,
-        "the resolved `svelte` version in pnpm-lock.yaml ({resolved}) does NOT equal \
-         the oracle pin SVELTE_ORACLE_VERSION ({pin}) in svelte-golden-lib.mjs. A \
-         `svelte` bump is a reviewed oracle delta: re-pin SVELTE_ORACLE_VERSION, \
-         bump the lockfile, run `node scripts/gen-svelte-goldens.mjs`, and review \
-         the golden diff."
-    );
-}
-
-#[test]
 fn committed_svelte_goldens_match_oracle_pin() {
     let root = workspace_root();
     let lib_src = std::fs::read_to_string(root.join("scripts/svelte-golden-lib.mjs"))
@@ -705,39 +659,6 @@ fn version_stamp_guard_discriminates_a_mismatched_oracle_version() {
 fn oracle_pin_parser_extracts_the_declared_version() {
     let src = "// header\nexport const SVELTE_ORACLE_VERSION = \"9.9.9\";\nconst x = 1;\n";
     assert_eq!(oracle_pin_version(src), "9.9.9");
-}
-
-#[test]
-fn lockfile_parser_extracts_the_bare_resolved_version() {
-    // A realistic snippet: the package key is the bare `svelte@<version>:`,
-    // while scoped + peer-suffixed entries must NOT be mistaken for it.
-    let lock = "\
-  '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
-    resolution: {integrity: sha512-aaa==}
-  oxfmt@0.52.0(svelte@5.56.3):
-    resolution: {integrity: sha512-bbb==}
-  svelte@5.56.3:
-    resolution: {integrity: sha512-ccc==}
-";
-    assert_eq!(
-        lockfile_svelte_version(lock).as_deref(),
-        Some("5.56.3"),
-        "must extract the bare resolved svelte version, ignoring peer-suffixed entries"
-    );
-}
-
-#[test]
-fn lockfile_guard_discriminates_a_version_bump() {
-    // If the lockfile resolves a DIFFERENT version than the pin, the equality
-    // the guard asserts must NOT hold — proving a bump fails the guard.
-    let bumped_lock = "  svelte@5.99.0:\n    resolution: {integrity: sha512-zzz==}\n";
-    let resolved = lockfile_svelte_version(bumped_lock).expect("resolved version");
-    let pin = oracle_pin_version("export const SVELTE_ORACLE_VERSION = \"5.56.3\";\n");
-    assert_ne!(
-        resolved, pin,
-        "a lockfile svelte bump (5.99.0) must NOT equal the pin (5.56.3) — \
-         the guard would fail, as required"
-    );
 }
 
 #[test]

--- a/crates/verter_compiler/tests/cases/svelte_rsvelte_runtime_bridge.rs
+++ b/crates/verter_compiler/tests/cases/svelte_rsvelte_runtime_bridge.rs
@@ -1,0 +1,127 @@
+use verter_compiler::framework_common::{CarrierCompiler, RuntimeCompileOptions};
+use verter_compiler::svelte::SvelteCarrierCompiler;
+
+/// @ai-generated - Pins the Verter carrier contract at the rsvelte runtime boundary.
+#[test]
+fn svelte_carrier_emits_server_runtime_through_the_registered_backend() {
+    let source = r#"<script>
+  let { greeting = "hello" } = $props();
+</script>
+<h1>{greeting}</h1>"#;
+    let compiler = SvelteCarrierCompiler::default();
+    let artifact = compiler.parse(source, &Default::default());
+    let allocator = oxc_allocator::Allocator::default();
+    let output = compiler
+        .compile_bundle(
+            source,
+            &artifact,
+            &RuntimeCompileOptions {
+                filename: Some("Greeting.svelte".to_string()),
+                ssr: true,
+                source_map: true,
+                ..Default::default()
+            },
+            &allocator,
+        )
+        .expect("the Svelte carrier must accept a registered runtime backend");
+
+    assert!(
+        !output.runtime_surface_refused(),
+        "a supported server component must not be reported as a runtime refusal: {:?}",
+        output.diagnostics
+    );
+    let module = output
+        .main
+        .body_code
+        .expect("the server backend must produce a main module");
+    assert!(module.contains("svelte/internal/server"), "{module}");
+    assert!(
+        module.contains("export default"),
+        "the generated server module must expose the component: {module}"
+    );
+    assert_eq!(output.main.lang.as_deref(), Some("js"));
+    let source_map = oxc_sourcemap::OwnedSourceMap::from_json_string(&output.main.source_map)
+        .expect("the server backend must return a valid source map");
+    assert_eq!(
+        source_map.get_sources().collect::<Vec<_>>(),
+        ["./Greeting.svelte"]
+    );
+    assert_eq!(source_map.get_source_content(0), Some(source));
+}
+
+#[test]
+fn rsvelte_types_are_confined_to_the_private_bridge() {
+    fn visit_rust_files(directory: &std::path::Path, files: &mut Vec<std::path::PathBuf>) {
+        for entry in std::fs::read_dir(directory)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", directory.display()))
+        {
+            let path = entry.expect("source directory entry").path();
+            if path.is_dir() {
+                visit_rust_files(&path, files);
+            } else if path.extension().and_then(|extension| extension.to_str()) == Some("rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    let source_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let allowed = source_root.join("svelte/rsvelte_bridge.rs");
+    let mut rust_files = Vec::new();
+    visit_rust_files(&source_root, &mut rust_files);
+
+    let offenders = rust_files
+        .into_iter()
+        .filter(|path| path != &allowed)
+        .filter(|path| {
+            std::fs::read_to_string(path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+                .contains("rsvelte_core")
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        offenders.is_empty(),
+        "rsvelte types must not cross the private neutral bridge: {offenders:?}"
+    );
+}
+
+#[test]
+fn application_runtime_matches_the_rsvelte_svelte_target() {
+    use std::collections::BTreeSet;
+
+    let workspace_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("verter_compiler must live at <workspace>/crates/verter_compiler")
+        .to_path_buf();
+    let bridge_path = workspace_root.join("crates/verter_compiler/src/svelte/rsvelte_bridge.rs");
+    let bridge = std::fs::read_to_string(&bridge_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", bridge_path.display()));
+    let target = bridge
+        .lines()
+        .find_map(|line| {
+            let value = line
+                .trim()
+                .strip_prefix("const EXPECTED_SVELTE_VERSION: &str = ")?;
+            Some(value.trim_end_matches(';').trim_matches('"').to_string())
+        })
+        .expect("the private bridge must declare its expected Svelte target");
+
+    let lock_path = workspace_root.join("pnpm-lock.yaml");
+    let lock = std::fs::read_to_string(&lock_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", lock_path.display()));
+    let resolved = lock
+        .lines()
+        .filter_map(|line| {
+            let package = line.trim().strip_prefix("svelte@")?.strip_suffix(':')?;
+            let version = package.split('(').next()?;
+            (!version.contains('/') && !version.is_empty()).then(|| version.to_string())
+        })
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        resolved,
+        BTreeSet::from([target]),
+        "the application runtime must resolve exactly the Svelte version targeted by rsvelte"
+    );
+}

--- a/crates/verter_macro_dto/tests/cases/dependency_closure_guard.rs
+++ b/crates/verter_macro_dto/tests/cases/dependency_closure_guard.rs
@@ -212,14 +212,17 @@ impl ResolveGraph {
             .unwrap_or_else(|| panic!("resolve node `{id}` must have a package entry"))
     }
 
-    /// BFS over production edges from `root_name`, returning every reached
+    /// BFS over production edges from `root_id`, returning every reached
     /// package id (including the root).
-    fn production_closure(&self, root_name: &str) -> HashSet<String> {
-        let root = self.id_of(root_name).to_string();
+    fn production_closure_from_id(&self, root_id: &str) -> HashSet<String> {
+        assert!(
+            self.names.contains_key(root_id),
+            "package id `{root_id}` must exist in the resolve graph"
+        );
         let mut seen: HashSet<String> = HashSet::new();
         let mut queue: VecDeque<String> = VecDeque::new();
-        seen.insert(root.clone());
-        queue.push_back(root);
+        seen.insert(root_id.to_string());
+        queue.push_back(root_id.to_string());
         while let Some(id) = queue.pop_front() {
             let deps = self
                 .production_deps
@@ -233,14 +236,32 @@ impl ResolveGraph {
         }
         seen
     }
+
+    /// BFS over production edges from the uniquely named workspace root.
+    fn production_closure(&self, root_name: &str) -> HashSet<String> {
+        self.production_closure_from_id(self.id_of(root_name))
+    }
 }
 
 /// The sanctioned span-primitive subtree: `oxc_span`'s OWN production
 /// closure, computed structurally from the live resolve graph, canaried
 /// against front-end rot, and equality-pinned against the audited
 /// `oxc`-prefixed allowlist before use.
-fn sanctioned_span_subtree(graph: &ResolveGraph) -> HashSet<String> {
-    let subtree = graph.production_closure(OXC_EXCEPTION_ROOT);
+fn sanctioned_span_subtree(
+    graph: &ResolveGraph,
+    firewalled_closure: &HashSet<String>,
+) -> HashSet<String> {
+    let mut roots = firewalled_closure
+        .iter()
+        .filter(|id| graph.name_of(id) == OXC_EXCEPTION_ROOT);
+    let root = roots.next().unwrap_or_else(|| {
+        panic!("firewalled closure must contain its sanctioned `{OXC_EXCEPTION_ROOT}` package")
+    });
+    assert!(
+        roots.next().is_none(),
+        "firewalled closure must reach exactly one `{OXC_EXCEPTION_ROOT}` package id"
+    );
+    let subtree = graph.production_closure_from_id(root);
     for id in &subtree {
         let name = graph.name_of(id);
         assert!(
@@ -285,7 +306,7 @@ fn sanctioned_span_subtree(graph: &ResolveGraph) -> HashSet<String> {
 fn assert_firewalled_closure(graph: &ResolveGraph, root: &str, required_reachable: &[&str]) {
     let closure = graph.production_closure(root);
     let closure_names: HashSet<&str> = closure.iter().map(|id| graph.name_of(id)).collect();
-    let sanctioned = sanctioned_span_subtree(graph);
+    let sanctioned = sanctioned_span_subtree(graph, &closure);
 
     // Non-vacuity: a broken walk that reached nothing must not pass.
     for &required in required_reachable {

--- a/crates/verter_session/src/cache.rs
+++ b/crates/verter_session/src/cache.rs
@@ -280,7 +280,7 @@ mod tests {
                 tsx: None,
                 template_analysis: None,
                 fact_dep_signature: crate::fact_signature_helpers::ReadSetSignature::empty(),
-                runtime_surface_refused: false,
+                runtime_refusal: None,
             },
         );
 

--- a/crates/verter_session/src/cache_runtime/compile_output_node.rs
+++ b/crates/verter_session/src/cache_runtime/compile_output_node.rs
@@ -136,13 +136,8 @@ pub(crate) struct CompileOutputValue {
     pub tsx: Option<CachedTsx>,
     /// Optional template-analysis snapshot extracted during compile.
     pub template_analysis: Option<verter_semantic::analysis::template::TemplateAnalysisSnapshot>,
-    /// Whether the carrier FAIL-CLOSED on an unsupported runtime surface (no
-    /// `Main` produced). The TYPED runtime-refusal signal the carrier sets on its
-    /// [`RuntimeCompileOutput`](verter_compiler::framework_common::RuntimeCompileOutput);
-    /// threaded onto the cached value so a runtime-requesting consumer reads the
-    /// refusal from this flag, NOT by sniffing the diagnostic-code prefix
-    /// (framework-neutral — the host never parses a framework-specific code).
-    pub runtime_surface_refused: bool,
+    /// Framework-neutral runtime-refusal reason threaded onto the cached value.
+    pub runtime_refusal: Option<crate::types::RuntimeRefusal>,
 }
 
 impl CompileOutputValue {
@@ -159,7 +154,7 @@ impl CompileOutputValue {
         last_good_outputs: Option<FxHashMap<VirtualNodeKind, CachedVirtualFile>>,
         tsx: Option<CachedTsx>,
         template_analysis: Option<verter_semantic::analysis::template::TemplateAnalysisSnapshot>,
-        runtime_surface_refused: bool,
+        runtime_refusal: Option<crate::types::RuntimeRefusal>,
     ) -> Self {
         Self {
             semantic_hash,
@@ -171,7 +166,7 @@ impl CompileOutputValue {
             last_good_outputs,
             tsx,
             template_analysis,
-            runtime_surface_refused,
+            runtime_refusal,
         }
     }
 }
@@ -561,7 +556,7 @@ impl CompileOutputNodeFactValidatedSession {
             outputs: slot.outputs.clone(),
             diagnostics: slot.diagnostics.clone(),
             tsx: slot.tsx.clone(),
-            runtime_surface_refused: slot.runtime_surface_refused,
+            runtime_refusal: slot.runtime_refusal.clone(),
         })
     }
 
@@ -599,7 +594,7 @@ impl CompileOutputNodeFactValidatedSession {
                     tsx: value.tsx,
                     template_analysis: value.template_analysis,
                     fact_dep_signature: signature,
-                    runtime_surface_refused: value.runtime_surface_refused,
+                    runtime_refusal: value.runtime_refusal,
                 };
                 profile_state.compile_slot_insert_for_node(profile_hash, slot);
                 SessionPublishOutcome::Admitted
@@ -738,9 +733,8 @@ pub(crate) struct SessionLookupHit {
     pub diagnostics: DiagnosticsSnapshot,
     /// Optional combined TSX output (IDE / LSP).
     pub tsx: Option<CachedTsx>,
-    /// Whether the carrier fail-closed on an unsupported runtime surface (the typed
-    /// runtime-refusal signal carried on the cached value).
-    pub runtime_surface_refused: bool,
+    /// Framework-neutral runtime-refusal reason carried on the cached value.
+    pub runtime_refusal: Option<crate::types::RuntimeRefusal>,
 }
 
 /// Result of [`CompileOutputNodeFactValidatedSession::publish`].

--- a/crates/verter_session/src/cache_runtime/compile_output_node_tests.rs
+++ b/crates/verter_session/src/cache_runtime/compile_output_node_tests.rs
@@ -47,7 +47,7 @@ fn value(semantic_hash: Hash16) -> CompileOutputValue {
         None,
         None,
         None,
-        false,
+        None,
     )
 }
 
@@ -64,7 +64,7 @@ fn value_with_css_override(semantic_hash: Hash16, css_override: &str) -> Compile
         None,
         None,
         None,
-        false,
+        None,
     )
 }
 
@@ -482,7 +482,7 @@ fn session_peek_output_returns_per_kind_pair() {
         None,
         None,
         None,
-        false,
+        None,
     );
     let admission = SignatureAdmission::Cacheable(ReadSetSignature::new(empty_fact_signature()));
     node.publish(&mut state, 42, admission, value, 0);

--- a/crates/verter_session/src/host_resolve/virtual_file_pipeline.rs
+++ b/crates/verter_session/src/host_resolve/virtual_file_pipeline.rs
@@ -176,12 +176,8 @@ pub(crate) struct CompileServe {
     pub(crate) actual_mode: CompileCacheMode,
     /// The first downgrade reason, when one fired.
     pub(crate) downgrade_reason: Option<DowngradeReason>,
-    /// Whether the carrier FAIL-CLOSED on an unsupported runtime surface (no `Main`
-    /// produced) — the TYPED runtime-refusal signal sourced from the carrier
-    /// bundle's `runtime_surface_refused`. A runtime-requesting consumer reads THIS
-    /// flag (never the diagnostic-code prefix) to turn a requested-but-absent `Main`
-    /// into an explicit `RuntimeSurfaceRefused`.
-    pub(crate) runtime_surface_refused: bool,
+    /// Framework-neutral reason the carrier failed closed on runtime emission.
+    pub(crate) runtime_refusal: Option<crate::types::RuntimeRefusal>,
 }
 
 /// BY-VALUE observation of what
@@ -1045,38 +1041,26 @@ impl VerterHost {
             Some(found) => found,
             None => {
                 // A REQUESTED `Main` runtime node that is absent is examined for a
-                // RUNTIME REFUSAL via the TYPED `runtime_surface_refused` flag the
-                // carrier set on its bundle (threaded onto `CompileServe`): a carrier
-                // that fail-closed on an unsupported runtime construct emits no
-                // `Main` and sets the flag. Such a request is an EXPLICIT refusal —
+                // A typed runtime refusal on the carrier bundle is threaded onto
+                // `CompileServe`. A carrier that fails closed emits no `Main` and
+                // carries the exact framework-neutral reason. Such a request is an explicit refusal —
                 // distinct from a generic missing node and from an IDE-only carrier —
                 // so a runtime-requesting consumer reads `RuntimeSurfaceRefused` and
                 // cannot mistake the absent node for a clean compile. The host reads
-                // the FRAMEWORK-NEUTRAL typed flag, never a framework-specific
-                // diagnostic-code prefix; the precise per-surface code/message is
-                // recovered from the refusal diagnostic for the error payload. The
+                // the framework-neutral typed reason, never a framework-specific
+                // diagnostic-code prefix. The
                 // IDE `tsx` is still produced (the `Ide` demand resolves it). Every
                 // OTHER missing node stays the generic `MissingVirtualNode`.
-                if node_kind == VirtualNodeKind::Main && served.runtime_surface_refused {
-                    // Recover the precise per-surface code + message from the
-                    // refusal diagnostic the carrier lifted (a non-fatal Warning).
-                    let (diagnostic_code, message) = served
-                        .diagnostics
-                        .diagnostics
-                        .iter()
-                        .find(|d| d.code.starts_with("svelte-runtime-unsupported-"))
-                        .map(|d| (d.code.clone(), d.message.clone()))
-                        .unwrap_or_else(|| {
-                            (
-                                "runtime-surface-refused".to_string(),
-                                "the carrier fail-closed on an unsupported runtime surface"
-                                    .to_string(),
-                            )
+                if node_kind == VirtualNodeKind::Main {
+                    let Some(refusal) = served.runtime_refusal.as_ref() else {
+                        return Err(HostError::MissingVirtualNode {
+                            canonical_id: canonical_id.clone(),
                         });
+                    };
                     return Err(HostError::RuntimeSurfaceRefused {
                         canonical_id: canonical_id.clone(),
-                        diagnostic_code,
-                        message,
+                        diagnostic_code: refusal.code.clone(),
+                        message: refusal.message.clone(),
                     });
                 }
                 return Err(HostError::MissingVirtualNode {
@@ -1376,7 +1360,7 @@ impl VerterHost {
                     outputs: FxHashMap<VirtualNodeKind, CachedVirtualFile>,
                     diagnostics: DiagnosticsSnapshot,
                     tsx: Option<CachedTsx>,
-                    runtime_surface_refused: bool,
+                    runtime_refusal: Option<crate::types::RuntimeRefusal>,
                 }
                 let warm_hit: Option<WarmHit> = match actual_mode {
                     CompileCacheMode::Stateless => None,
@@ -1423,7 +1407,7 @@ impl VerterHost {
                                 outputs: hit.outputs,
                                 diagnostics: hit.diagnostics,
                                 tsx: hit.tsx,
-                                runtime_surface_refused: hit.runtime_surface_refused,
+                                runtime_refusal: hit.runtime_refusal,
                             })
                     }),
                     CompileCacheMode::Content => {
@@ -1436,7 +1420,7 @@ impl VerterHost {
                                 outputs: value.outputs.clone(),
                                 diagnostics: value.diagnostics.clone(),
                                 tsx: value.tsx.clone(),
-                                runtime_surface_refused: value.runtime_surface_refused,
+                                runtime_refusal: value.runtime_refusal.clone(),
                             })
                     }
                 };
@@ -1488,7 +1472,7 @@ impl VerterHost {
                         requested_mode,
                         actual_mode,
                         downgrade_reason: classification.first_downgrade_reason(),
-                        runtime_surface_refused: hit.runtime_surface_refused,
+                        runtime_refusal: hit.runtime_refusal,
                     };
                     if Self::compile_serve_satisfies_demand(&serve, &demand) {
                         return Ok(serve);
@@ -1684,7 +1668,7 @@ impl VerterHost {
             stale,
             compiled_tsx,
             compiled_template_analysis,
-            runtime_surface_refused,
+            runtime_refusal,
         ) = match compile_result {
             Ok((outputs, diagnostics, tsx, tpl, refused)) => {
                 (outputs, diagnostics, false, tsx, tpl, refused)
@@ -1705,7 +1689,7 @@ impl VerterHost {
                 if serve_last_good {
                     if let Some(last_good) = fallback_last_good.clone() {
                         // A last-good serve is not a fresh runtime refusal.
-                        (last_good, diagnostics, true, None, None, false)
+                        (last_good, diagnostics, true, None, None, None)
                     } else {
                         return Err(HostError::CompileError(CompileFailure {
                             diagnostics,
@@ -1759,7 +1743,7 @@ impl VerterHost {
             },
             compiled_tsx.clone(),
             compiled_template_analysis.clone(),
-            runtime_surface_refused,
+            runtime_refusal.clone(),
         );
 
         // The `latest_diagnostics` + generation bump runs for EVERY mode
@@ -1950,7 +1934,7 @@ impl VerterHost {
             requested_mode: classification.requested_mode,
             actual_mode,
             downgrade_reason,
-            runtime_surface_refused,
+            runtime_refusal,
         })
     }
 
@@ -1960,7 +1944,7 @@ impl VerterHost {
     ///
     /// A `Main` demand is ALSO satisfied by a RUNTIME REFUSAL: a carrier that
     /// fail-closed on an unsupported runtime surface produces no `Main` output but
-    /// sets `runtime_surface_refused`. That refusal is the FINAL, cacheable answer to
+    /// carries a `runtime_refusal`. That refusal is the FINAL, cacheable answer to
     /// a `Main` request (`get_virtual_file` turns the absent-`Main`-but-refused serve
     /// into a typed `RuntimeSurfaceRefused`), so a warm cached refusal must SATISFY
     /// the demand and be reused — never fall through to a cold recompile that would
@@ -1969,7 +1953,7 @@ impl VerterHost {
         match demand {
             CompileDemand::VirtualNode(kind) => {
                 serve.outputs.contains_key(kind)
-                    || (*kind == VirtualNodeKind::Main && serve.runtime_surface_refused)
+                    || (*kind == VirtualNodeKind::Main && serve.runtime_refusal.is_some())
             }
             CompileDemand::Ide => serve.tsx.is_some(),
         }
@@ -1998,7 +1982,7 @@ impl VerterHost {
     ///
     /// Drives the shared compile under [`CompileDemand::Ide`] — it NEVER
     /// requests `VirtualNodeKind::Main`, so a carrier that projects only an IDE
-    /// surface (Svelte today) succeeds without a runtime `Main`. The caller's
+    /// surface succeeds without a runtime `Main`. The caller's
     /// profile is normalized to an IDE/TSX-bearing target INTERNALLY (see
     /// [`Self::ide_normalized_profile`]) so the compile produces the IDE surface
     /// regardless of the caller's runtime target. Return contract:
@@ -2569,9 +2553,8 @@ impl VerterHost {
             DiagnosticsSnapshot,
             Option<CachedTsx>,
             Option<verter_semantic::analysis::template::TemplateAnalysisSnapshot>,
-            // Whether the carrier fail-closed on an unsupported runtime surface (the
-            // TYPED runtime-refusal signal, sourced from the bundle).
-            bool,
+            // Framework-neutral reason the carrier failed closed on runtime emission.
+            Option<crate::types::RuntimeRefusal>,
         ),
         DiagnosticsSnapshot,
     > {
@@ -2808,10 +2791,15 @@ impl VerterHost {
             }
         };
 
-        // Capture the TYPED runtime-refusal signal BEFORE the bundle's fields are
-        // moved out below (the `Main` body / blocks are consumed when assembling the
-        // outputs), so the final `CompileServe`/cache record can carry it.
-        let runtime_surface_refused = compiled.runtime_surface_refused();
+        // Capture the typed runtime-refusal reason before the bundle's fields
+        // are moved into virtual outputs.
+        let runtime_refusal =
+            compiled
+                .runtime_refusal()
+                .map(|diagnostic| crate::types::RuntimeRefusal {
+                    code: diagnostic.code.clone(),
+                    message: diagnostic.message.clone(),
+                });
 
         // Lift the bundle's framework-neutral diagnostics into the host
         // `DiagnosticsSnapshot` (a Svelte projector diagnostic reaches the
@@ -2842,11 +2830,9 @@ impl VerterHost {
 
         let mut outputs = FxHashMap::default();
 
-        // The `Main` virtual node is the framework RUNTIME module. A carrier
-        // that produced a runtime surface assembles it; a carrier that
-        // projects ONLY an IDE surface (Svelte today) emits NO `Main` node —
-        // `get_virtual_file(Main)` then reports missing until that carrier
-        // emits a runtime surface.
+        // The `Main` virtual node is the framework runtime module. A carrier
+        // that produced a runtime surface assembles it; an IDE-only carrier
+        // emits no `Main` node.
         if compiled.has_runtime_surface() {
             let main_code = match &compiled.main.body_code {
                 // A carrier that emits its own self-contained ESM body uses it
@@ -3032,10 +3018,7 @@ impl VerterHost {
             compile_diags,
             cached_tsx,
             template_analysis,
-            // The TYPED runtime-refusal signal the carrier set on the bundle (no
-            // `Main` was produced for an unsupported runtime surface), captured
-            // before the bundle's fields were moved out.
-            runtime_surface_refused,
+            runtime_refusal,
         ))
     }
 

--- a/crates/verter_session/src/lib_tests.rs
+++ b/crates/verter_session/src/lib_tests.rs
@@ -764,7 +764,7 @@ fn invalidate_nodes_removes_last_good() {
             tsx: None,
             template_analysis: None,
             fact_dep_signature: crate::fact_signature_helpers::ReadSetSignature::empty(),
-            runtime_surface_refused: false,
+            runtime_refusal: None,
         },
     );
 
@@ -3634,7 +3634,7 @@ mod upsert_compile_cache_tests {
                     tsx: None,
                     template_analysis: None,
                     fact_dep_signature: crate::fact_signature_helpers::ReadSetSignature::empty(),
-                    runtime_surface_refused: false,
+                    runtime_refusal: None,
                 },
             );
         }

--- a/crates/verter_session/src/project_type_store_tests.rs
+++ b/crates/verter_session/src/project_type_store_tests.rs
@@ -141,7 +141,7 @@ fn seed_all_three_sub_states(host: &super::VerterHost, canonical: &str) {
                 tsx: None,
                 template_analysis: None,
                 fact_dep_signature: crate::fact_signature_helpers::ReadSetSignature::empty(),
-                runtime_surface_refused: false,
+                runtime_refusal: None,
             },
         );
     }

--- a/crates/verter_session/src/types.rs
+++ b/crates/verter_session/src/types.rs
@@ -2003,8 +2003,7 @@ pub enum HostError {
     RuntimeSurfaceRefused {
         /// The canonical id of the refused file.
         canonical_id: String,
-        /// The machine-stable refusal diagnostic code (e.g.
-        /// `svelte-runtime-unsupported-block`).
+        /// The carrier's machine-stable refusal diagnostic code.
         diagnostic_code: String,
         /// The human-readable refusal reason.
         message: String,
@@ -2400,10 +2399,17 @@ pub(crate) struct CompileSlot {
     /// falls back to the existing `semantic_hash`/override-hash
     /// pre-filter.
     pub(crate) fact_dep_signature: crate::fact_signature_helpers::ReadSetSignature,
-    /// Whether the carrier fail-closed on an unsupported runtime surface (the typed
-    /// runtime-refusal signal). Survives a warm hit so a runtime-requesting consumer
-    /// reads the refusal from this flag, not a diagnostic-code prefix.
-    pub(crate) runtime_surface_refused: bool,
+    /// Framework-neutral runtime-refusal reason. Survives a warm hit so a
+    /// runtime-requesting consumer receives the exact typed reason without
+    /// parsing a framework-specific diagnostic code.
+    pub(crate) runtime_refusal: Option<RuntimeRefusal>,
+}
+
+/// The framework-neutral reason a carrier failed closed on runtime emission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeRefusal {
+    pub(crate) code: String,
+    pub(crate) message: String,
 }
 
 /// Lightweight extract of FileEntry fields needed for compilation,

--- a/crates/verter_session/tests/cases/svelte_compiler_block1.rs
+++ b/crates/verter_session/tests/cases/svelte_compiler_block1.rs
@@ -562,7 +562,7 @@ fn runtime_main_request_on_a_refused_special_element_is_an_explicit_refusal_yet_
     // still refused; the window/document/body host + `<svelte:element>` + `<svelte:boundary>` +
     // `<svelte:head>` surfaces now EMIT, so a still-refused special fixture is a standalone
     // `<svelte:fragment>`) yields the EXPLICIT `HostError::RuntimeSurfaceRefused` (carrying the
-    // precise `svelte-runtime-unsupported-*` reason) — NOT a silent `MissingVirtualNode`, and NOT
+    // precise rsvelte compiler reason) — NOT a silent `MissingVirtualNode`, and NOT
     // a successful compile. YET the IDE projection (`get_ide`) still resolves (type-checking
     // survives). RED against the prior host path (which ignored `runtime_surface_refused` and
     // collapsed the request to a generic missing node, indistinguishable from a clean IDE-only
@@ -583,15 +583,15 @@ fn runtime_main_request_on_a_refused_special_element_is_an_explicit_refusal_yet_
             diagnostic_code, ..
         }) => {
             assert!(
-                diagnostic_code.starts_with("svelte-runtime-unsupported-"),
+                diagnostic_code.starts_with("rsvelte-"),
                 "the refusal must carry the precise reason, got: {diagnostic_code}"
             );
             // A standalone `<svelte:fragment>` special refuses with the EXACT
-            // `ComponentOrSnippet` diagnostic code (`special_label`) — assert it precisely.
+            // rsvelte/Svelte diagnostic code — assert it precisely.
             assert_eq!(
-                diagnostic_code, "svelte-runtime-unsupported-component",
+                diagnostic_code, "rsvelte-svelte_fragment_invalid_placement",
                 "a refused special-element host must refuse with the exact \
-                 `svelte-runtime-unsupported-component` code, got: {diagnostic_code}"
+                 rsvelte diagnostic code, got: {diagnostic_code}"
             );
         }
         Err(HostError::MissingVirtualNode { .. }) => panic!(
@@ -799,7 +799,7 @@ fn runtime_main_request_on_a_supported_svelte_component_returns_the_main_module(
 #[test]
 fn cached_runtime_refusal_satisfies_a_main_demand_without_recompute() {
     // The refused runtime surface here is a standalone `<svelte:fragment>` (the transparent-
-    // wrapper surface, still refused with `svelte-runtime-unsupported-component`; the
+    // wrapper surface, refused with `rsvelte-svelte_fragment_invalid_placement`; the
     // window/document/body host + `<svelte:element>` + `<svelte:boundary>` + `<svelte:head>`
     // surfaces now EMIT); its IDE projection still resolves.
     // A WARM cached runtime refusal (`runtime_surface_refused = true`, no `Main`
@@ -833,14 +833,14 @@ fn cached_runtime_refusal_satisfies_a_main_demand_without_recompute() {
     };
 
     // First request: the cold compile runs, fails closed, and the refusal is cached
-    // carrying the EXACT `svelte-runtime-unsupported-component` code.
+    // carrying the exact rsvelte/Svelte diagnostic code.
     match request() {
         Err(HostError::RuntimeSurfaceRefused {
             diagnostic_code, ..
         }) => assert_eq!(
-            diagnostic_code, "svelte-runtime-unsupported-component",
+            diagnostic_code, "rsvelte-svelte_fragment_invalid_placement",
             "the first runtime Main request on a refused component is a typed refusal \
-             carrying the exact `svelte-runtime-unsupported-component` code, got: \
+             carrying the exact rsvelte diagnostic code, got: \
              {diagnostic_code}"
         ),
         Ok(_) => panic!(
@@ -860,9 +860,9 @@ fn cached_runtime_refusal_satisfies_a_main_demand_without_recompute() {
         Err(HostError::RuntimeSurfaceRefused {
             diagnostic_code, ..
         }) => assert_eq!(
-            diagnostic_code, "svelte-runtime-unsupported-component",
+            diagnostic_code, "rsvelte-svelte_fragment_invalid_placement",
             "the warm-served runtime Main request on a refused component is STILL a typed \
-             refusal carrying the exact `svelte-runtime-unsupported-component` code, got: \
+             refusal carrying the exact rsvelte diagnostic code, got: \
              {diagnostic_code}"
         ),
         Ok(_) => panic!(

--- a/crates/verter_session/tests/cases/svelte_typecheck_gate/vendor_svelte/package.json
+++ b/crates/verter_session/tests/cases/svelte_typecheck_gate/vendor_svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte",
-  "version": "5.56.3",
+  "version": "5.56.8",
   "types": "index.d.ts",
   "exports": {
     ".": { "types": "./index.d.ts" },

--- a/crates/verter_session_query/tests/cases/dependency_closure_guard.rs
+++ b/crates/verter_session_query/tests/cases/dependency_closure_guard.rs
@@ -198,14 +198,17 @@ impl ResolveGraph {
             .unwrap_or_else(|| panic!("resolve node `{id}` must have a package entry"))
     }
 
-    /// BFS over production edges from `root_name`, returning every reached
+    /// BFS over production edges from `root_id`, returning every reached
     /// package id (including the root).
-    fn production_closure(&self, root_name: &str) -> HashSet<String> {
-        let root = self.id_of(root_name).to_string();
+    fn production_closure_from_id(&self, root_id: &str) -> HashSet<String> {
+        assert!(
+            self.names.contains_key(root_id),
+            "package id `{root_id}` must exist in the resolve graph"
+        );
         let mut seen: HashSet<String> = HashSet::new();
         let mut queue: VecDeque<String> = VecDeque::new();
-        seen.insert(root.clone());
-        queue.push_back(root);
+        seen.insert(root_id.to_string());
+        queue.push_back(root_id.to_string());
         while let Some(id) = queue.pop_front() {
             let deps = self
                 .production_deps
@@ -219,14 +222,32 @@ impl ResolveGraph {
         }
         seen
     }
+
+    /// BFS over production edges from the uniquely named workspace root.
+    fn production_closure(&self, root_name: &str) -> HashSet<String> {
+        self.production_closure_from_id(self.id_of(root_name))
+    }
 }
 
 /// The sanctioned span-primitive subtree: `oxc_span`'s OWN production
 /// closure, computed structurally from the live resolve graph, canaried
 /// against front-end rot, and equality-pinned against the audited
 /// `oxc`-prefixed allowlist before use.
-fn sanctioned_span_subtree(graph: &ResolveGraph) -> HashSet<String> {
-    let subtree = graph.production_closure(OXC_EXCEPTION_ROOT);
+fn sanctioned_span_subtree(
+    graph: &ResolveGraph,
+    firewalled_closure: &HashSet<String>,
+) -> HashSet<String> {
+    let mut roots = firewalled_closure
+        .iter()
+        .filter(|id| graph.name_of(id) == OXC_EXCEPTION_ROOT);
+    let root = roots.next().unwrap_or_else(|| {
+        panic!("firewalled closure must contain its sanctioned `{OXC_EXCEPTION_ROOT}` package")
+    });
+    assert!(
+        roots.next().is_none(),
+        "firewalled closure must reach exactly one `{OXC_EXCEPTION_ROOT}` package id"
+    );
+    let subtree = graph.production_closure_from_id(root);
     for id in &subtree {
         let name = graph.name_of(id);
         assert!(
@@ -277,7 +298,7 @@ fn assert_firewalled_closure(
 ) {
     let closure = graph.production_closure(root);
     let closure_names: HashSet<&str> = closure.iter().map(|id| graph.name_of(id)).collect();
-    let sanctioned = sanctioned_span_subtree(graph);
+    let sanctioned = sanctioned_span_subtree(graph, &closure);
 
     // Non-vacuity: a broken walk that reached nothing must not pass.
     for &required in required_reachable {

--- a/docs/api/unplugin.md
+++ b/docs/api/unplugin.md
@@ -32,7 +32,9 @@ export default defineConfig({
 });
 ```
 
-Install and pin `svelte@5.56.3` in the application; emitted `svelte/internal/client` imports are deliberately resolved from the application's Svelte package.
+Install and pin `svelte@5.56.8` in the application; emitted
+`svelte/internal/client` and `svelte/internal/server` imports are deliberately
+resolved from the application's Svelte package.
 
 For a mixed Vue/Svelte project:
 
@@ -46,7 +48,10 @@ export default defineConfig({
 ```
 
 ::: warning Experimental Svelte support
-Svelte support is **experimental — not yet validated in real-world use**. The client compiler, external scoped CSS, dependency routing, and preview mount path are integrated. Unsupported runtime surfaces, including unavailable server output, fail closed with typed diagnostics rather than producing successful empty modules.
+Svelte support is **experimental — not yet validated in real-world use**. The
+rsvelte-backed client and server compilers, external scoped CSS, dependency
+routing, and preview mount path are integrated. Compiler failures fail closed
+with typed diagnostics rather than producing successful empty modules.
 :::
 
 ## Bundler Setup

--- a/docs/arch/release-state.md
+++ b/docs/arch/release-state.md
@@ -33,15 +33,15 @@ and fixture disposition are recorded in
 - **Editors:** VS Code is the primary packaged integration. Neovim, Helix,
   Zed, and Lapce adapters use the shared native client and LSP contracts, with
   each adapter's packaging limitations documented alongside its implementation.
-- **Svelte (experimental):** native **client** compilation is experimental and
-  pinned to `svelte@5.56.3`; it is usable for the in-scope covered fixtures,
-  whose behavior is protected by runtime, conformance, and official-oracle
-  tests. **SSR and hydration are not shipped** — they are post-merge follow-ups
-  (the CSR/SSR hydration round-trip gate is a plan target, not a current
-  status). Unsupported runtime features and unavailable server output fail
-  closed with typed diagnostics; they do not return successful placeholder
-  modules. See the [unplugin API](../api/unplugin.md) and the forward-looking
-  [Svelte compiler program plan](./svelte-native-compiler-plan.md).
+- **Svelte (experimental):** runtime compilation delegates to rsvelte's pinned
+  Rust toolchain, targeting `svelte@5.56.8`. Client and server modules, external
+  scoped CSS, source maps, and compiler diagnostics cross one private neutral
+  bridge; compiler failures fail closed and never produce successful
+  placeholder modules. Verter still owns the IDE projection and host/session
+  architecture. Hydration remains experimental and requires the public
+  end-to-end gate described in the
+  [rsvelte runtime integration decision](./rsvelte-runtime-integration.md).
+  See also the [unplugin API](../api/unplugin.md).
 
 Verter remains beta software. The public [guide](../guide/index.md) is the
 authority for user-facing maturity and installation expectations.

--- a/docs/arch/rsvelte-runtime-integration.md
+++ b/docs/arch/rsvelte-runtime-integration.md
@@ -1,0 +1,75 @@
+# rsvelte runtime integration
+
+This decision records the ownership boundary for Svelte runtime compilation in
+Verter. It is deliberately narrower than a wholesale Svelte adapter rewrite:
+runtime compilation moves to rsvelte, while Verter keeps its existing IDE
+projection until rsvelte and Verter can prove mapping parity independently.
+
+## Ownership
+
+rsvelte owns Svelte source parsing, component analysis, and client/server
+runtime emission. Verter owns carrier registration, compile profiles, cache
+admission, scheduling, virtual files, diagnostics transport, IDE projection,
+template facts, and cross-file type resolution.
+
+The only production dependency edge is
+`verter_compiler::svelte::rsvelte_bridge`. Its input and output are Verter's
+framework-neutral `RuntimeCompileOptions` and `RuntimeCompileOutput`; no rsvelte
+AST, allocator, diagnostic, or mapping type escapes the module. The bridge:
+
+- pins the rsvelte crate version, Git revision, toolchain ABI, runtime ABI, and
+  Svelte compatibility version;
+- translates the resolved Verter profile into policy-free rsvelte compile
+  options;
+- emits either client or server ESM verbatim as the carrier `Main` module;
+- translates external CSS, source maps, scope hashes, warnings, and failures
+  into neutral carrier DTOs;
+- fails closed on compiler or fingerprint mismatch; there is no production
+  fallback to Verter's former runtime backend.
+
+Verter's IDE projection remains independent in this cutover. rsvelte's
+projection has a different exact-mapping contract, so replacing it belongs in
+a separate parity change rather than being hidden inside a runtime migration.
+
+## Version and publication contract
+
+The initial boundary targets:
+
+| Axis | Pin |
+| --- | --- |
+| `rsvelte_core` | `=0.9.4` plus an exact Git revision during integration |
+| rsvelte toolchain ABI | `1` |
+| rsvelte runtime ABI | `1` |
+| rsvelte facts ABI | `2` |
+| Svelte compatibility target/runtime | `5.56.8` |
+
+The Git revision makes review builds reproducible, but it fetches rsvelte's
+repository and submodules and ties routine builds to GitHub availability. It is
+therefore a review dependency, not the normal release/CI contract. Publish
+`rsvelte_esrap` and then `rsvelte_core` to the registry before replacing the
+exact Git pin with the same exact crate version. That source-only change must
+not require changes to bridge code.
+
+## Merge gates
+
+The runtime cutover is mergeable only when all of these are true:
+
+1. `rsvelte_core`'s `default-features = false` graph excludes formatter, CLI,
+   watcher, and module-resolver tooling.
+2. `rsvelte_esrap` and `rsvelte_core` are packageable and published in
+   dependency order, and Verter resolves the exact registry version without a
+   Git source.
+3. Verter has only one production Svelte runtime route and no fallback.
+4. Client and server carrier tests cover module output, source maps, external
+   CSS, default and configured scope hashes, warnings, and fail-closed errors.
+5. Verter's canonical workspace, shared-process session, clippy, release,
+   WASM, formatting, and TypeScript gates pass.
+6. The application runtime is pinned to the same Svelte version rsvelte
+   targets, and CSR/SSR behavior is exercised through Verter's public carrier
+   path.
+
+Verter's native runtime module is a conformance surface, not a registered host
+backend. It may keep its independently pinned Svelte 5.56.3 oracle corpus while
+the application runtime follows rsvelte's 5.56.8 target. It must not be
+selected by a feature flag or error fallback; the carrier has one production
+runtime route.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -106,13 +106,12 @@ flowchart LR
 
 ## Experimental Svelte compiler
 
-Verter includes an experimental native Svelte client compiler tested against
-the pinned `svelte@5.56.3` runtime. It is not presented as a general drop-in
-replacement for the official compiler: supported client behavior is covered by
-runtime and official-oracle tests, while unsupported runtime or server-output
-surfaces fail closed with typed diagnostics. Published benchmark evidence is
-limited to its explicit, equal-work fixture corpus and is not a general speed
-or memory claim.
+Verter delegates Svelte client and server runtime compilation to the pinned
+rsvelte Rust toolchain targeting `svelte@5.56.8`. Verter continues to own the
+IDE projection, cache, and host/session integration. Compiler failures fail
+closed with typed diagnostics; they are never replaced by a successful empty
+module. This integration remains experimental until its public hydration and
+real-world application gates are established.
 
 ## Next Steps
 

--- a/editors/nvim/tests/fixtures/real-client/package-lock.json
+++ b/editors/nvim/tests/fixtures/real-client/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "verter-neovim-real-client-fixture",
       "dependencies": {
-        "svelte": "5.56.3",
+        "svelte": "5.56.8",
         "typescript": "7.0.2",
         "vue": "3.5.34"
       }
@@ -721,9 +721,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.56.3",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.3.tgz",
-      "integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
+      "version": "5.56.8",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.8.tgz",
+      "integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -737,7 +737,7 @@
         "clsx": "^2.1.1",
         "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.11",
+        "esrap": "^2.2.12",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",

--- a/editors/nvim/tests/fixtures/real-client/package.json
+++ b/editors/nvim/tests/fixtures/real-client/package.json
@@ -2,7 +2,7 @@
   "name": "verter-neovim-real-client-fixture",
   "private": true,
   "dependencies": {
-    "svelte": "5.56.3",
+    "svelte": "5.56.8",
     "typescript": "7.0.2",
     "vue": "3.5.34"
   }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "husky": "^9.1.7",
     "json-diff": "^1.0.6",
     "shx": "0.4.0",
-    "svelte": "5.56.3",
+    "svelte": "5.56.8",
     "typescript": "7.0.2",
     "vitest": "^4.1.7",
     "vue": "3.5.34"
@@ -100,6 +100,9 @@
   },
   "packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c",
   "pnpm": {
+    "overrides": {
+      "svelte": "5.56.8"
+    },
     "onlyBuiltDependencies": [
       "@swc/core",
       "@vscode/vsce-sign",

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -45,7 +45,7 @@ pnpm bench:json
 ## Svelte Compiler Fence
 
 The Svelte fence compares Verter's experimental native client compiler with the
-pinned official `svelte@5.56.3` compiler:
+pinned official `svelte@5.56.8` compiler:
 
 ```bash
 pnpm --filter @verter/benchmark bench:svelte:compiler

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -38,7 +38,7 @@
     "@vue/compiler-sfc": "^3.5.34",
     "@vue/language-server": "^3.3.2",
     "magic-string": "^0.30.21",
-    "svelte": "5.56.3",
+    "svelte": "5.56.8",
     "tinybench": "^6.0.2",
     "vue": "^3.5.34",
     "vue-component-meta": "^3.3.2"

--- a/packages/benchmark/src/svelte-perf-contract.ts
+++ b/packages/benchmark/src/svelte-perf-contract.ts
@@ -1,6 +1,6 @@
 import type { SvelteCompilerFixture } from "./svelte-perf-fixtures";
 
-export const PINNED_OFFICIAL_SVELTE_VERSION = "5.56.3";
+export const PINNED_OFFICIAL_SVELTE_VERSION = "5.56.8";
 export const SVELTE_COMPILER_WALL_THRESHOLD = 1.1;
 export const SVELTE_COMPILER_RSS_THRESHOLD = 1.1;
 export const MIN_SVELTE_PERF_ITERATIONS = 50;

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -6,7 +6,7 @@
 Online playground for live framework-carrier compilation using Verter. Write Vue or Svelte components in a browser-based editor and inspect the generated TypeScript, JavaScript, CSS, diagnostics, and live preview.
 
 > [!IMPORTANT]
-> Svelte support is **experimental — not yet validated in real-world use**. The preview uses the compiler-pinned Svelte 5.56.3 runtime. Unsupported runtime surfaces remain visible as diagnostics instead of being previewed as successful empty output.
+> Svelte support is **experimental — not yet validated in real-world use**. The preview uses the compiler-pinned Svelte 5.56.8 runtime. Unsupported runtime surfaces remain visible as diagnostics instead of being previewed as successful empty output.
 
 This is a **private** package (not published to npm). It is deployed to Netlify via the release CI workflow.
 

--- a/packages/playground/src/core/importMap.spec.ts
+++ b/packages/playground/src/core/importMap.spec.ts
@@ -40,7 +40,7 @@ describe("getDefaultImportMap", () => {
 
   it("pins every Svelte runtime entry used by emitted client and server modules", () => {
     const map = getDefaultImportMap();
-    const base = "https://cdn.jsdelivr.net/npm/svelte@5.56.3";
+    const base = "https://cdn.jsdelivr.net/npm/svelte@5.56.8";
 
     expect(map.imports.svelte).toBe(`${base}/src/index-client.js`);
     expect(map.imports["svelte/internal/client"]).toBe(`${base}/src/internal/client/index.js`);

--- a/packages/playground/src/core/importMap.ts
+++ b/packages/playground/src/core/importMap.ts
@@ -3,7 +3,7 @@ export interface ImportMap {
   scopes?: Record<string, Record<string, string>>;
 }
 
-export const SVELTE_RUNTIME_VERSION = "5.56.3";
+export const SVELTE_RUNTIME_VERSION = "5.56.8";
 
 export function getDefaultImportMap(vueVersion = "3.5.26"): ImportMap {
   const svelteBase = `https://cdn.jsdelivr.net/npm/svelte@${SVELTE_RUNTIME_VERSION}`;

--- a/packages/svelte-runtime-tests/package.json
+++ b/packages/svelte-runtime-tests/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@types/node": "^25.9.1",
     "happy-dom": "^20.9.0",
-    "svelte": "5.56.3",
+    "svelte": "5.56.8",
     "vitest": "^4.1.7"
   }
 }

--- a/packages/svelte-runtime-tests/test/svelte-client-5a-smoke.spec.ts
+++ b/packages/svelte-runtime-tests/test/svelte-client-5a-smoke.spec.ts
@@ -2,7 +2,7 @@
 //
 // Behavioral smoke for the native Svelte client Block-5a surface (dynamic
 // attributes + boolean DOM props + class/style). It mounts Verter's EMITTED
-// modules against the REAL pinned `svelte@5.56.3` client runtime and asserts the
+// modules against the REAL pinned `svelte@5.56.8` client runtime and asserts the
 // observable DOM behavior reacts to `$state` changes:
 //   - a dynamic `id={…}` attribute, a dynamic `class={…}` (via `$.clsx`), and a
 //     `style:color={…}` directive (merged with a static `style` base) all update on

--- a/packages/svelte-runtime-tests/test/svelte-client-bind-smoke.spec.ts
+++ b/packages/svelte-runtime-tests/test/svelte-client-bind-smoke.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 //
 // Behavioral smoke for the native Svelte client DOM-hosted bind family. It
-// mounts Verter's EMITTED §1.2 modules against the REAL pinned `svelte@5.56.3`
+// mounts Verter's EMITTED §1.2 modules against the REAL pinned `svelte@5.56.8`
 // client runtime and asserts the observable DOM↔signal behavior of each
 // `$.bind_*` host:
 //   - `<textarea bind:value>`  — typing into the textarea updates the reflected `<p>`;

--- a/packages/svelte-runtime-tests/test/svelte-client-blocks-smoke.spec.ts
+++ b/packages/svelte-runtime-tests/test/svelte-client-blocks-smoke.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 //
 // Behavioral smoke for the native Svelte client CONTROL-FLOW blocks (5e). It mounts
-// Verter's EMITTED modules against the REAL pinned `svelte@5.56.3` client runtime and
+// Verter's EMITTED modules against the REAL pinned `svelte@5.56.8` client runtime and
 // asserts the observable mount-and-react behavior of each block:
 //   - `{#if}`   — the truthy branch renders its body;
 //   - `{#each}` — a `$props()`-sourced array renders one body per item, the item read

--- a/packages/svelte-runtime-tests/test/svelte-client-events-smoke.spec.ts
+++ b/packages/svelte-runtime-tests/test/svelte-client-events-smoke.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 //
 // Behavioral smoke for the native Svelte client regular-element event surface. It
-// mounts Verter's EMITTED modules against the REAL pinned `svelte@5.56.3` client
+// mounts Verter's EMITTED modules against the REAL pinned `svelte@5.56.8` client
 // runtime and asserts the observable runtime behavior of each event registration:
 //   - a non-delegated `$.event` listener attaches + fires (`onfocus`);
 //   - `|once`                 — the handler fires only ONCE across repeated dispatch;

--- a/packages/svelte-runtime-tests/test/svelte-client-lifecycle-smoke.spec.ts
+++ b/packages/svelte-runtime-tests/test/svelte-client-lifecycle-smoke.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 //
 // Behavioral smoke for the native Svelte client element lifecycle-directive surface
-// (5f-c). It mounts Verter's EMITTED modules against the REAL pinned `svelte@5.56.3`
+// (5f-c). It mounts Verter's EMITTED modules against the REAL pinned `svelte@5.56.8`
 // client runtime and asserts the observable runtime behavior of each lifecycle
 // helper:
 //   - `use:act`        — the action fn RUNS on mount, receiving the mounted element;

--- a/packages/svelte-runtime-tests/test/svelte-client-smoke.spec.ts
+++ b/packages/svelte-runtime-tests/test/svelte-client-smoke.spec.ts
@@ -2,7 +2,7 @@
 //
 // Behavioral smoke for the native Svelte client emission (§1.2 conformance
 // target). It mounts Verter's EMITTED §1.2 module against the REAL pinned
-// `svelte@5.56.3` client runtime and asserts the observable DOM behavior:
+// `svelte@5.56.8` client runtime and asserts the observable DOM behavior:
 //   - the initial render shows `Hello world!` and `clicks: 0`;
 //   - editing the `<input>` (a `bind:value`) updates the `<h1>` reactively;
 //   - clicking the `<button>` (a delegated `onclick`) updates the count text.

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -149,7 +149,7 @@
     "sass-embedded": "1.100.0",
     "sass-loader": "^17.0.0",
     "sirv-cli": "^3.0.1",
-    "svelte": "5.56.3",
+    "svelte": "5.56.8",
     "style-loader": "^4.0.0",
     "tailwindcss": "4.3.0",
     "tsdown": "^0.22.0",

--- a/packages/vue-vscode/e2e/fixtures/ecosystem-parity/package.json
+++ b/packages/vue-vscode/e2e/fixtures/ecosystem-parity/package.json
@@ -2,7 +2,7 @@
   "name": "verter-e2e-ecosystem-parity",
   "private": true,
   "dependencies": {
-    "svelte": "5.56.3",
+    "svelte": "5.56.8",
     "verter": "file:../../../../../../verter-release-clean",
     "vue": "3.5.40"
   },

--- a/packages/vue-vscode/e2e/fixtures/mixed-parity/package.json
+++ b/packages/vue-vscode/e2e/fixtures/mixed-parity/package.json
@@ -2,7 +2,7 @@
   "name": "verter-e2e-mixed-parity",
   "private": true,
   "dependencies": {
-    "svelte": "5.56.3",
+    "svelte": "5.56.8",
     "verter": "file:../../../../..",
     "vue": "3.5.40"
   },

--- a/packages/vue-vscode/e2e/fixtures/multi-root-parity/pkg-b/package.json
+++ b/packages/vue-vscode/e2e/fixtures/multi-root-parity/pkg-b/package.json
@@ -2,7 +2,7 @@
   "name": "verter-e2e-multi-root-b",
   "private": true,
   "dependencies": {
-    "svelte": "5.56.3",
+    "svelte": "5.56.8",
     "verter-vscode": "file:../../../.."
   },
   "devDependencies": {

--- a/packages/vue-vscode/e2e/fixtures/svelte-contract/package.json
+++ b/packages/vue-vscode/e2e/fixtures/svelte-contract/package.json
@@ -2,7 +2,7 @@
   "name": "verter-e2e-svelte-contract",
   "private": true,
   "dependencies": {
-    "svelte": "5.56.3",
+    "svelte": "5.56.8",
     "verter": "file:../../../../.."
   },
   "devDependencies": {

--- a/packages/vue-vscode/e2e/fixtures/svelte-parity/package.json
+++ b/packages/vue-vscode/e2e/fixtures/svelte-parity/package.json
@@ -2,7 +2,7 @@
   "name": "verter-e2e-svelte-parity",
   "private": true,
   "dependencies": {
-    "svelte": "5.56.3",
+    "svelte": "5.56.8",
     "verter": "file:../../../../.."
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  svelte: 5.56.8
+
 importers:
 
   .:
@@ -16,7 +19,7 @@ importers:
         version: 3.5.34
       oxfmt:
         specifier: 0.52.0
-        version: 0.52.0(svelte@5.56.3)
+        version: 0.52.0(svelte@5.56.8)
     devDependencies:
       '@bufbuild/buf':
         specifier: 1.70.0
@@ -52,8 +55,8 @@ importers:
         specifier: 0.4.0
         version: 0.4.0
       svelte:
-        specifier: 5.56.3
-        version: 5.56.3
+        specifier: 5.56.8
+        version: 5.56.8
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -118,8 +121,8 @@ importers:
         specifier: ^0.30.21
         version: 0.30.21
       svelte:
-        specifier: 5.56.3
-        version: 5.56.3
+        specifier: 5.56.8
+        version: 5.56.8
       tinybench:
         specifier: ^6.0.2
         version: 6.0.2
@@ -416,8 +419,8 @@ importers:
   packages/svelte-jsx:
     dependencies:
       svelte:
-        specifier: '>=5.0.0'
-        version: 5.56.3
+        specifier: 5.56.8
+        version: 5.56.8
 
   packages/svelte-runtime-tests:
     devDependencies:
@@ -428,8 +431,8 @@ importers:
         specifier: ^20.9.0
         version: 20.9.0
       svelte:
-        specifier: 5.56.3
-        version: 5.56.3
+        specifier: 5.56.8
+        version: 5.56.8
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))
@@ -593,8 +596,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.107.2)
       svelte:
-        specifier: 5.56.3
-        version: 5.56.3
+        specifier: 5.56.8
+        version: 5.56.8
       tailwindcss:
         specifier: 4.3.0
         version: 4.3.0
@@ -6840,6 +6843,14 @@ packages:
       '@typescript-eslint/types':
         optional: true
 
+  esrap@2.2.12:
+    resolution: {integrity: sha512-On0QbLyaiAkVC4eXtgnXK9Kh2opit+3rcUSOc45DqJ2s/X2eXAHsGOKRSJ6IDagQEW5vPyivANfXUiqgXC67Rw==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
+
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
@@ -10219,8 +10230,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svelte@5.56.3:
-    resolution: {integrity: sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==}
+  svelte@5.56.8:
+    resolution: {integrity: sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==}
     engines: {node: '>=18'}
 
   svgo@2.8.2:
@@ -17644,6 +17655,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  esrap@2.2.12:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
@@ -19864,7 +19879,7 @@ snapshots:
       magic-regexp: 0.10.0
       oxc-parser: 0.112.0
 
-  oxfmt@0.52.0(svelte@5.56.3):
+  oxfmt@0.52.0(svelte@5.56.8):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -19887,7 +19902,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.52.0
       '@oxfmt/binding-win32-ia32-msvc': 0.52.0
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
-      svelte: 5.56.3
+      svelte: 5.56.8
 
   p-filter@2.1.0:
     dependencies:
@@ -21567,7 +21582,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte@5.56.3:
+  svelte@5.56.8:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -21580,7 +21595,7 @@ snapshots:
       clsx: 2.1.1
       devalue: 5.8.1
       esm-env: 1.2.2
-      esrap: 2.2.11
+      esrap: 2.2.12
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.21


### PR DESCRIPTION
This is just a proposal, so the implementation is still a draft.
I recently learned that this library also supports Svelte. I’m working on a project called `rsvelte`, which aims to rewrite the Svelte compiler and related ecosystem tools in Rust.
If Vue is your primary focus and you’d like to make Svelte support easier to maintain, would you consider delegating Svelte-specific processing to `rsvelte`?

https://github.com/baseballyama/rsvelte