### PR TITLE
docs(compiler): native session contract-vocabulary migration

### DIFF
--- a/crates/verter_session/src/host_compile.rs
+++ b/crates/verter_session/src/host_compile.rs
@@ -240,8 +240,11 @@ impl CompileBatchEntry {
 /// This carries EVERY output-affecting field the render lane feeds into
 /// `RuntimeCompileOptions`, so the RuntimeRender lane reproduces the
 /// caller's build profile byte-for-byte against the HostBacked
-/// `get_virtual_file` path (which builds its profile from the same JS
-/// `HostCompileProfile`). Omitting a field would silently drop it — e.g.
+/// `get_virtual_file` path (which builds its profile from the same
+/// JS-supplied fields of the framework-discriminated `HostCompileRequest` —
+/// its identity, requested products and their general product options, plus
+/// the framework arm's options, as distinct from this flattened
+/// runtime-render profile). Omitting a field would silently drop it — e.g.
 /// without `source_map` a production build would lose its source maps.
 /// Optional fields keep the same "absent = `CompileProfile` default"
 /// semantics as the FFI profile conversion, so the render profile also
@@ -361,8 +364,10 @@ pub fn compile_profile_for_bundler() -> CompileProfile {
 ///
 /// Absent-field semantics match FFI (`ffi_profile_to_host`). Hash-
 /// load-bearing: the profile must hash identically to the
-/// `CompileProfile` from the same JS `HostCompileProfile`, because
-/// `apply_block_overrides` stores supplied content under that hash.
+/// `CompileProfile` projected from the same JS framework-discriminated
+/// `HostCompileRequest` identity, runtime-product options, and framework-arm
+/// options, because `apply_block_overrides` stores supplied content under
+/// that hash.
 fn render_base_profile(rp: &CompileBatchRenderProfile) -> CompileProfile {
     let mut profile = CompileProfile {
         filename: rp.filename.clone(),

--- a/crates/verter_session/src/runtime_render_lane_tests.rs
+++ b/crates/verter_session/src/runtime_render_lane_tests.rs
@@ -112,7 +112,8 @@ fn host_backed_one(
 
 /// Build the batch render profile mirroring an unplugin build. Non-varied
 /// output-affecting fields take the same defaults `CompileProfile::default`
-/// / an absent `HostCompileProfile` field would (so this matches the
+/// / an absent general product or framework-arm option on the
+/// framework-discriminated `HostCompileRequest` would (so this matches the
 /// `get_virtual_file` oracle unless a test overrides a field explicitly).
 fn render_profile(
     is_production: bool,
@@ -129,7 +130,8 @@ fn render_profile(
         force_vapor: false,
         source_map: false,
         // Tri-state: absent means "compiler default" (`!is_production`),
-        // exactly like an absent `HostCompileProfile.comments`.
+        // exactly like an absent `comments` in the `HostCompileRequest`'s
+        // framework-arm options.
         comments: None,
         filename: None,
         hmr_strategy: hmr,

--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -97,7 +97,7 @@ schema = 2
 "CCA1O2C" = { status = "pending" }
 "CCA1O2D" = { status = "pending" }
 "CCA1O2E" = { status = "pending" }
-"CCA1O2F" = { status = "pending" }
+"CCA1O2F" = { status = "implemented", commit_message = "docs(session): name the framework-tagged host request in compile-lane comments", commit_date = "2026-09-02T01:28:36+01:00", pull_request = 466 }
 "CCA1O2G" = { status = "pending" }
 "CCA1O2H" = { status = "implemented", commit_message = "fix(napi): refuse a request key stated as undefined", commit_date = "2026-09-01T00:56:27+01:00" }
 "CCA1O2I" = { status = "implemented", commit_message = "refactor(napi): generate the published host compile-request declaration", commit_date = "2026-09-01T14:00:00+01:00" }


### PR DESCRIPTION
Autonomous candidate for one roadmap block.

Do not merge manually: the TAMA controller owns landing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that runtime-render profile parity is evaluated using framework-specific host compilation request options, including identity, products, general options, and framework-specific settings.
  * Updated test documentation to reflect the available framework-discriminated compilation options.

* **Chores**
  * Updated implementation tracking metadata for a completed roadmap item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #138
