### PR TITLE
fix: Main's CI Required failure was two intermittent test races, not the head landing

### DIFF
--- a/crates/verter_lsp/src/server_tests.rs
+++ b/crates/verter_lsp/src/server_tests.rs
@@ -10127,7 +10127,7 @@ async fn component_completion_cold_parent_import_converges_without_test_prewarm(
         server,
         DidChangeTextDocumentParams {
             text_document: VersionedTextDocumentIdentifier {
-                uri: child_uri,
+                uri: child_uri.clone(),
                 version: 2,
             },
             content_changes: vec![TextDocumentContentChangeEvent {
@@ -10138,8 +10138,18 @@ async fn component_completion_cold_parent_import_converges_without_test_prewarm(
         },
     )
     .await;
+    // Re-arm the background lane on every poll instead of resting on the one
+    // debounced pass the edit scheduled. Publication is enqueue-driven: a pass
+    // whose projection is not available yet returns a retryable outcome and
+    // ends the lane, and only a later trigger restarts it. In an editor that
+    // trigger is the next feature request that misses the contract; with no
+    // request in flight this loop is the only thing left to supply it. The
+    // enqueue is idle-guarded, so an already-active pass merely records a
+    // trailing one — the contract still has to come from the normal background
+    // publication, never a test-only prewarm.
     tokio::time::timeout(CONVERGENCE_TIMEOUT, async {
         while server.cached_child_public_contract(&child_id).is_none() {
+            server.enqueue_import_dependency_publication_if_idle(&child_uri);
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
     })

--- a/crates/verter_session/src/cold_artifact_dedup_tests.rs
+++ b/crates/verter_session/src/cold_artifact_dedup_tests.rs
@@ -3731,12 +3731,24 @@ fn changed_workspace_reload_does_not_fence_out_its_own_cold_artifact() {
     host.ensure_indexed_ready(canonical)
         .expect("initial workspace source materializes");
 
-    host.evict(canonical);
-    host.scheduler.close_file(canonical);
+    // The demand below must BE the loading flight: it installs the changed
+    // source itself, advancing the store view mid-flight, and must still
+    // publish its own artifact. So drop the scheduler source WITHOUT
+    // scheduling a competing reload. Closing the file would enqueue an
+    // asynchronous background reload, and whichever way that reload races
+    // the demand the test stops proving its invariant: winning with the
+    // pre-change bytes republishes them as the authoritative content (the
+    // demand then serves a superseded artifact), and winning with the new
+    // bytes installs the source outside the flight (the canonical stays
+    // marked evicted, so it has no authoritative artifact key at all).
+    // Publishing the new content first keeps the workspace unambiguous for
+    // any read that follows.
     workspace.inject_file(
         canonical.to_string(),
         Arc::from("export const value = 2;\n"),
     );
+    host.evict(canonical);
+    host.scheduler.invalidate(canonical);
     host.provenance().reset();
 
     let refreshed = host


### PR DESCRIPTION
Main-recovery repair chosen as the smallest correct fix/revert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of background publication retries during contract convergence.
  * Updated workspace reload coverage to verify artifacts are correctly published and reused from the warm cache.
  * Reduced race conditions in asynchronous reload and eviction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->