### PR TITLE
feat(wasm): expose a callable typed compile request on the browser host

### DIFF
--- a/.claude/skills/host-session/SKILL.md
+++ b/.claude/skills/host-session/SKILL.md
@@ -660,8 +660,9 @@ routes above, and the two differ in WHO owns the demand:
 - **No compile cache slot.** This route consults and publishes none, so
   distinct requests for one canonical are distinct compiles.
 
-Native-only (`#[cfg(not(target_arch = "wasm32"))]`), along with the bound
-framework host backends it executes through.
+`compile_request` is available on native and `wasm32`; the browser binding
+calls it synchronously after decoding one typed request. `compile_request_many`
+and its source-registering batch coordinator remain native-only.
 
 ### LSP Integration
 

--- a/crates/verter_session/src/host_resolve/compile_request_execute.rs
+++ b/crates/verter_session/src/host_resolve/compile_request_execute.rs
@@ -62,7 +62,6 @@ impl VerterHost {
     /// # Errors
     ///
     /// [`CompileRequestFailure`] — see its arms.
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn compile_request(
         &self,
         canonical_id: &str,
@@ -220,7 +219,6 @@ impl VerterHost {
     /// virtual nodes, the IDE product publishes the IDE projection, and
     /// the analysis product publishes the host analysis payload — each row
     /// one-to-one with a requested kind, in request order.
-    #[cfg(not(target_arch = "wasm32"))]
     fn compile_request_entry(
         &self,
         snapshot: &CompileInput,

--- a/crates/verter_session/src/host_resolve/mod.rs
+++ b/crates/verter_session/src/host_resolve/mod.rs
@@ -105,7 +105,8 @@ pub(crate) use virtual_file_pipeline::CompileEntryOutcome;
 
 // The caller-supplied canonical-request execution route: the session
 // entry, its lane, and the virtual-node publication both lanes share.
-#[cfg(not(target_arch = "wasm32"))]
+// Available on EVERY target, browser included: the route is synchronous
+// and single-threaded, and the browser binding is one of its callers.
 mod compile_request_execute;
 
 // The canonical-request compile seam's own tests, housed with the route

--- a/crates/verter_wasm/Cargo.toml
+++ b/crates/verter_wasm/Cargo.toml
@@ -37,13 +37,11 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 # dependency graph. `getrandom` 0.4 is the only major reached here.
 getrandom = { version = "0.4", features = ["wasm_js"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
+
 [dev-dependencies]
 wasm-bindgen-test = "0.3.72"
-# The JS-boundary tests build one payload as a real JavaScript object graph:
-# an own key valued `undefined` cannot be expressed by serialising a
-# `serde_json::Value`, and that is precisely the shape where a closed schema
-# can be closed on paper and open in practice.
-js-sys = "0.3"
 verter_identity = { path = "../verter_identity" }
 verter_css_syntax = { path = "../verter_css_syntax", features = ["test-support"] }
 verter_semantic = { path = "../verter_semantic", features = ["test-support"] }

--- a/crates/verter_wasm/src/compile_request_response.rs
+++ b/crates/verter_wasm/src/compile_request_response.rs
@@ -1,0 +1,310 @@
+//! The browser projection of the session's typed compile-request envelope.
+//!
+//! One direction only: a [`host::CompileRequestResponse`] (or the typed
+//! failure that replaces it) becomes the JavaScript value the caller
+//! receives. Nothing here decides anything about the compile — the
+//! response is already complete when it arrives, so this module carries it
+//! across the boundary and invents no vocabulary of its own: the product
+//! tags it publishes, and the product names its refusals use, are the
+//! REQUEST's spellings, so a caller matches an answer against what it sent
+//! without learning a second set of names.
+//!
+//! The payload shapes reuse the SHARED FFI output DTOs wherever one already
+//! exists ([`FfiDiagnosticsSnapshot`], [`FfiIdeResponse`],
+//! [`FfiVirtualNodeKind`], [`FfiVirtualMeta`]), so a diagnostic, a node kind
+//! and an IDE projection read identically on this route and on the legacy
+//! per-node reads beside it — including the UTF-16 offsets, which come from
+//! the same `host_diagnostics_to_ffi` conversion the legacy routes use.
+
+use serde::Serialize;
+
+use verter_ffi::convert::{host_diagnostics_to_ffi, host_error_to_string, host_node_kind_to_ffi};
+use verter_protocol::types::{
+    FfiDestructuredBlockMeta, FfiDiagnosticsSnapshot, FfiIdeResponse, FfiVirtualMeta,
+    FfiVirtualNodeKind,
+};
+use verter_session as host;
+
+/// One separately addressed output of a compiled runtime product.
+///
+/// A runtime product is not one blob: the carrier's assembled main module,
+/// its script, its compiled template, each style block and each custom
+/// block are distinct modules a consumer loads and maps independently, so
+/// each row keeps its own code and its own map.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WasmCompiledVirtualNode {
+    node: FfiVirtualNodeKind,
+    code: String,
+    source_map: Option<String>,
+    lang: Option<String>,
+    meta: FfiVirtualMeta,
+}
+
+/// One row of a response's product list, one-to-one with a requested
+/// product kind and in request order.
+///
+/// Tagged by `kind` with the SAME spellings the request's product arms
+/// carry, so a caller matches a row against the product it asked for
+/// without learning a second vocabulary.
+///
+/// An arm may flatten its payload beside `kind` ONLY when that payload is
+/// a wire-owned DTO — one whose fields exist to be serialised and cannot
+/// gain a `kind` without this taxonomy being part of the change. That holds
+/// for [`FfiIdeResponse`], and the shared schema flattens its product
+/// options the same way.
+///
+/// Every other arm NESTS under its own key. A flattened arm over a payload
+/// this wire does not own is a latent collision: a field named `kind` added
+/// upstream is serialised into the same object as the discriminant, the
+/// later write wins, and every consumer's `kind === "…"` branch stops
+/// matching on a row that still carries its data. That is why the analysis
+/// arm nests its semantic-crate snapshot, as the runtime arms already nest
+/// their nodes.
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub(crate) enum WasmCompiledProduct {
+    RuntimeClient {
+        nodes: Vec<WasmCompiledVirtualNode>,
+    },
+    RuntimeServer {
+        nodes: Vec<WasmCompiledVirtualNode>,
+    },
+    IdeCompanion(FfiIdeResponse),
+    Analysis {
+        analysis: Box<verter_semantic::analysis::template::TemplateAnalysisSnapshot>,
+    },
+}
+
+/// The result of executing one caller-supplied typed compile request.
+///
+/// Complete-only, exactly as the session envelope is: every requested
+/// product is present, and a refusal is thrown instead of being reported as
+/// a partial response, a `null`, or a boolean.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WasmCompileRequestResponse {
+    canonical_id: String,
+    diagnostics: FfiDiagnosticsSnapshot,
+    products: Vec<WasmCompiledProduct>,
+}
+
+/// Project a host IDE response, resolving the destructured block's mappings
+/// against the carrier source in UTF-16 offsets.
+///
+/// Shared by this route and the legacy cached IDE read, so both publish the
+/// identical payload for the same compiled surface.
+pub(crate) fn ide_response_to_ffi(
+    response: &host::IdeResponse,
+    sfc_source: Option<&str>,
+) -> FfiIdeResponse {
+    FfiIdeResponse {
+        code: response.code.to_string(),
+        source_map: response.source_map.as_ref().map(ToString::to_string),
+        is_jsx: response.is_jsx,
+        destructured_block: destructured_block_to_ffi(response, sfc_source),
+    }
+}
+
+fn destructured_block_to_ffi(
+    response: &host::IdeResponse,
+    sfc_source: Option<&str>,
+) -> Option<FfiDestructuredBlockMeta> {
+    let meta = response.destructured_block.as_ref()?;
+    let sfc = sfc_source.unwrap_or("");
+    let bindings: Vec<verter_ffi::convert::DestructuredBindingInput<'_>> = meta
+        .bindings
+        .iter()
+        .map(|binding| verter_ffi::convert::DestructuredBindingInput {
+            name: &binding.name,
+            source_start: binding.source_span.start,
+            source_end: binding.source_span.end,
+        })
+        .collect();
+    Some(verter_ffi::convert::convert_destructured_block_meta(
+        &bindings,
+        meta.block_start,
+        meta.block_end,
+        sfc,
+        &response.code,
+        verter_ffi::convert::OffsetEncoding::Utf16,
+    ))
+}
+
+/// Project the session's typed envelope for JavaScript.
+///
+/// `sfc_source` is the registered carrier source the compile ran against;
+/// it is what turns the host's UTF-8 diagnostic spans into the UTF-16
+/// offsets a JavaScript caller indexes with, so it is supplied rather than
+/// rediscovered here.
+///
+/// Fallible, and fails CLOSED: a product row this taxonomy cannot tag
+/// exactly refuses the whole response rather than publishing the row under
+/// a substituted tag, which a JavaScript caller cannot tell from a correct
+/// one.
+pub(crate) fn compile_request_response_to_wasm(
+    response: host::CompileRequestResponse,
+    sfc_source: Option<&str>,
+) -> Result<WasmCompileRequestResponse, String> {
+    let host::CompileRequestResponse {
+        canonical_id,
+        diagnostics,
+        products,
+    } = response;
+    let products = products
+        .into_iter()
+        .map(|product| compiled_product_to_wasm(&canonical_id, product, sfc_source))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(WasmCompileRequestResponse {
+        canonical_id,
+        diagnostics: host_diagnostics_to_ffi(&diagnostics, sfc_source),
+        products,
+    })
+}
+
+fn compiled_product_to_wasm(
+    canonical_id: &str,
+    product: host::CompiledProduct,
+    sfc_source: Option<&str>,
+) -> Result<WasmCompiledProduct, String> {
+    use verter_compiler::compile_request::ProductKind;
+
+    Ok(match product {
+        host::CompiledProduct::Runtime { kind, nodes } => {
+            let nodes = nodes.into_iter().map(compiled_node_to_wasm).collect();
+            match kind {
+                ProductKind::RuntimeClient => WasmCompiledProduct::RuntimeClient { nodes },
+                ProductKind::RuntimeServer => WasmCompiledProduct::RuntimeServer { nodes },
+                // Both runtime tags are matched by name, and the remaining
+                // kinds are listed rather than swept up by a wildcard: a
+                // product kind added upstream fails THIS build instead of
+                // reaching a browser mislabelled. No input produces a
+                // runtime row under these kinds today, so the arm is a
+                // fail-closed refusal rather than a fabricated tag.
+                kind @ (ProductKind::IdeCompanion
+                | ProductKind::PublicApi
+                | ProductKind::Declarations
+                | ProductKind::Analysis) => {
+                    return Err(format!(
+                        "refused host compile request for {canonical_id}: the {} product \
+                         published a runtime output row, which has no runtime wire tag",
+                        requested_product_wire_name(kind)
+                    ));
+                }
+            }
+        }
+        host::CompiledProduct::Ide(response) => {
+            WasmCompiledProduct::IdeCompanion(ide_response_to_ffi(&response, sfc_source))
+        }
+        host::CompiledProduct::Analysis(snapshot) => {
+            WasmCompiledProduct::Analysis { analysis: snapshot }
+        }
+    })
+}
+
+/// A product kind in the vocabulary the REQUEST spells it with.
+///
+/// A refusal names the offending product the way the caller wrote it, not
+/// the way Rust spells the variant — the schema's arm is `publicApi`, so
+/// that is what the message says. Exhaustive by name on purpose: a product
+/// kind added upstream is a compile error here rather than a message that
+/// silently drifts out of the wire's vocabulary.
+fn requested_product_wire_name(
+    kind: verter_compiler::compile_request::ProductKind,
+) -> &'static str {
+    use verter_compiler::compile_request::ProductKind;
+
+    match kind {
+        ProductKind::RuntimeClient => "runtimeClient",
+        ProductKind::RuntimeServer => "runtimeServer",
+        ProductKind::IdeCompanion => "ideCompanion",
+        ProductKind::PublicApi => "publicApi",
+        ProductKind::Declarations => "declarations",
+        ProductKind::Analysis => "analysis",
+    }
+}
+
+fn compiled_node_to_wasm(node: host::CompiledVirtualNode) -> WasmCompiledVirtualNode {
+    WasmCompiledVirtualNode {
+        node: host_node_kind_to_ffi(&node.node),
+        code: node.code.to_string(),
+        source_map: node.source_map.as_ref().map(ToString::to_string),
+        lang: node.lang,
+        meta: FfiVirtualMeta {
+            scope_id: node.meta.scope_id,
+            block_type: node.meta.block_type,
+        },
+    }
+}
+
+/// Render a typed compile-request refusal as the thrown JavaScript error.
+///
+/// Each arm states which authority refused and what it refused, drawn from
+/// the failure's own typed fields. The refusal's diagnostics carry the exact
+/// rule that refused it, so they ride along verbatim rather than re-worded.
+pub(crate) fn compile_request_failure_to_string(failure: &host::CompileRequestFailure) -> String {
+    use host::CompileRequestFailure as Failure;
+
+    match failure {
+        Failure::Host(error) => host_error_to_string(error),
+        Failure::FrameworkMismatch {
+            canonical_id,
+            requested,
+            registered,
+        } => format!(
+            "refused host compile request for {canonical_id}: the request names {requested}, but \
+             the registered carrier is {registered}"
+        ),
+        Failure::UnsupportedProduct {
+            canonical_id,
+            kind,
+            diagnostics,
+        } => format!(
+            "refused host compile request for {canonical_id}: no host production route for the \
+             {} product{}",
+            requested_product_wire_name(*kind),
+            rendered_diagnostics(diagnostics)
+        ),
+        Failure::ProductNotProduced {
+            canonical_id,
+            kind,
+            diagnostics,
+        } => format!(
+            "refused host compile request for {canonical_id}: the {} product was admitted and \
+             published no payload{}",
+            requested_product_wire_name(*kind),
+            rendered_diagnostics(diagnostics)
+        ),
+        Failure::RuntimeSurfaceRefused {
+            canonical_id,
+            diagnostic_code,
+            message,
+            diagnostics,
+        } => format!(
+            "refused host compile request for {canonical_id}: {diagnostic_code}: {message}{}",
+            rendered_diagnostics(diagnostics)
+        ),
+        Failure::Refused {
+            canonical_id,
+            diagnostics,
+        } => format!(
+            "refused host compile request for {canonical_id}{}",
+            rendered_diagnostics(diagnostics)
+        ),
+    }
+}
+
+/// The refusal's own diagnostics, appended verbatim. An empty set appends
+/// nothing rather than an empty bracket pair.
+fn rendered_diagnostics(diagnostics: &host::DiagnosticsSnapshot) -> String {
+    if diagnostics.diagnostics.is_empty() {
+        return String::new();
+    }
+    let rendered = diagnostics
+        .diagnostics
+        .iter()
+        .map(|diagnostic| format!("{}: {}", diagnostic.code, diagnostic.message))
+        .collect::<Vec<_>>()
+        .join("; ");
+    format!(" [{rendered}]")
+}

--- a/crates/verter_wasm/src/host_compile_request_route_tests.rs
+++ b/crates/verter_wasm/src/host_compile_request_route_tests.rs
@@ -1,0 +1,1070 @@
+// ── the callable route on the generated host object ──────────────────────
+//
+// The sibling decode fixtures prove what the decode boundary accepts and
+// refuses. None of them proves a browser caller can REACH that boundary: a
+// Rust function with no binding annotation is reachable from Rust and from
+// nothing else, and a route nobody can call is not a route.
+//
+// These reach the method the way a browser does — read it off the generated
+// host object by its JavaScript name and invoke it with real JS values — so
+// what they exercise is the generated glue, not the Rust function behind it.
+// A method that stopped being exported, or that was exported under a
+// different name, fails here while every Rust caller of the same code keeps
+// compiling.
+
+use super::*;
+
+use js_sys::{Function, Object, Reflect, JSON};
+use serde::Serialize;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+use crate::WasmVerterHost;
+
+const VUE_SFC: &str = r#"<script setup lang="ts">
+const greeting = 'hello'
+</script>
+<template><div class="box">{{ greeting }}</div></template>
+<style scoped>.box { color: red }</style>
+<i18n>{ "en": { "hi": "hello" } }</i18n>
+"#;
+
+const SVELTE_SFC: &str = r#"<script lang="ts">
+let name = 'world';
+</script>
+<h1>hello {name}</h1>
+<style>h1 { color: blue }</style>
+"#;
+
+/// A carrier that reports source offsets, with multi-byte characters ahead
+/// of every one of them: `é` is two UTF-8 bytes, `—` is three, and `😀` is
+/// four bytes but TWO UTF-16 code units. Every reported offset therefore has
+/// a different value depending on which encoding it is stated in, which is
+/// what makes the offset assertion below discriminating rather than
+/// decorative.
+const VUE_SFC_OFFSET_CARRIER: &str = "<script setup lang=\"ts\">\n\
+     // h\u{e9}llo \u{2014} \u{1f600}\n\
+     const greeting = 'x'\n\
+     const { title = greeting } = defineProps<{ title?: string }>()\n\
+     </script>\n\
+     <template><div>{{ title }}</div></template>\n";
+
+/// A carrier whose template repeats a directive, so the compile publishes a
+/// spanned WARNING and still produces every product. An error-severity
+/// fixture would refuse the whole request and leave nothing to inspect, and
+/// a malformed expression breaks runtime assembly outright.
+///
+/// The text before the duplicate is the point: `{PREFIX}` is substituted
+/// with two spellings of the SAME UTF-16 length but different byte lengths,
+/// so a byte-indexed span moves between the two renderings while a
+/// UTF-16-indexed span does not.
+const VUE_SFC_DIAGNOSTIC_CARRIER: &str = "<script setup lang=\"ts\">\n\
+     const ok = true\n\
+     </script>\n\
+     <template>\n\
+     <p>{PREFIX}</p>\n\
+     <div v-if=\"ok\" v-if=\"ok\">shown</div>\n\
+     </template>\n";
+
+/// Ten UTF-16 code units in fifteen UTF-8 bytes: `é` is two bytes, `—` is
+/// three, and `😀` is four bytes but TWO UTF-16 units.
+const MULTI_BYTE_PREFIX: &str = "h\u{e9}llo \u{2014} \u{1f600}";
+/// Ten UTF-16 code units in ten UTF-8 bytes.
+const ASCII_PREFIX: &str = "plain-text";
+
+fn diagnostic_carrier(prefix: &str) -> String {
+    VUE_SFC_DIAGNOSTIC_CARRIER.replace("{PREFIX}", prefix)
+}
+
+/// The host as the JavaScript object a browser caller holds. The Rust value
+/// is consumed on purpose: everything below reaches the host the way
+/// JavaScript does.
+fn js_host() -> JsValue {
+    JsValue::from(WasmVerterHost::new(JsValue::UNDEFINED).expect("the host constructs"))
+}
+
+/// Read a method off the generated object by its JavaScript name.
+///
+/// This is the point of the module: `Reflect::get` walks the generated class
+/// prototype, so a name that is not exported — or is exported under a
+/// different spelling — is not a function here.
+#[track_caller]
+fn method(host: &JsValue, name: &str) -> Function {
+    let value = Reflect::get(host, &JsValue::from_str(name))
+        .unwrap_or_else(|_| panic!("`{name}` is readable on the generated host object"));
+    assert!(
+        !value.is_undefined(),
+        "the generated host object exposes no `{name}` method"
+    );
+    value
+        .dyn_into::<Function>()
+        .unwrap_or_else(|_| panic!("`{name}` is not callable on the generated host object"))
+}
+
+/// A `serde_json::Value` fixture as the plain JS object graph a browser
+/// caller writes.
+fn js(wire: Value) -> JsValue {
+    wire.serialize(&serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true))
+        .expect("the fixture is representable as a plain JS object")
+}
+
+/// Parse JSON the way a browser caller commonly obtains request data.
+/// Unlike object-literal syntax or `Reflect::set` on an ordinary object,
+/// `JSON.parse` creates `__proto__` as an own enumerable data property.
+fn json_parsed_js(wire: Value) -> JsValue {
+    JSON::parse(&wire.to_string()).expect("the fixture is valid JSON")
+}
+
+/// The JS value back as a `serde_json::Value`, for structural reads.
+#[track_caller]
+fn from_js(value: &JsValue) -> Value {
+    serde_wasm_bindgen::from_value(value.clone()).expect("the response is a JSON-shaped value")
+}
+
+/// Register a carrier through the generated `upsert` — source only, no
+/// compile demand and no profile.
+#[track_caller]
+fn register(host: &JsValue, canonical_id: &str, source: &str, file_kind: &str) {
+    let request = js(json!({
+        "canonicalId": canonical_id,
+        "inputId": canonical_id,
+        "source": source,
+        "fileKind": file_kind,
+    }));
+    method(host, "upsert")
+        .call1(host, &request)
+        .expect("the source-only registration succeeds");
+}
+
+/// One typed compile, through the generated method.
+#[track_caller]
+fn compile_request(host: &JsValue, canonical_id: &str, request: Value) -> Value {
+    compile_request_js(host, canonical_id, js(request))
+}
+
+/// One typed compile from a JS object graph that cannot be represented as
+/// JSON, such as an own property whose value is `undefined`.
+#[track_caller]
+fn compile_request_js(host: &JsValue, canonical_id: &str, request: JsValue) -> Value {
+    let raw = method(host, "compileRequest")
+        .call2(host, &JsValue::from_str(canonical_id), &request)
+        .unwrap_or_else(|error| {
+            panic!(
+                "the typed compile was refused: {}",
+                error.as_string().unwrap_or_default()
+            )
+        });
+    from_js(&raw)
+}
+
+/// The thrown refusal's message. A response — of any shape — is a failure:
+/// this route is complete-only.
+#[track_caller]
+fn compile_request_refusal(host: &JsValue, canonical_id: &str, request: Value) -> String {
+    compile_request_refusal_js(host, canonical_id, js(request))
+}
+
+#[track_caller]
+fn compile_request_refusal_js(host: &JsValue, canonical_id: &str, request: JsValue) -> String {
+    match method(host, "compileRequest").call2(host, &JsValue::from_str(canonical_id), &request) {
+        Ok(value) => panic!(
+            "expected a thrown refusal, got a response: {:?}",
+            from_js(&value)
+        ),
+        Err(error) => error
+            .as_string()
+            .expect("the refusal reaches JavaScript as a string"),
+    }
+}
+
+fn runtime_client_product(source_map: bool) -> Value {
+    json!({ "runtimeClient": { "runtimeSourceMap": source_map } })
+}
+
+/// The IDE product with the axes the host execution route consumes.
+/// `ideChunkBoundaries` stays false because the carrier bridge substitutes
+/// that axis and a caller-stated value is refused.
+fn ide_companion_product(source_map: bool) -> Value {
+    json!({ "ideCompanion": {
+        "wantSourceMap": source_map,
+        "embedAmbientTypes": false,
+        "conditionalRootNarrowing": false,
+        "strictSlots": false,
+        "ideChunkBoundaries": false,
+    }})
+}
+
+fn template_analysis_product() -> Value {
+    json!({ "analysis": { "wantScriptBindings": false, "wantTemplateData": true } })
+}
+
+/// The identity every request below shares. `filename` is absent, so the
+/// route binds the executing canonical id — the same source identity a
+/// profile-derived compile of the same registration uses.
+fn route_identity() -> Value {
+    json!({ "isProduction": false, "forceJs": false })
+}
+
+fn vue_route_request(products: Value) -> Value {
+    vue_route_request_with_ssr(products, false)
+}
+
+/// The `ssr` option and the runtime product kind are ONE demand: admission
+/// refuses a server product compiled under client options and vice versa,
+/// so a server request states both.
+fn vue_route_request_with_ssr(products: Value, ssr: bool) -> Value {
+    json!({ "vue": {
+        "identity": route_identity(),
+        "products": products,
+        "options": {
+            "backend": "inferred",
+            "ssr": ssr,
+            "isCustomElement": [],
+            "babelParserPlugins": [],
+            "scriptCustomElement": false,
+        },
+    }})
+}
+
+fn svelte_route_request(products: Value) -> Value {
+    json!({ "svelte": {
+        "identity": route_identity(),
+        "products": products,
+        "options": { "customElement": false },
+    }})
+}
+
+/// The legacy demand that matches the typed requests below: every runtime
+/// node, the IDE projection, template data, and maps on.
+fn legacy_profile() -> Value {
+    json!({ "target": "full", "sourceMap": true, "isProduction": false })
+}
+
+#[track_caller]
+fn product_row<'response>(response: &'response Value, kind: &str) -> &'response Value {
+    response["products"]
+        .as_array()
+        .expect("the response carries a product list")
+        .iter()
+        .find(|row| row["kind"] == kind)
+        .unwrap_or_else(|| panic!("no `{kind}` product row in {response:?}"))
+}
+
+fn product_kinds(response: &Value) -> Vec<String> {
+    response["products"]
+        .as_array()
+        .expect("the response carries a product list")
+        .iter()
+        .map(|row| row["kind"].as_str().expect("a kind tag").to_string())
+        .collect()
+}
+
+/// The runtime row's node rows with their addressing, so a comparison
+/// against the legacy per-node reads is order-independent.
+#[track_caller]
+fn runtime_nodes(response: &Value) -> Vec<(String, Option<u64>, &Value)> {
+    product_row(response, "runtimeClient")["nodes"]
+        .as_array()
+        .expect("the runtime row carries its nodes")
+        .iter()
+        .map(|node| {
+            (
+                node["node"]["kind"]
+                    .as_str()
+                    .expect("a node kind string")
+                    .to_string(),
+                node["node"]["index"].as_u64(),
+                node,
+            )
+        })
+        .collect()
+}
+
+/// The legacy per-node read for the same demand.
+#[track_caller]
+fn legacy_virtual_file(
+    host: &JsValue,
+    canonical_id: &str,
+    kind: &str,
+    index: Option<u64>,
+) -> Value {
+    let mut node_kind = json!({ "kind": kind });
+    if let Some(index) = index {
+        node_kind["index"] = json!(index);
+    }
+    let query = js(json!({
+        "canonicalId": canonical_id,
+        "nodeKind": node_kind,
+        "compileProfile": legacy_profile(),
+    }));
+    let raw = method(host, "getVirtualFile")
+        .call1(host, &query)
+        .unwrap_or_else(|error| {
+            panic!(
+                "the legacy read of {kind}/{index:?} failed: {}",
+                error.as_string().unwrap_or_default()
+            )
+        });
+    assert!(
+        !raw.is_null(),
+        "the legacy route publishes no {kind}/{index:?} node to compare against"
+    );
+    from_js(&raw)
+}
+
+/// The legacy IDE read, through its ensure-then-read pair.
+#[track_caller]
+fn legacy_ide(host: &JsValue, canonical_id: &str) -> Value {
+    let profile = js(legacy_profile());
+    method(host, "ensureIdeCompiled")
+        .call2(host, &JsValue::from_str(canonical_id), &profile)
+        .expect("the legacy IDE ensure succeeds");
+    let raw = method(host, "getIde")
+        .call2(host, &JsValue::from_str(canonical_id), &profile)
+        .expect("the legacy IDE read succeeds");
+    assert!(!raw.is_null(), "the legacy route published no IDE surface");
+    from_js(&raw)
+}
+
+/// Every published runtime node's bytes, map, language and metadata against
+/// the legacy per-node read of the same demand.
+#[track_caller]
+fn assert_runtime_nodes_match_legacy(
+    host: &JsValue,
+    canonical_id: &str,
+    response: &Value,
+    expected: &[(&str, Option<u64>)],
+) {
+    let nodes = runtime_nodes(response);
+    let mut published: Vec<(String, Option<u64>)> = nodes
+        .iter()
+        .map(|(kind, index, _)| (kind.clone(), *index))
+        .collect();
+    published.sort();
+    let mut wanted: Vec<(String, Option<u64>)> = expected
+        .iter()
+        .map(|(kind, index)| ((*kind).to_string(), *index))
+        .collect();
+    wanted.sort();
+    // Both directions: iterating only the published list would let the route
+    // silently stop publishing a node and still read as green.
+    assert_eq!(
+        published, wanted,
+        "the runtime row must publish exactly this node set"
+    );
+
+    for (kind, index, node) in nodes {
+        let legacy = legacy_virtual_file(host, canonical_id, &kind, index);
+        assert_eq!(
+            node["code"], legacy["code"],
+            "{kind}/{index:?} bytes must match the legacy route"
+        );
+        assert_eq!(
+            node["sourceMap"], legacy["sourceMap"],
+            "{kind}/{index:?} source map must match the legacy route"
+        );
+        assert_eq!(
+            node["lang"], legacy["lang"],
+            "{kind}/{index:?} output language must match the legacy route"
+        );
+        assert_eq!(
+            node["meta"], legacy["meta"],
+            "{kind}/{index:?} metadata must match the legacy route"
+        );
+    }
+}
+
+// ── the route exists on the generated object ─────────────────────────────
+
+/// The control for everything below, and the acceptance this route exists
+/// for: the typed compile is a method on the generated host object,
+/// reachable by its JavaScript name and taking its two arguments separately.
+#[wasm_bindgen_test]
+fn the_generated_host_object_exposes_the_typed_compile_method() {
+    let host = js_host();
+    let compile_request = method(&host, "compileRequest");
+    assert_eq!(
+        compile_request.length(),
+        2,
+        "the method takes the canonical id and the typed request as separate arguments"
+    );
+}
+
+// ── one registration, one typed call ─────────────────────────────────────
+
+/// The whole transaction from JavaScript: register the source once, then
+/// execute one typed request against it. No second compile call, no ensure
+/// step, and no copy of the source into the request.
+#[wasm_bindgen_test]
+fn one_registration_and_one_typed_call_produce_every_requested_vue_product() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let response = compile_request(
+        &host,
+        "/src/App.vue",
+        vue_route_request(json!([
+            runtime_client_product(true),
+            ide_companion_product(true),
+            template_analysis_product(),
+        ])),
+    );
+
+    assert_eq!(response["canonicalId"], json!("/src/App.vue"));
+    assert_eq!(
+        product_kinds(&response),
+        vec!["runtimeClient", "ideCompanion", "analysis"],
+        "one row per requested kind, in request order"
+    );
+    assert!(
+        product_row(&response, "ideCompanion")["code"]
+            .as_str()
+            .is_some_and(|code| !code.is_empty()),
+        "the IDE row carries its projected surface"
+    );
+    assert!(
+        product_row(&response, "analysis")["analysis"]["bindingOccurrences"].is_array(),
+        "the analysis row carries the template payload, not an empty marker"
+    );
+}
+
+/// With TypeScript's default optional-property semantics, an optional
+/// `never` property admits an explicitly written `undefined`. The public
+/// route therefore reads an undefined sibling tag as absent at both tagged
+/// union layers while retaining populated duplicate-tag refusals.
+#[wasm_bindgen_test]
+fn explicitly_undefined_sibling_tags_are_absent_on_the_public_route() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let outer = js(vue_route_request(json!([template_analysis_product()])));
+    Reflect::set(&outer, &JsValue::from_str("svelte"), &JsValue::UNDEFINED)
+        .expect("the framework sibling tag is writable");
+    let outer_response = compile_request_js(&host, "/src/App.vue", outer);
+    assert_eq!(product_kinds(&outer_response), vec!["analysis"]);
+
+    let product = js(vue_route_request(json!([template_analysis_product()])));
+    let vue = Reflect::get(&product, &JsValue::from_str("vue")).expect("the Vue arm exists");
+    let products =
+        Reflect::get(&vue, &JsValue::from_str("products")).expect("the product list exists");
+    let first =
+        Reflect::get(&products, &JsValue::from_f64(0.0)).expect("the analysis product exists");
+    Reflect::set(
+        &first,
+        &JsValue::from_str("runtimeClient"),
+        &JsValue::UNDEFINED,
+    )
+    .expect("the product sibling tag is writable");
+    let product_response = compile_request_js(&host, "/src/App.vue", product);
+    assert_eq!(product_kinds(&product_response), vec!["analysis"]);
+}
+
+/// Undefined sibling normalization must not weaken the externally tagged
+/// union: two populated arms remain a decoder refusal at either layer.
+#[wasm_bindgen_test]
+fn populated_sibling_tags_remain_refused_on_the_public_route() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let both_frameworks = set(
+        vue_route_request(json!([template_analysis_product()])),
+        &[],
+        "svelte",
+        svelte_route_request(json!([template_analysis_product()]))["svelte"].clone(),
+    );
+    let framework_message = compile_request_refusal(&host, "/src/App.vue", both_frameworks);
+    assert!(
+        framework_message.contains("expected map with a single key"),
+        "expected the populated framework sibling to remain a decoder refusal, got: \
+         {framework_message}"
+    );
+
+    let both_products = vue_route_request(json!([{
+        "analysis": { "wantScriptBindings": false, "wantTemplateData": true },
+        "runtimeClient": { "runtimeSourceMap": false },
+    }]));
+    let product_message = compile_request_refusal(&host, "/src/App.vue", both_products);
+    assert!(
+        product_message.contains("expected map with a single key"),
+        "expected the populated product sibling to remain a decoder refusal, got: \
+         {product_message}"
+    );
+}
+
+/// The analysis payload is nested under its own key, and the `kind`
+/// discriminant sits BESIDE it rather than inside it.
+///
+/// A flattened arm would serialise the snapshot's fields into the same
+/// object as the tag, so a snapshot field named `kind` — a type this wire
+/// does not own and cannot freeze — would overwrite the discriminant while
+/// the row still carried its data, and every consumer's `kind === "analysis"`
+/// branch would stop matching.
+#[wasm_bindgen_test]
+fn the_analysis_payload_is_nested_beside_its_discriminant_not_flattened_into_it() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let response = compile_request(
+        &host,
+        "/src/App.vue",
+        vue_route_request(json!([template_analysis_product()])),
+    );
+
+    let row = product_row(&response, "analysis");
+    let mut keys: Vec<&str> = row
+        .as_object()
+        .expect("the analysis row is an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        vec!["analysis", "kind"],
+        "the analysis row carries exactly its tag and its nested payload — a flattened arm would \
+         put the snapshot's own fields here beside `kind`"
+    );
+    assert!(
+        row["analysis"]["bindingOccurrences"].is_array(),
+        "the payload lives under `analysis`, not at the row root"
+    );
+}
+
+/// The analysis row publishes the TEMPLATE snapshot — the value the legacy
+/// `getAnalysis` read carries under its `template` field — not the
+/// whole-file snapshot that read returns.
+///
+/// This is the run-time half of the published declaration's claim: the
+/// declaration says which of the two shapes the row is, and nothing but
+/// this comparison holds it to that. Both directions are asserted, so a row
+/// that quietly became the file snapshot fails here rather than reaching a
+/// consumer that reads `row.analysis.template.bindingOccurrences` and finds
+/// nothing.
+#[wasm_bindgen_test]
+fn the_analysis_row_is_the_legacy_reads_template_snapshot_not_its_file_snapshot() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let response = compile_request(
+        &host,
+        "/src/App.vue",
+        vue_route_request(json!([template_analysis_product()])),
+    );
+    let published = &product_row(&response, "analysis")["analysis"];
+
+    let legacy_raw = method(&host, "getAnalysis")
+        .call1(&host, &JsValue::from_str("/src/App.vue"))
+        .expect("the legacy whole-file analysis read succeeds");
+    assert!(
+        !legacy_raw.is_null(),
+        "the legacy read publishes no analysis to compare against"
+    );
+    let legacy = from_js(&legacy_raw);
+
+    assert!(
+        legacy["template"].is_object(),
+        "fixture drift: the legacy file snapshot must nest a template snapshot"
+    );
+    assert_eq!(
+        *published, legacy["template"],
+        "the analysis row must be the legacy read's `template` value"
+    );
+    assert_ne!(
+        *published, legacy,
+        "the analysis row must NOT be the whole-file snapshot"
+    );
+}
+
+/// The server runtime arm is tagged `runtimeServer`, not folded into the
+/// client tag.
+///
+/// The two runtime kinds publish through one host row shape, so the wire
+/// tag is the ONLY thing distinguishing an SSR bundle from a client one on
+/// the JavaScript side. A caller that received the client tag for a server
+/// compile would ship server output to a browser with nothing to notice it
+/// by.
+#[wasm_bindgen_test]
+fn the_server_runtime_product_publishes_under_its_own_wire_tag() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let response = compile_request(
+        &host,
+        "/src/App.vue",
+        vue_route_request_with_ssr(
+            json!([json!({ "runtimeServer": { "runtimeSourceMap": false } })]),
+            true,
+        ),
+    );
+
+    assert_eq!(
+        product_kinds(&response),
+        vec!["runtimeServer"],
+        "a server runtime demand publishes exactly one server-tagged row"
+    );
+    assert!(
+        product_row(&response, "runtimeServer")["nodes"]
+            .as_array()
+            .is_some_and(|nodes| !nodes.is_empty()),
+        "the server row carries its compiled nodes"
+    );
+}
+
+/// The Svelte carrier through the same method, the same way. A route proven
+/// on one framework proves nothing about the other: the request's framework
+/// arm decides which backend executes.
+#[wasm_bindgen_test]
+fn one_registration_and_one_typed_call_produce_every_requested_svelte_product() {
+    let host = js_host();
+    register(&host, "/src/Widget.svelte", SVELTE_SFC, "svelte");
+
+    let response = compile_request(
+        &host,
+        "/src/Widget.svelte",
+        svelte_route_request(json!([
+            runtime_client_product(true),
+            ide_companion_product(true),
+        ])),
+    );
+
+    assert_eq!(response["canonicalId"], json!("/src/Widget.svelte"));
+    assert_eq!(
+        product_kinds(&response),
+        vec!["runtimeClient", "ideCompanion"],
+    );
+    assert!(
+        product_row(&response, "ideCompanion")["code"]
+            .as_str()
+            .is_some_and(|code| !code.is_empty()),
+        "the Svelte IDE row carries its projected surface"
+    );
+}
+
+// ── equivalence with the legacy route ────────────────────────────────────
+
+/// Same demand, same bytes: every runtime node and the IDE projection match
+/// what the legacy profile-bearing pair produces for the same registration,
+/// through the same JavaScript boundary.
+#[wasm_bindgen_test]
+fn the_vue_route_is_equivalent_to_the_legacy_pair_for_the_same_demand() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let response = compile_request(
+        &host,
+        "/src/App.vue",
+        vue_route_request(json!([
+            runtime_client_product(true),
+            ide_companion_product(true),
+        ])),
+    );
+
+    assert_runtime_nodes_match_legacy(
+        &host,
+        "/src/App.vue",
+        &response,
+        &[
+            ("main", None),
+            ("script", None),
+            ("template", None),
+            ("style", Some(0)),
+            ("custom", Some(0)),
+        ],
+    );
+
+    let legacy = legacy_ide(&host, "/src/App.vue");
+    let ide = product_row(&response, "ideCompanion");
+    assert_eq!(ide["code"], legacy["code"]);
+    assert_eq!(ide["sourceMap"], legacy["sourceMap"]);
+    assert_eq!(ide["isJsx"], legacy["isJsx"]);
+
+    // Diagnostics are named in the equivalence contract beside the bytes and
+    // the maps, so the whole set — codes, messages and spans — is compared
+    // against the legacy compile's rather than assumed to match.
+    let legacy_main = legacy_virtual_file(&host, "/src/App.vue", "main", None);
+    assert_eq!(response["diagnostics"], legacy_main["diagnostics"]);
+}
+
+/// The Svelte carrier's own equivalence. Its published node set differs
+/// from Vue's, which is exactly why it is asserted rather than assumed.
+#[wasm_bindgen_test]
+fn the_svelte_route_is_equivalent_to_the_legacy_pair_for_the_same_demand() {
+    let host = js_host();
+    register(&host, "/src/Widget.svelte", SVELTE_SFC, "svelte");
+
+    let response = compile_request(
+        &host,
+        "/src/Widget.svelte",
+        svelte_route_request(json!([
+            runtime_client_product(true),
+            ide_companion_product(true),
+        ])),
+    );
+
+    assert_runtime_nodes_match_legacy(
+        &host,
+        "/src/Widget.svelte",
+        &response,
+        &[("main", None), ("style", Some(0))],
+    );
+
+    let legacy = legacy_ide(&host, "/src/Widget.svelte");
+    let ide = product_row(&response, "ideCompanion");
+    assert_eq!(ide["code"], legacy["code"]);
+    assert_eq!(ide["sourceMap"], legacy["sourceMap"]);
+    assert_eq!(ide["isJsx"], legacy["isJsx"]);
+
+    let legacy_main = legacy_virtual_file(&host, "/src/Widget.svelte", "main", None);
+    assert_eq!(response["diagnostics"], legacy_main["diagnostics"]);
+}
+
+/// IDE offsets retain their distinct coordinate spaces: binding spans index
+/// the registered source, while block bounds index the generated IDE code.
+/// Both use UTF-16 code units and remain the legacy route's own.
+///
+/// Legacy equality alone cannot prove either meaning. The binding start is
+/// checked against distinct UTF-8 and UTF-16 source indices; the block start
+/// is beyond the source string and inside the generated code.
+#[wasm_bindgen_test]
+fn published_ide_offsets_use_their_own_utf16_coordinate_spaces() {
+    let host = js_host();
+    register(&host, "/src/Offsets.vue", VUE_SFC_OFFSET_CARRIER, "vue");
+
+    let response = compile_request(
+        &host,
+        "/src/Offsets.vue",
+        vue_route_request(json!([ide_companion_product(true)])),
+    );
+
+    let published = &product_row(&response, "ideCompanion")["destructuredBlock"];
+    let binding = published["bindings"]
+        .as_array()
+        .expect("the destructured block carries its bindings")
+        .iter()
+        .find(|binding| binding["name"] == "greeting")
+        .expect("the destructured block reports the `greeting` binding");
+
+    let byte_start = VUE_SFC_OFFSET_CARRIER
+        .find("greeting")
+        .expect("the fixture contains the binding");
+    let utf16_start = VUE_SFC_OFFSET_CARRIER[..byte_start].encode_utf16().count();
+    assert_ne!(
+        byte_start, utf16_start,
+        "fixture drift: the two encodings must disagree for this to prove anything"
+    );
+    assert_eq!(
+        binding["sourceStart"].as_u64(),
+        Some(utf16_start as u64),
+        "the published offset must be the source's UTF-16 index, not its byte index ({byte_start})"
+    );
+
+    let block_start = published["blockStart"]
+        .as_u64()
+        .expect("the generated block carries a start offset") as usize;
+    let generated_code = product_row(&response, "ideCompanion")["code"]
+        .as_str()
+        .expect("the IDE row carries generated code");
+    assert!(
+        block_start > VUE_SFC_OFFSET_CARRIER.encode_utf16().count()
+            && block_start <= generated_code.encode_utf16().count(),
+        "blockStart must index the generated IDE code, not the registered source"
+    );
+
+    let legacy = legacy_ide(&host, "/src/Offsets.vue");
+    assert_eq!(
+        *published, legacy["destructuredBlock"],
+        "the published offsets must be the legacy route's own"
+    );
+
+    // Every other response shape this route publishes reuses a shared
+    // declaration, so a Rust-side field change breaks the legacy binding's
+    // declaration too. The destructured block is the exception — the shared
+    // IDE response does not name it, so the package declares it locally and
+    // nothing else holds that copy to the struct being serialised. These are
+    // the keys the local declaration states; a field added, removed or
+    // renamed in Rust fails here rather than reaching a consumer whose type
+    // says otherwise.
+    assert_eq!(
+        object_keys(published),
+        vec!["bindings", "blockEnd", "blockStart"],
+        "the destructured block's published keys must be the ones its declaration states"
+    );
+    assert_eq!(
+        object_keys(binding),
+        vec!["name", "sourceEnd", "sourceStart"],
+        "a binding row's published keys must be the ones its declaration states"
+    );
+}
+
+/// An object's own keys, sorted, so a comparison does not depend on the
+/// order a serialiser happened to emit.
+#[track_caller]
+fn object_keys(value: &Value) -> Vec<&str> {
+    let mut keys: Vec<&str> = value
+        .as_object()
+        .expect("the value is an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort_unstable();
+    keys
+}
+
+/// Published diagnostic spans are UTF-16 code units, and they are the
+/// legacy route's own.
+///
+/// The clean fixtures above publish an EMPTY diagnostic set, so their
+/// legacy-equivalence assertion compares nothing. This one publishes a real
+/// spanned warning and closes both halves of the contract:
+///
+/// - **Encoding.** Two carriers that differ only in a prefix of equal
+///   UTF-16 length and unequal byte length must report the SAME span. A
+///   byte-indexed span would differ by the five-byte gap; comparing only
+///   against the legacy route would pass if both published bytes.
+/// - **Equivalence.** The multi-byte carrier's set must equal what the
+///   legacy per-node read publishes for the same demand — non-empty, so the
+///   comparison discriminates.
+#[wasm_bindgen_test]
+fn published_diagnostic_spans_are_utf16_and_match_the_legacy_route() {
+    let multi_byte = diagnostic_carrier(MULTI_BYTE_PREFIX);
+    let ascii = diagnostic_carrier(ASCII_PREFIX);
+    assert_eq!(
+        multi_byte.encode_utf16().count(),
+        ascii.encode_utf16().count(),
+        "fixture drift: the two carriers must have equal UTF-16 length"
+    );
+    assert_ne!(
+        multi_byte.len(),
+        ascii.len(),
+        "fixture drift: the two carriers must have unequal byte length, else this proves nothing"
+    );
+
+    let host = js_host();
+    register(&host, "/src/Warn.vue", &multi_byte, "vue");
+    register(&host, "/src/WarnAscii.vue", &ascii, "vue");
+
+    let demand = || vue_route_request(json!([runtime_client_product(false)]));
+    let multi_byte_response = compile_request(&host, "/src/Warn.vue", demand());
+    let ascii_response = compile_request(&host, "/src/WarnAscii.vue", demand());
+
+    let spans = |response: &Value| -> Vec<(u64, u64)> {
+        response["diagnostics"]["diagnostics"]
+            .as_array()
+            .expect("the response carries a diagnostic list")
+            .iter()
+            .map(|diagnostic| {
+                (
+                    diagnostic["spanStart"].as_u64().expect("a start offset"),
+                    diagnostic["spanEnd"].as_u64().expect("an end offset"),
+                )
+            })
+            .collect()
+    };
+
+    let multi_byte_spans = spans(&multi_byte_response);
+    assert!(
+        !multi_byte_spans.is_empty(),
+        "fixture drift: the malformed interpolation must publish a spanned diagnostic, got {:?}",
+        multi_byte_response["diagnostics"]
+    );
+    assert!(
+        multi_byte_spans.iter().any(|(start, _)| *start > 0),
+        "a zero-only span set cannot distinguish the two encodings"
+    );
+    assert_eq!(
+        multi_byte_spans,
+        spans(&ascii_response),
+        "diagnostic offsets must be UTF-16 code units: a byte-indexed span moves when the \
+         multi-byte prefix does"
+    );
+
+    let legacy_main = legacy_virtual_file(&host, "/src/Warn.vue", "main", None);
+    assert_eq!(
+        multi_byte_response["diagnostics"], legacy_main["diagnostics"],
+        "the published diagnostics must be the legacy route's own"
+    );
+}
+
+// ── refusals throw ───────────────────────────────────────────────────────
+
+/// The decode boundary's refusals reach this route unchanged: an unknown key
+/// is refused by name, on the method a browser calls.
+#[wasm_bindgen_test]
+fn an_unknown_property_is_refused_by_name_on_this_route() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let message = compile_request_refusal(
+        &host,
+        "/src/App.vue",
+        set(
+            vue_route_request(json!([template_analysis_product()])),
+            &["vue", "options"],
+            "target",
+            json!("ide"),
+        ),
+    );
+    assert!(
+        message.contains("unknown field") && message.contains("target"),
+        "expected an unknown-field refusal naming `target`, got: {message}"
+    );
+}
+
+/// Normalizing explicit `undefined` tags must not erase an unknown property
+/// with JavaScript's special prototype-setter spelling. The request, its
+/// framework body, and every product row are cloned independently, so each
+/// level is a distinct boundary.
+#[wasm_bindgen_test]
+fn an_own_enumerable_proto_property_is_refused_at_every_normalized_level() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let cases = [
+        (
+            "request",
+            Vec::<&str>::new(),
+            false,
+            set(
+                vue_route_request(json!([template_analysis_product()])),
+                &[],
+                "__proto__",
+                json!({ "polluted": true }),
+            ),
+        ),
+        (
+            "framework body",
+            vec!["vue"],
+            true,
+            set(
+                vue_route_request(json!([template_analysis_product()])),
+                &["vue"],
+                "__proto__",
+                json!({ "polluted": true }),
+            ),
+        ),
+        (
+            "product row",
+            vec!["vue", "products", "0"],
+            false,
+            set(
+                vue_route_request(json!([template_analysis_product()])),
+                &["vue", "products", "0"],
+                "__proto__",
+                json!({ "polluted": true }),
+            ),
+        ),
+    ];
+
+    for (level, path, names_unknown_field, wire) in cases {
+        let request = json_parsed_js(wire);
+        let mut target = request.clone();
+        for segment in path {
+            target = Reflect::get(&target, &JsValue::from_str(segment))
+                .expect("the parsed fixture exposes every path segment");
+        }
+        assert!(
+            Object::keys(target.unchecked_ref::<Object>())
+                .iter()
+                .any(|key| key.as_string().as_deref() == Some("__proto__")),
+            "fixture drift: {level} does not carry an own enumerable `__proto__` property"
+        );
+
+        let message = compile_request_refusal_js(&host, "/src/App.vue", request);
+        assert!(
+            !message.is_empty(),
+            "expected {level}'s unknown `__proto__` property to be refused"
+        );
+        if names_unknown_field {
+            assert!(
+                message.contains("unknown field") && message.contains("__proto__"),
+                "expected {level}'s unknown `__proto__` property to be refused by name, got: {message}"
+            );
+        }
+    }
+}
+
+/// The other framework's option key is refused on this route too — the arms
+/// are structurally separate, and the separation has to hold where a browser
+/// caller meets it.
+#[wasm_bindgen_test]
+fn the_other_frameworks_option_is_refused_on_this_route() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let message = compile_request_refusal(
+        &host,
+        "/src/App.vue",
+        set(
+            vue_route_request(json!([template_analysis_product()])),
+            &["vue", "options"],
+            "runes",
+            json!("infer"),
+        ),
+    );
+    assert!(
+        message.contains("unknown field") && message.contains("runes"),
+        "expected an unknown-field refusal naming `runes`, got: {message}"
+    );
+}
+
+/// A request whose framework arm contradicts the registered carrier throws
+/// rather than compiling the carrier under the wrong framework.
+#[wasm_bindgen_test]
+fn a_framework_arm_the_carrier_contradicts_throws() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let message = compile_request_refusal(
+        &host,
+        "/src/App.vue",
+        svelte_route_request(json!([runtime_client_product(false)])),
+    );
+    let lowered = message.to_ascii_lowercase();
+    assert!(
+        message.contains("/src/App.vue") && lowered.contains("svelte") && lowered.contains("vue"),
+        "the refusal must name the carrier and both frameworks, got: {message}"
+    );
+}
+
+/// An unregistered canonical id throws. The nearest wrong answers — `null`,
+/// `undefined`, or a response carrying an empty product list — would each
+/// make a caller believe the carrier compiled to nothing.
+#[wasm_bindgen_test]
+fn an_unregistered_canonical_id_throws_rather_than_answering_empty() {
+    let host = js_host();
+
+    let message = compile_request_refusal(
+        &host,
+        "/src/Missing.vue",
+        vue_route_request(json!([template_analysis_product()])),
+    );
+    let lowered = message.to_ascii_lowercase();
+    assert!(
+        message.contains("/src/Missing.vue") && lowered.contains("missingsource"),
+        "the refusal must name the missing carrier and say the source is absent, got: {message}"
+    );
+}
+
+/// A product the host integration has no production route for fails the
+/// WHOLE request: no sibling product is published beside it.
+///
+/// The offending product is named the way the REQUEST named it. The
+/// assertion is byte-exact rather than case-folded on purpose: folding
+/// would accept the Rust variant spelling `PublicApi`, and a refusal that
+/// answers in a vocabulary the caller never wrote is a refusal the caller
+/// cannot match against the product it sent.
+#[wasm_bindgen_test]
+fn an_unproducible_product_is_refused_in_the_requests_own_vocabulary() {
+    let host = js_host();
+    register(&host, "/src/App.vue", VUE_SFC, "vue");
+
+    let message = compile_request_refusal(
+        &host,
+        "/src/App.vue",
+        vue_route_request(json!([template_analysis_product(), "publicApi"])),
+    );
+    assert!(
+        message.contains("/src/App.vue") && message.contains("publicApi"),
+        "the refusal must name the carrier and the unproducible kind as `publicApi`, got: {message}"
+    );
+}

--- a/crates/verter_wasm/src/host_compile_request_tests.rs
+++ b/crates/verter_wasm/src/host_compile_request_tests.rs
@@ -955,3 +955,10 @@ mod js_boundary {
         );
     }
 }
+
+// The callable route on the generated host object, housed beside the decode
+// fixtures it depends on: same wire form, same refusals, reached the way a
+// browser reaches it rather than the way Rust does.
+#[cfg(target_arch = "wasm32")]
+#[path = "host_compile_request_route_tests.rs"]
+mod js_route;

--- a/crates/verter_wasm/src/lib.rs
+++ b/crates/verter_wasm/src/lib.rs
@@ -32,6 +32,7 @@ use verter_session::component_meta_audit::{
 use wasm_bindgen::prelude::*;
 
 mod audit;
+mod compile_request_response;
 #[cfg(test)]
 mod host_compile_request_tests;
 mod typeinfo;
@@ -40,6 +41,9 @@ use audit::{
     parse_bundler_kind_wasm, parse_compile_target_wasm, parse_request_id_str_wasm,
     stored_audit_record_to_json_string, AuditRecordFilterWasm, BundlerBatchSummaryArgsWasm,
     WorkspaceOpArgWasm,
+};
+use compile_request_response::{
+    compile_request_failure_to_string, compile_request_response_to_wasm, ide_response_to_ffi,
 };
 
 /// WASM audit bundle — mirror of the NAPI binding's bundle shape.
@@ -284,8 +288,9 @@ fn default_known_dependency_extensions() -> Vec<String> {
 // decides whether the payload matches the schema, and the canonical
 // constructor decides whether the decoded request is admissible.
 //
-// The legacy `HostCompileProfile`-shaped entry points below are untouched
-// and still serve every call; nothing routes through this adapter yet.
+// The callable typed compile entry below is this adapter's only consumer.
+// The legacy `HostCompileProfile`-shaped entries stay on their existing
+// decode and execution paths.
 
 /// Why a JS host compile request did not become a canonical
 /// [`CompileRequest`].
@@ -370,6 +375,110 @@ pub fn host_compile_request_from_js(
         .map_err(|error| JsValue::from_str(&error.to_string()))
 }
 
+/// Match TypeScript's default optional-property semantics at the public
+/// callable boundary.
+///
+/// `ExactlyOneOf` can reject two populated tags, but without
+/// `exactOptionalPropertyTypes` an optional sibling key may be explicitly
+/// `undefined`. The serializer preserves that own key as JSON `null`, which
+/// an externally tagged enum correctly refuses as a second arm. Treat only
+/// known tag keys with an `undefined` value as absent before the single
+/// canonical decode; unknown keys and `null` values remain untouched and are
+/// still refused by the schema.
+#[cfg(target_arch = "wasm32")]
+fn normalize_compile_request_undefined_tags(request: JsValue) -> Result<JsValue, JsValue> {
+    use js_sys::{Array, Object, Reflect};
+    use wasm_bindgen::JsCast;
+
+    const FRAMEWORK_TAGS: &[&str] = &["vue", "svelte"];
+    const PRODUCT_TAGS: &[&str] = &["runtimeClient", "runtimeServer", "ideCompanion", "analysis"];
+
+    fn inspection_error() -> JsValue {
+        ffi_err("invalid host compile request: could not inspect tagged request properties")
+    }
+
+    fn clone_without_undefined_tags(
+        value: &JsValue,
+        tags: &[&str],
+    ) -> Result<Option<JsValue>, JsValue> {
+        if !value.is_object() || value.is_null() || Array::is_array(value) {
+            return Ok(None);
+        }
+
+        let mut has_defined_tag = false;
+        for tag in tags {
+            let tag = JsValue::from_str(tag);
+            has_defined_tag |= !Reflect::get(value, &tag)
+                .map_err(|_| inspection_error())?
+                .is_undefined();
+        }
+        // Preserve `Map` inputs: their entries are not reflected as object
+        // properties, and the existing decoder deliberately supports them.
+        if !has_defined_tag {
+            return Ok(None);
+        }
+
+        // An ordinary target inherits Object.prototype's `__proto__`
+        // setter. Object.assign would invoke it for an own enumerable source
+        // key of that name, changing the clone's prototype and erasing the
+        // key before the closed decoder can reject it. A null-prototype
+        // target has no inherited setters, so every enumerable own property
+        // remains an own property for Object.entries.
+        let cloned = Object::try_assign(
+            &Object::create(JsValue::NULL.unchecked_ref::<Object>()),
+            value.unchecked_ref::<Object>(),
+        )
+        .map_err(|_| inspection_error())?;
+        for tag in tags {
+            let tag = JsValue::from_str(tag);
+            if Reflect::get(value, &tag)
+                .map_err(|_| inspection_error())?
+                .is_undefined()
+            {
+                Reflect::delete_property(&cloned, &tag).map_err(|_| inspection_error())?;
+            }
+        }
+        Ok(Some(cloned.into()))
+    }
+
+    let Some(normalized) = clone_without_undefined_tags(&request, FRAMEWORK_TAGS)? else {
+        return Ok(request);
+    };
+    for framework_tag in FRAMEWORK_TAGS {
+        let framework_key = JsValue::from_str(framework_tag);
+        let body = Reflect::get(&normalized, &framework_key).map_err(|_| inspection_error())?;
+        if !body.is_object() || body.is_null() || Array::is_array(&body) {
+            continue;
+        }
+        let products_key = JsValue::from_str("products");
+        let products = Reflect::get(&body, &products_key).map_err(|_| inspection_error())?;
+        if !Array::is_array(&products) {
+            continue;
+        }
+
+        let normalized_products = Array::new();
+        for product in products.unchecked_ref::<Array>().iter() {
+            let product = clone_without_undefined_tags(&product, PRODUCT_TAGS)?.unwrap_or(product);
+            normalized_products.push(&product);
+        }
+        let normalized_body = Object::try_assign(
+            &Object::create(JsValue::NULL.unchecked_ref::<Object>()),
+            body.unchecked_ref::<Object>(),
+        )
+        .map_err(|_| inspection_error())?;
+        Reflect::set(&normalized_body, &products_key, &normalized_products)
+            .map_err(|_| inspection_error())?;
+        Reflect::set(&normalized, &framework_key, &normalized_body)
+            .map_err(|_| inspection_error())?;
+    }
+    Ok(normalized)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn normalize_compile_request_undefined_tags(request: JsValue) -> Result<JsValue, JsValue> {
+    Ok(request)
+}
+
 // =============================================================================
 // VerterHost (in-memory virtual file host)
 //
@@ -377,6 +486,7 @@ pub fn host_compile_request_from_js(
 // - Both: new, resolve, upsert, applyBlockOverrides, getVirtualFile,
 //         listVirtualFiles, remove, setImportDependencies, getAnalysis
 // - NAPI-only: prepareStyleForPreprocessor / transformVueStyle / analyzeStyle
+// - WASM-only: compileRequest
 // =============================================================================
 
 /// In-memory virtual file host for Vue SFC compilation (WASM variant).
@@ -608,34 +718,7 @@ impl WasmVerterHost {
         let host_profile = ffi_profile_to_host(ffi_profile).map_err(ffi_err)?;
         let result = catch_panic(|| self.inner.get_ide(canonical_id, &host_profile))?;
         let sfc_source = self.inner.get_source(canonical_id);
-        to_wasm_value(&result.map(|r| {
-            let destructured_block = r.destructured_block.as_ref().map(|meta| {
-                let sfc = sfc_source.as_deref().unwrap_or("");
-                let bindings: Vec<verter_ffi::convert::DestructuredBindingInput<'_>> = meta
-                    .bindings
-                    .iter()
-                    .map(|b| verter_ffi::convert::DestructuredBindingInput {
-                        name: &b.name,
-                        source_start: b.source_span.start,
-                        source_end: b.source_span.end,
-                    })
-                    .collect();
-                verter_ffi::convert::convert_destructured_block_meta(
-                    &bindings,
-                    meta.block_start,
-                    meta.block_end,
-                    sfc,
-                    &r.code,
-                    verter_ffi::convert::OffsetEncoding::Utf16,
-                )
-            });
-            FfiIdeResponse {
-                code: r.code.to_string(),
-                source_map: r.source_map.map(|s| s.to_string()),
-                is_jsx: r.is_jsx,
-                destructured_block,
-            }
-        }))
+        to_wasm_value(&result.map(|response| ide_response_to_ffi(&response, sfc_source.as_deref())))
     }
 
     /// Ensure the IDE (`CachedTsx`) projection exists for a file + profile.
@@ -671,6 +754,83 @@ impl WasmVerterHost {
         let host_profile = ffi_profile_to_host(ffi_profile).map_err(ffi_err)?;
         catch_panic(|| self.inner.ensure_ide_compiled(canonical_id, &host_profile))?
             .map_err(host_err)
+    }
+
+    /// Execute ONE typed compile request against an already-registered
+    /// source and return its complete result.
+    ///
+    /// The whole transaction is one call: register the carrier once through
+    /// the ordinary source-only [`upsert`](Self::upsert), then hand this
+    /// entry the canonical id and the request. There is no ensure-then-read
+    /// pair whose ordering a caller has to get right, and no boolean whose
+    /// meaning a caller has to infer.
+    ///
+    /// - `canonical_id` — the registered carrier the request executes
+    ///   against. The source is NOT part of the request and is never copied
+    ///   into it.
+    /// - `request` — a framework-discriminated typed request
+    ///   (`{ vue: { identity, products, options } }` or
+    ///   `{ svelte: … }`). It is the demand document end to end: the
+    ///   product set is what gets compiled, and no compile profile is built
+    ///   from it on any path.
+    ///
+    /// Returns `{ canonicalId, diagnostics, products }` — one product row
+    /// per requested product kind, in request order, each tagged with the
+    /// same `kind` spelling the request used. This route produces
+    /// `runtimeClient`, `runtimeServer`, `ideCompanion`, and `analysis`.
+    /// The shared request schema's `publicApi` and `declarations` arms are
+    /// refused for both frameworks.
+    ///
+    /// Diagnostic spans and destructured binding source spans are UTF-16
+    /// offsets into the registered source. Destructured block bounds are
+    /// UTF-16 offsets into the IDE row's generated `code`; the `analysis`
+    /// row's own spans stay UTF-8 byte offsets into the source, exactly as
+    /// `getAnalysis` publishes them.
+    ///
+    /// Every call is a COMPLETE compile. This route consults and publishes
+    /// no compile cache slot, so two identical calls compile twice — a
+    /// per-keystroke loop that only needs the IDE surface stays cheaper on
+    /// the cached `ensureIdeCompiled` / `getIde` pair.
+    ///
+    /// Complete-only. A payload the schema refuses, a request the compiler
+    /// refuses, a framework arm the registered carrier contradicts, an
+    /// unproducible product, or an execution refusal all THROW the refusal
+    /// message as a string — never a partial response, a `null`, or a
+    /// boolean, and never a sibling product published beside a refusal.
+    #[wasm_bindgen(js_name = compileRequest)]
+    pub fn compile_request(
+        &self,
+        canonical_id: &str,
+        request: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        // Known sibling tags explicitly valued `undefined` are first read as
+        // absent, matching the published TypeScript type under its default
+        // compiler semantics. The result is then decoded ONCE, straight into
+        // the canonical request, through the existing schema boundary.
+        //
+        // Every host-resolved profile identity is absent: the wire has no
+        // slot for one, and the host execution route consumes none. A
+        // caller therefore cannot state one, and nothing is substituted on
+        // its behalf.
+        let request = host_compile_request_from_js(
+            normalize_compile_request_undefined_tags(request)?,
+            &HostResolvedCompileProfiles {
+                semantic: None,
+                output: None,
+                presentation: None,
+                serialization: None,
+            },
+        )?;
+        let response = catch_panic(|| self.inner.compile_request(canonical_id, request))?
+            .map_err(|failure| ffi_err(compile_request_failure_to_string(&failure)))?;
+        // The registered source is read AFTER the compile, by the canonical
+        // id the response resolved to, so the UTF-16 diagnostic offsets are
+        // indexed against the carrier the compile actually ran on rather
+        // than whatever alias the caller happened to name.
+        let sfc_source = self.inner.get_source(&response.canonical_id);
+        let published =
+            compile_request_response_to_wasm(response, sfc_source.as_deref()).map_err(ffi_err)?;
+        to_wasm_value(&published)
     }
 
     /// Retrieve TSC declaration output for a file.

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -82,20 +82,20 @@ const host = await createHost();
 The `Host` class exposes the shared host methods below plus the WASM-only
 `compileRequest()` route:
 
-| Method                                                                                      | Returns                    | Description                                                   |
-| ------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------- |
-| `resolve(rawId)`                                                                            | `HostResolvedId \| null`   | Resolve raw ID to canonical ID                                |
-| `upsert(request)`                                                                           | `HostUpdateResult`         | Register/update a file                                        |
-| `applyBlockOverrides(request)`                                                              | `HostUpdateResult`         | Apply preprocessed block overrides                            |
-| `getIde(canonicalId, profile?)`                                                             | `HostIdeResponse \| null`  | Get TSX or JSX for type checking                              |
-| `compileRequest(canonicalId, request)`                                                      | `HostCompileRequestResponse` | Execute one typed compile request (throws on refusal)       |
+| Method                                                                                      | Returns                           | Description                                                     |
+| ------------------------------------------------------------------------------------------- | --------------------------------- | --------------------------------------------------------------- |
+| `resolve(rawId)`                                                                            | `HostResolvedId \| null`          | Resolve raw ID to canonical ID                                  |
+| `upsert(request)`                                                                           | `HostUpdateResult`                | Register/update a file                                          |
+| `applyBlockOverrides(request)`                                                              | `HostUpdateResult`                | Apply preprocessed block overrides                              |
+| `getIde(canonicalId, profile?)`                                                             | `HostIdeResponse \| null`         | Get TSX or JSX for type checking                                |
+| `compileRequest(canonicalId, request)`                                                      | `HostCompileRequestResponse`      | Execute one typed compile request (throws on refusal)           |
 | `getVirtualFile(query)`                                                                     | `HostVirtualFileResponse \| null` | Get compiled virtual file (`null` when the node does not exist) |
-| `listVirtualFiles(canonicalId)`                                                             | `HostVirtualNodeKind[]`    | List virtual nodes for a file                                 |
-| `remove(canonicalOrAlias)`                                                                  | `HostRemoveResult \| null` | Remove file from host                                         |
-| `getAnalysis(canonicalOrAlias)`                                                             | `unknown \| null`          | Get analysis snapshot (native JS object)                      |
-| `setImportDependencies(id, deps)`                                                           | `void`                     | Set resolved import dependencies                              |
-| `collectResolvableModuleReferenceSpecifiers(moduleReferences)`                              | `string[]`                 | Return exact/finite candidate specifiers in encounter order   |
-| `resolveKnownModuleReferenceDependencies(ownerId, moduleReferences, knownIds, extensions?)` | `string[]`                 | Resolve exact/finite candidates against an in-memory file set |
+| `listVirtualFiles(canonicalId)`                                                             | `HostVirtualNodeKind[]`           | List virtual nodes for a file                                   |
+| `remove(canonicalOrAlias)`                                                                  | `HostRemoveResult \| null`        | Remove file from host                                           |
+| `getAnalysis(canonicalOrAlias)`                                                             | `unknown \| null`                 | Get analysis snapshot (native JS object)                        |
+| `setImportDependencies(id, deps)`                                                           | `void`                            | Set resolved import dependencies                                |
+| `collectResolvableModuleReferenceSpecifiers(moduleReferences)`                              | `string[]`                        | Return exact/finite candidate specifiers in encounter order     |
+| `resolveKnownModuleReferenceDependencies(ownerId, moduleReferences, knownIds, extensions?)` | `string[]`                        | Resolve exact/finite candidates against an in-memory file set   |
 
 See the [@verter/native documentation](./native.md) for detailed descriptions of each method and their parameter types.
 
@@ -123,16 +123,18 @@ const code = "<p>Hello</p>";
 
 host.applyBlockOverrides({
   canonicalId: update.canonicalId,
-  overrides: [{
-    correlationToken: pending.correlationToken,
-    blockToken: pending.blockToken,
-    ownerRevision: pending.ownerRevision,
-    artifactToken: pending.artifactToken,
-    basisToken: pending.basisToken,
-    sourceSpaceToken: pending.sourceSpaceToken,
-    code,
-    codeHash: await hashBlockContent(code),
-  }],
+  overrides: [
+    {
+      correlationToken: pending.correlationToken,
+      blockToken: pending.blockToken,
+      ownerRevision: pending.ownerRevision,
+      artifactToken: pending.artifactToken,
+      basisToken: pending.basisToken,
+      sourceSpaceToken: pending.sourceSpaceToken,
+      code,
+      codeHash: await hashBlockContent(code),
+    },
+  ],
 });
 ```
 
@@ -225,7 +227,7 @@ non-ASCII carrier.
 
 **No compile cache slot.** Every call is a complete compile: this route
 consults and publishes no cache slot, so two identical calls compile twice. The
-profile-bearing `ensureIdeCompiled()` / `getIde()` pair *is* cached, so a
+profile-bearing `ensureIdeCompiled()` / `getIde()` pair _is_ cached, so a
 per-keystroke editor loop that only needs the IDE surface stays cheaper there;
 reach for `compileRequest()` when the demand is a fresh multi-product compile.
 

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -79,7 +79,8 @@ const host = await createHost();
 
 #### Host Methods
 
-The `Host` class exposes the same methods as `@verter/native`'s `VerterHost`:
+The `Host` class exposes the shared host methods below plus the WASM-only
+`compileRequest()` route:
 
 | Method                                                                                      | Returns                    | Description                                                   |
 | ------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------- |
@@ -87,6 +88,7 @@ The `Host` class exposes the same methods as `@verter/native`'s `VerterHost`:
 | `upsert(request)`                                                                           | `HostUpdateResult`         | Register/update a file                                        |
 | `applyBlockOverrides(request)`                                                              | `HostUpdateResult`         | Apply preprocessed block overrides                            |
 | `getIde(canonicalId, profile?)`                                                             | `HostIdeResponse \| null`  | Get TSX or JSX for type checking                              |
+| `compileRequest(canonicalId, request)`                                                      | `HostCompileRequestResponse` | Execute one typed compile request (throws on refusal)       |
 | `getVirtualFile(query)`                                                                     | `HostVirtualFileResponse \| null` | Get compiled virtual file (`null` when the node does not exist) |
 | `listVirtualFiles(canonicalId)`                                                             | `HostVirtualNodeKind[]`    | List virtual nodes for a file                                 |
 | `remove(canonicalOrAlias)`                                                                  | `HostRemoveResult \| null` | Remove file from host                                         |
@@ -138,6 +140,107 @@ The host validates the current revision, artifact, basis, source space, code
 hash, and optional source-map hash after the asynchronous processor completes.
 It refuses stale or mismatched results without mutating its caches.
 
+#### `compileRequest(canonicalId, request)`
+
+Executes one typed compile request against an already-registered source. The
+whole transaction is one call: register the carrier once with `upsert()`,
+source only, then hand this the canonical id and the request. There is no
+ensure-then-read pair to order correctly and no boolean to interpret.
+
+The request is the demand document end to end — its **product set** is what
+gets compiled. No compile profile is built from it on any path, and the source
+is never copied into it.
+
+This route can produce `runtimeClient`, `runtimeServer`, `ideCompanion`, and
+`analysis`. The shared schema also exposes the bare tags `"publicApi"` and
+`"declarations"`; `compileRequest()` refuses both for Vue and Svelte.
+
+```ts
+const host = await createHost();
+
+host.upsert({ inputId: "/src/App.vue", source: sfcSource, fileKind: "vue" });
+
+const result = host.compileRequest("/src/App.vue", {
+  vue: {
+    identity: { isProduction: false, forceJs: false },
+    products: [
+      { runtimeClient: { runtimeSourceMap: true } },
+      {
+        ideCompanion: {
+          wantSourceMap: true,
+          embedAmbientTypes: false,
+          conditionalRootNarrowing: false,
+          strictSlots: false,
+          ideChunkBoundaries: false,
+        },
+      },
+    ],
+    options: { backend: "inferred", ssr: false, isCustomElement: [], babelParserPlugins: [] },
+  },
+});
+
+// One row per requested product kind, in request order, tagged with the
+// same `kind` spelling the request used.
+for (const product of result.products) {
+  if (product.kind === "runtimeClient") {
+    // The assembled main module, the script, the compiled template, each
+    // style block and each custom block — each with its own code and map.
+    for (const node of product.nodes) console.log(node.node.kind, node.code.length);
+  }
+}
+```
+
+The request is discriminated by framework at the outermost level
+(`{ vue: … }` / `{ svelte: … }`), and the arms are **mutually exclusive** — a
+payload populating both is a TypeScript error as well as a decoder refusal.
+Under TypeScript's default optional-property semantics, a known sibling tag
+explicitly set to `undefined` is treated as absent. Every object is otherwise
+closed: a key the schema does not declare — including the other framework's
+option key — is refused by name.
+
+The response carries `canonicalId` (after alias resolution), one deduplicated
+`diagnostics` set for the whole compile, and the `products` rows. The
+`analysis` row nests its payload under its own `analysis` key, so no field of
+that payload can collide with the row's `kind` discriminant:
+
+```ts
+for (const product of result.products) {
+  if (product.kind === "analysis") console.log(product.analysis.bindingOccurrences);
+}
+```
+
+That payload is the **template** analysis snapshot — the value `getAnalysis()`
+publishes under its `template` field — not the whole-file snapshot
+`getAnalysis()` returns.
+
+**Offset encodings and coordinate spaces differ by field.**
+`diagnostics[].spanStart` / `spanEnd` and
+`destructuredBlock.bindings[].sourceStart` / `sourceEnd` are **UTF-16 code
+units into the registered source**, indexable against that JavaScript string.
+`destructuredBlock.blockStart` / `blockEnd` are **UTF-16 code units into the
+IDE product row's own `code`**, the generated IDE surface. The `analysis`
+row's spans are **UTF-8 byte offsets into the registered source**, exactly as
+`getAnalysis()` reports them — indexing a JS string with one is wrong on any
+non-ASCII carrier.
+
+**No compile cache slot.** Every call is a complete compile: this route
+consults and publishes no cache slot, so two identical calls compile twice. The
+profile-bearing `ensureIdeCompiled()` / `getIde()` pair *is* cached, so a
+per-keystroke editor loop that only needs the IDE surface stays cheaper there;
+reach for `compileRequest()` when the demand is a fresh multi-product compile.
+
+**Complete-only.** Every requested product the host can produce is present.
+There is no partial response, no `null`, and no ensure boolean: a payload the
+schema refuses, a request the compiler refuses, a framework arm the registered
+carrier contradicts, an unproducible product kind, or an execution refusal all
+**throw**, and no sibling product is published beside a refusal. A refusal
+names the offending product the way the request spelled it (`publicApi`, not
+`PublicApi`) and is thrown as the refusal-message string, not an `Error`
+instance.
+
+The profile-bearing `getIde()` / `ensureIdeCompiled()` / `getVirtualFile()`
+methods are unchanged and keep serving every existing caller.
+
 #### Shared module reference flow
 
 `host.upsert()` now returns `moduleReferences`, which are classified as:
@@ -183,6 +286,36 @@ that equivalence:
 - `HostBlockOverrideRequest`
 - `HostVirtualQuery`
 
+### Typed compile request types
+
+`compileRequest()`'s request is the shared framework-discriminated schema, tagged
+differently for this binding: the arm name is the object's single key
+(`{ vue: … }`, `{ analysis: … }`) where `@verter/native`'s decoder reads an
+internal `framework` / `kind` field. Because the two wire forms are NOT
+interchangeable, the browser forms carry a `Browser` prefix — a payload that
+moved between the packages under a shared name would keep type-checking and be
+refused by the other decoder at run time. Only the tagged wrappers are declared
+here; every leaf option, identity and product shape is imported from
+`@verter/native`'s generated projection, and `src/index.test-d.ts` pins the arm
+sets, the arm payloads, and their mutual exclusivity to it:
+
+- `BrowserHostCompileRequest`, `BrowserHostVueCompileRequest`,
+  `BrowserHostSvelteCompileRequest`
+- `BrowserHostRequestedProduct`
+- `HostCompileIdentity`, `HostVueCompileOptions`, `HostSvelteCompileOptions`
+- `HostRuntimeProductOptions`, `HostIdeProductOptions`, `HostAnalysisProductOptions`
+
+The response has no `@verter/native` counterpart, so its types are unprefixed
+and this binding's own. They reuse the re-exported shared shapes wherever the
+route serialises one (`HostDiagnosticsSnapshot`, `HostVirtualNodeKind`,
+`HostVirtualMeta`, `HostIdeResponse`) rather than restating them:
+
+- `HostCompileRequestResponse`
+- `HostCompiledProduct`, `HostCompiledRuntimeProduct`, `HostCompiledIdeProduct`,
+  `HostCompiledAnalysisProduct`
+- `HostCompiledVirtualNode`, `HostDestructuredBlockMeta`,
+  `HostTemplateAnalysisSnapshot`
+
 The remaining types are re-exported from `@verter/native/host-types`:
 
 - `HostConfig`
@@ -210,4 +343,5 @@ re-exported types.
 | `analyzeStyle()`                | Available                        | Not available                    |
 | `VerterHost`                    | Synchronous constructor          | Async via `createHost()`         |
 | `getAnalysis()` return          | JSON `string`                    | Native JS `object`               |
+| `compileRequest()`              | Not available yet                | Available                        |
 | `source` accepts                | `string \| Buffer`               | `string`                         |

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -126,8 +126,10 @@ console.log(main?.code);
 ```
 
 There is no standalone `compile()` / `compileSync()`. The WASM artifact
-exports `VerterHost` and nothing else compile-shaped, so those wrappers
-never worked; they were removed rather than left throwing. Use the host.
+exports `VerterHost` and nothing else compile-shaped, so those wrappers never
+worked; they were removed rather than left throwing. Compile through the host:
+`Host.compileRequest()` for a typed one-call compile, or the profile-bearing
+reads for a cached IDE surface.
 
 ### `isInitialized(): boolean`
 
@@ -143,10 +145,13 @@ if (!isInitialized()) {
 
 ### Types
 
-Host request and response types (`HostConfig`, `HostUpsertRequest`,
+Shared host request and response types (`HostConfig`, `HostUpsertRequest`,
 `HostVirtualQuery`, `HostVirtualFileResponse`, …) are re-exported from
-`@verter/native/host-types`, so the two packages type-check against one
-definition.
+`@verter/native/host-types`. `BrowserHostCompileRequest` and
+`HostCompileRequestResponse` are exported by this package: the browser wire
+form tags each arm by key (`{ vue: … }`) where the native one uses a
+`framework` field, so the prefix keeps the two from being mistaken for each
+other at an import site.
 
 ## Development / Build
 

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -239,16 +239,16 @@ pnpm test    # runs: vitest run
 
 ## Dependencies
 
-| Dependency                            | Purpose                                           |
-| ------------------------------------- | ------------------------------------------------- |
-| `verter_compiler` (Rust)                  | Core Vue template compiler                        |
-| `wasm-bindgen` (Rust)                 | Rust/WASM interop layer                           |
+| Dependency                            | Purpose                                               |
+| ------------------------------------- | ----------------------------------------------------- |
+| `verter_compiler` (Rust)              | Core Vue template compiler                            |
+| `wasm-bindgen` (Rust)                 | Rust/WASM interop layer                               |
 | `wasm-bindgen-cli` (tool)             | Generates browser JS glue and TypeScript declarations |
-| `binaryen` / `wasm-opt` (npm tool)    | Size-optimizes the compiled WASM binary           |
-| `serde` / `serde-wasm-bindgen` (Rust) | Serialization between Rust structs and JS objects |
-| `console_error_panic_hook` (Rust)     | Better panic messages in browser console          |
-| `oxc_allocator` (Rust)                | Memory allocator for OXC AST nodes                |
-| `tsdown` (dev)                        | TypeScript bundler for the JS wrapper             |
+| `binaryen` / `wasm-opt` (npm tool)    | Size-optimizes the compiled WASM binary               |
+| `serde` / `serde-wasm-bindgen` (Rust) | Serialization between Rust structs and JS objects     |
+| `console_error_panic_hook` (Rust)     | Better panic messages in browser console              |
+| `oxc_allocator` (Rust)                | Memory allocator for OXC AST nodes                    |
+| `tsdown` (dev)                        | TypeScript bundler for the JS wrapper                 |
 
 ## License
 

--- a/packages/wasm/src/artifact-exports.spec.ts
+++ b/packages/wasm/src/artifact-exports.spec.ts
@@ -14,7 +14,7 @@
  * has not quietly come back through the wrapper without the artifact.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -23,9 +23,36 @@ import * as wasm from "../wasm/verter_wasm.js";
 import * as pkg from "./index.js";
 
 const WASM_BINARY_PATH = resolve(import.meta.dirname, "../wasm/verter_wasm_bg.wasm");
+const WASM_DECLARATIONS_PATH = resolve(import.meta.dirname, "../wasm/verter_wasm.d.ts");
 
 /** Every binding `initialize()` reads off the imported module. */
 const REQUIRED_ARTIFACT_EXPORTS = ["default", "initSync", "VerterHost"] as const;
+
+/**
+ * Every host method the wrapper forwards to. The wrapper reaches these off
+ * the constructed instance, so an absent one throws at call time on a fully
+ * initialized module — the exact defect `compile`/`compileSync` were.
+ */
+const REQUIRED_HOST_METHODS = [
+  "resolve",
+  "upsert",
+  "applyBlockOverrides",
+  "getIde",
+  "ensureIdeCompiled",
+  "compileRequest",
+  "getVirtualFile",
+  "listVirtualFiles",
+  "remove",
+  "getAnalysis",
+  "setImportDependencies",
+  "collectResolvableModuleReferenceSpecifiers",
+  "resolveKnownModuleReferenceDependencies",
+  "lint",
+  "getCodeActions",
+  "getLintRuleMetadata",
+  "getDocumentSymbols",
+  "matchCssSelectors",
+] as const;
 
 describe("@verter/wasm artifact export surface", () => {
   it("the built artifact carries every export the wrapper binds", () => {
@@ -61,5 +88,31 @@ describe("@verter/wasm artifact export surface", () => {
         `@verter/wasm exports \`${name}\` but the artifact does not — the wrapper would throw at call time`,
       ).toBe(false);
     }
+  });
+
+  it("the generated host object carries every method the wrapper forwards", () => {
+    // The generated JS object, not the Rust source: a Rust method with no
+    // binding annotation compiles, is reachable from Rust tests, and is
+    // absent here. Reading the prototype needs no WASM instance, so this
+    // asks the same question a browser caller does before it ever calls.
+    const prototype = (wasm.VerterHost as unknown as { prototype: Record<string, unknown> })
+      .prototype;
+    const missing = REQUIRED_HOST_METHODS.filter((name) => typeof prototype[name] !== "function");
+    expect(
+      missing,
+      "the wrapper forwards to these; an absent one throws at call time, not here",
+    ).toEqual([]);
+  });
+
+  it("the generated declarations declare the typed compile entry", () => {
+    // The wrapper's own declaration says a `compileRequest` exists on the
+    // binding. That claim is only true if the GENERATED declarations say so
+    // too — a hand-written binding interface can name a method the artifact
+    // never had, which is how the removed standalone compile survived.
+    const declarations = readFileSync(WASM_DECLARATIONS_PATH, "utf8");
+    expect(
+      /^\s*compileRequest\(/m.test(declarations),
+      `no \`compileRequest\` method declared in ${WASM_DECLARATIONS_PATH}`,
+    ).toBe(true);
   });
 });

--- a/packages/wasm/src/compile-request-types.ts
+++ b/packages/wasm/src/compile-request-types.ts
@@ -1,0 +1,233 @@
+// =============================================================================
+// The typed compile request and its response
+//
+// REQUEST side — the arm name is the object's single key (`{ vue: … }`,
+// `{ analysis: … }`), where the native binding's decoder reads an internal
+// `framework` / `kind` tag. That difference is why every request type here
+// carries a `Browser` prefix: `@verter/native` exports `HostCompileRequest`
+// and `HostRequestedProduct` as the internally-tagged forms, and a shared
+// name would let a payload move between the two packages, keep
+// type-checking, and be refused by the other decoder at run time.
+//
+// Only the tagged wrappers are declared here — every leaf option, identity
+// and product shape is imported from `@verter/native`'s generated
+// projection, which is rendered from the very declarations this binding
+// decodes and byte-pinned against them. The arm SETS and arm PAYLOADS are
+// held to that projection in `src/index.test-d.ts`, so a product or
+// framework arm added, removed or renamed on the shared schema is a compile
+// error there rather than a shape that type-checks and then refuses at run
+// time.
+//
+// RESPONSE side — no native counterpart exists, so those names are
+// unprefixed. They reuse the shapes this package already re-exports from
+// `@verter/native` wherever the route serialises one, rather than restating
+// them: a second copy is only safe when something holds the two together,
+// and these have the strongest possible tie — the route serialises the very
+// Rust struct those declarations project.
+//
+// They live in a leaf module rather than in `index.ts` so `tsc` can check
+// them: `index.ts` imports the gitignored wasm-bindgen artifact and cannot
+// be type-checked from a clean tree.
+// =============================================================================
+
+import type {
+  HostAnalysisProductOptions,
+  HostCompileIdentity,
+  HostDiagnosticsSnapshot,
+  HostIdeProductOptions,
+  HostIdeResponse,
+  HostRuntimeProductOptions,
+  HostSvelteCompileOptions,
+  HostVirtualMeta,
+  HostVirtualNodeKind,
+  HostVueCompileOptions,
+} from "@verter/native/host-types";
+
+export type {
+  HostAnalysisProductOptions,
+  HostCompileIdentity,
+  HostIdeProductOptions,
+  HostRuntimeProductOptions,
+  HostSvelteCompileOptions,
+  HostVueCompileOptions,
+} from "@verter/native/host-types";
+
+/**
+ * A union whose populated arms are mutually exclusive at the type level.
+ *
+ * TypeScript's excess-property check does not fire through a plain union:
+ * an object stating BOTH `vue` and `svelte` satisfies
+ * `{ vue: … } | { svelte: … }` with no diagnostic, while the decoder
+ * refuses it as an unknown field. A well-typed call would then be a
+ * guaranteed run-time throw. Each arm therefore declares every OTHER arm's
+ * key as an optional `never`, so a multi-arm payload is a compile error
+ * exactly where the decoder would have refused it. Under TypeScript's
+ * default optional-property semantics, an explicitly written `undefined`
+ * still satisfies an optional `never`; the callable route treats those
+ * known undefined sibling tags as absent at both tagged-union layers.
+ */
+type ExactlyOneOf<Arms> = {
+  [Arm in keyof Arms]: Pick<Arms, Arm> & Partial<Record<Exclude<keyof Arms, Arm>, never>>;
+}[keyof Arms];
+
+/**
+ * One requested compiler product. There is no target preset that expands
+ * into a bundle, and request order is preserved in the response.
+ *
+ * `compileRequest()` currently produces `runtimeClient`, `runtimeServer`,
+ * `ideCompanion`, and `analysis`. The shared schema also contains
+ * `publicApi` and `declarations`, but this browser route cannot produce
+ * either and throws their refusal message as a string.
+ *
+ * An arm that carries no options is the bare tag STRING, not an object:
+ * `"publicApi"`, never `{ publicApi: {} }`. The option-carrying arms are
+ * mutually exclusive — one product row states one product.
+ */
+export type BrowserHostRequestedProduct =
+  | ExactlyOneOf<{
+      runtimeClient: HostRuntimeProductOptions;
+      runtimeServer: HostRuntimeProductOptions;
+      ideCompanion: HostIdeProductOptions;
+      analysis: HostAnalysisProductOptions;
+    }>
+  | "publicApi"
+  | "declarations";
+
+export interface BrowserHostVueCompileRequest {
+  identity: HostCompileIdentity;
+  products: BrowserHostRequestedProduct[];
+  options: HostVueCompileOptions;
+}
+
+export interface BrowserHostSvelteCompileRequest {
+  identity: HostCompileIdentity;
+  products: BrowserHostRequestedProduct[];
+  options: HostSvelteCompileOptions;
+}
+
+/**
+ * A host compile request discriminated by framework at the outermost level,
+ * so framework-owned options are structurally unreachable from the other
+ * framework's arm and a foreign key inside either arm is refused at decode.
+ *
+ * Exactly one populated framework arm: naming both is a compile error here
+ * and a decoder refusal. An explicitly undefined sibling is treated as
+ * absent, matching TypeScript's default optional-property semantics.
+ */
+export type BrowserHostCompileRequest = ExactlyOneOf<{
+  vue: BrowserHostVueCompileRequest;
+  svelte: BrowserHostSvelteCompileRequest;
+}>;
+
+// -----------------------------------------------------------------------------
+// The response
+// -----------------------------------------------------------------------------
+
+/**
+ * One separately addressed output of a compiled runtime product.
+ *
+ * A runtime product is not one blob: the assembled main module, the script,
+ * the compiled template, each style block and each custom block are distinct
+ * modules a consumer loads and maps independently, so each row carries its
+ * own code and its own map.
+ *
+ * The optional fields carry no `| null`: the route serialises through
+ * `serde_wasm_bindgen`'s default serializer, where an absent value is
+ * `undefined` and never `null`.
+ */
+export interface HostCompiledVirtualNode {
+  /** Which node of the carrier this row is. */
+  node: HostVirtualNodeKind;
+  code: string;
+  /** This node's own JSON source map, when the request asked for maps. */
+  sourceMap?: string;
+  /** Output language (e.g. `"js"`, `"ts"`, `"css"`). */
+  lang?: string;
+  /** Block-specific metadata carried beside the node's bytes. */
+  meta: HostVirtualMeta;
+}
+
+export interface HostCompiledRuntimeProduct {
+  kind: "runtimeClient" | "runtimeServer";
+  nodes: HostCompiledVirtualNode[];
+}
+
+/**
+ * Where a `<script setup>` destructured-props block sits in the generated
+ * IDE surface, and which bindings it declares.
+ *
+ * Declared here because the shared `HostIdeResponse` does not carry it,
+ * while every binding that publishes an IDE projection does. Offsets are
+ * UTF-16 code units.
+ */
+export interface HostDestructuredBlockMeta {
+  /** Binding spans in UTF-16 code units into the registered source. */
+  bindings: { name: string; sourceStart: number; sourceEnd: number }[];
+  /** UTF-16 start offset into the IDE product row's generated `code`. */
+  blockStart: number;
+  /** UTF-16 end offset into the IDE product row's generated `code`. */
+  blockEnd: number;
+}
+
+/**
+ * The IDE projection row: the shared IDE response plus the destructured
+ * block the shared declaration does not name.
+ */
+export type HostCompiledIdeProduct = { kind: "ideCompanion" } & HostIdeResponse & {
+    destructuredBlock?: HostDestructuredBlockMeta;
+  };
+
+/**
+ * The TEMPLATE analysis snapshot — binding occurrences, expression
+ * diagnostics, and the rest of the template's facts.
+ *
+ * This is NOT what `getAnalysis()` returns. `getAnalysis()` publishes the
+ * whole-file snapshot (imports, bindings, macros, styles, and a nested
+ * `template`); this payload is that snapshot's `template` value and nothing
+ * else. `@verter/language-shared` declares the same object as
+ * `TemplateAnalysisSnapshot`; it stays unstructured here rather than
+ * pulling an editor package into a browser binding's published types, and
+ * the equivalence is proven at run time by the browser boundary tests
+ * rather than asserted only in prose.
+ *
+ * Its spans are UTF-8 BYTE offsets into the SFC source. Diagnostics and
+ * destructured binding source spans are UTF-16 offsets into that source;
+ * destructured block bounds are UTF-16 offsets into the generated IDE code.
+ */
+export type HostTemplateAnalysisSnapshot = Record<string, unknown>;
+
+export interface HostCompiledAnalysisProduct {
+  kind: "analysis";
+  /**
+   * Nested under its own key rather than flattened into the row, so no
+   * field of the payload can collide with the `kind` discriminant.
+   */
+  analysis: HostTemplateAnalysisSnapshot;
+}
+
+/**
+ * One row of a response's product list, one-to-one with a requested product
+ * kind and in request order, tagged with the same spelling the request used.
+ */
+export type HostCompiledProduct =
+  | HostCompiledRuntimeProduct
+  | HostCompiledIdeProduct
+  | HostCompiledAnalysisProduct;
+
+/**
+ * The result of executing one typed compile request.
+ *
+ * Complete-only: every requested product is present. A refusal at any stage
+ * THROWS — there is no partial response, no `null`, and no boolean.
+ */
+export interface HostCompileRequestResponse {
+  /** The canonical id the request executed against, after alias resolution. */
+  canonicalId: string;
+  /**
+   * The compile's diagnostics, deduplicated once across every product.
+   * Spans are UTF-16 offsets into the registered source.
+   */
+  diagnostics: HostDiagnosticsSnapshot;
+  /** One row per requested product kind, in request order. */
+  products: HostCompiledProduct[];
+}

--- a/packages/wasm/src/index.spec.ts
+++ b/packages/wasm/src/index.spec.ts
@@ -33,6 +33,14 @@ const mockHostListVirtualFiles = vi.fn(() => []);
 const mockHostRemove = vi.fn(() => null);
 const mockHostCollectResolvableModuleReferenceSpecifiers = vi.fn(() => ["./Foo.vue"]);
 const mockHostResolveKnownModuleReferenceDependencies = vi.fn(() => ["src/Foo.vue"]);
+// The analysis payload nests under its own key, exactly as the binding
+// publishes it — a mock that flattened it would teach the wrong row shape,
+// which is how a previous mocked surface outlived the artifact it stood for.
+const mockHostCompileRequest = vi.fn(() => ({
+  canonicalId: "Comp.vue",
+  diagnostics: { diagnostics: [], hasErrors: false },
+  products: [{ kind: "analysis", analysis: { bindingOccurrences: [] } }],
+}));
 const mockHostCtor = vi.fn<(config?: unknown) => void>();
 class MockHost {
   constructor(config?: unknown) {
@@ -46,6 +54,7 @@ class MockHost {
   remove = mockHostRemove;
   collectResolvableModuleReferenceSpecifiers = mockHostCollectResolvableModuleReferenceSpecifiers;
   resolveKnownModuleReferenceDependencies = mockHostResolveKnownModuleReferenceDependencies;
+  compileRequest = mockHostCompileRequest;
 }
 
 vi.mock("../wasm/verter_wasm.js", () => ({
@@ -66,6 +75,7 @@ beforeEach(async () => {
   mockHostRemove.mockClear();
   mockHostCollectResolvableModuleReferenceSpecifiers.mockClear();
   mockHostResolveKnownModuleReferenceDependencies.mockClear();
+  mockHostCompileRequest.mockClear();
 
   // Ensure module is initialized for each test
   await initialize();
@@ -96,6 +106,28 @@ describe("@verter/wasm host wrapper", () => {
       expect(mockHostGetVirtualFile).toHaveBeenCalled();
       expect(mockHostListVirtualFiles).toHaveBeenCalledWith("Comp.vue");
       expect(mockHostRemove).toHaveBeenCalledWith("Comp.vue");
+    });
+
+    it("forwards the typed compile request as two separate arguments", async () => {
+      const host = await createHost();
+      const request = {
+        vue: {
+          identity: { isProduction: false, forceJs: false },
+          products: [{ analysis: { wantScriptBindings: true, wantTemplateData: false } }],
+          options: { backend: "inferred", ssr: false, isCustomElement: [], babelParserPlugins: [] },
+        },
+      } as const;
+
+      const response = host.compileRequest("Comp.vue", request);
+
+      // The id and the request stay separate on the way through: a wrapper
+      // that folded the id into the request, or reordered the pair, would
+      // hand the binding a payload the schema refuses at run time.
+      expect(mockHostCompileRequest).toHaveBeenCalledWith("Comp.vue", request);
+      expect(response.canonicalId).toBe("Comp.vue");
+      expect(response.products).toEqual([
+        { kind: "analysis", analysis: { bindingOccurrences: [] } },
+      ]);
     });
 
     it("forwards shared module reference helper methods", async () => {

--- a/packages/wasm/src/index.test-d.ts
+++ b/packages/wasm/src/index.test-d.ts
@@ -7,14 +7,26 @@ import type {
   WasmStampedBlockResult,
 } from "./handoff-types";
 import type {
+  BrowserHostCompileRequest,
+  BrowserHostRequestedProduct,
+  BrowserHostSvelteCompileRequest,
+  BrowserHostVueCompileRequest,
+} from "./compile-request-types";
+import type {
   HostBlockOverrideRequest,
   HostCompileProfile,
   HostVirtualQuery,
 } from "./request-types";
 import type {
+  HostAnalysisProductOptions as NativeHostAnalysisProductOptions,
   HostBlockOverrideRequest as NativeHostBlockOverrideRequest,
   HostCompileProfile as NativeHostCompileProfile,
+  HostCompileRequest as NativeHostCompileRequest,
+  HostRequestedProduct as NativeHostRequestedProduct,
+  HostRuntimeProductOptions as NativeHostRuntimeProductOptions,
+  HostSvelteCompileRequest as NativeHostSvelteCompileRequest,
   HostVirtualQuery as NativeHostVirtualQuery,
+  HostVueCompileRequest as NativeHostVueCompileRequest,
 } from "@verter/native/host-types";
 
 type Equal<Left, Right> =
@@ -57,6 +69,149 @@ type _ProfileIsExactlyTheNativeProfile = Expect<
 type _BlockOverrideRequestIsExactlyTheNativeOne = Expect<
   Equal<HostBlockOverrideRequest, NativeHostBlockOverrideRequest>
 >;
-type _VirtualQueryIsExactlyTheNativeOne = Expect<
-  Equal<HostVirtualQuery, NativeHostVirtualQuery>
+type _VirtualQueryIsExactlyTheNativeOne = Expect<Equal<HostVirtualQuery, NativeHostVirtualQuery>>;
+
+// The typed compile request is the SAME schema the native binding decodes,
+// tagged differently: this binding's decoder puts the arm name in the key
+// (`{ vue: … }`), the native one puts it in a `framework` / `kind` field.
+// Only the two tagged wrappers are declared locally; every leaf shape is
+// imported from the generated projection. What is unheld by that import is
+// the ARM SET and the wrapper BODIES — an arm added, removed or renamed on
+// the shared schema would type-check here and refuse at run time — so both
+// are pinned to the generated union below.
+//
+// The arms are mutually exclusive, so each one also declares every OTHER
+// arm's key as an optional `never`. The tag is therefore the arm's REQUIRED
+// key, not any key it mentions — reading `keyof` here would report the whole
+// arm set for every arm and stop discriminating a mis-tagged arm.
+type RequiredKeys<Value> = {
+  [Key in keyof Value]-?: Record<string, never> extends Pick<Value, Key> ? never : Key;
+}[keyof Value];
+type ExternalTag<Arm> = Arm extends string ? Arm : RequiredKeys<Arm>;
+
+type _ProductArmsAreTheGeneratedOnes = Expect<
+  Equal<ExternalTag<BrowserHostRequestedProduct>, NativeHostRequestedProduct["kind"]>
+>;
+type _FrameworkArmsAreTheGeneratedOnes = Expect<
+  Equal<ExternalTag<BrowserHostCompileRequest>, NativeHostCompileRequest["framework"]>
+>;
+
+// The arms are EXCLUSIVE. A plain union would accept an object naming two
+// arms at once — TypeScript's excess-property check does not fire through a
+// union — and the decoder refuses exactly that payload, so a well-typed call
+// would be a guaranteed run-time throw. Both directions are asserted: the
+// multi-arm shapes must be rejected AND the single-arm shapes must still be
+// accepted, else a type that rejects everything would pass the negative legs.
+type _BothFrameworkArmsAreRejected = Expect<
+  Equal<
+    {
+      vue: BrowserHostVueCompileRequest;
+      svelte: BrowserHostSvelteCompileRequest;
+    } extends BrowserHostCompileRequest
+      ? true
+      : false,
+    false
+  >
+>;
+type _OneFrameworkArmIsAccepted = Expect<
+  Equal<
+    { vue: BrowserHostVueCompileRequest } extends BrowserHostCompileRequest ? true : false,
+    true
+  >
+>;
+// Default consumer configs treat an optional property as accepting an
+// explicit `undefined`. The callable route treats those sibling tags as
+// absent, keeping the published declaration and runtime behavior aligned.
+type _UndefinedFrameworkSiblingIsAccepted = Expect<
+  Equal<
+    {
+      vue: BrowserHostVueCompileRequest;
+      svelte: undefined;
+    } extends BrowserHostCompileRequest
+      ? true
+      : false,
+    true
+  >
+>;
+type _TwoProductTagsAreRejected = Expect<
+  Equal<
+    {
+      runtimeClient: NativeHostRuntimeProductOptions;
+      analysis: NativeHostAnalysisProductOptions;
+    } extends BrowserHostRequestedProduct
+      ? true
+      : false,
+    false
+  >
+>;
+type _OneProductTagIsAccepted = Expect<
+  Equal<
+    { runtimeClient: NativeHostRuntimeProductOptions } extends BrowserHostRequestedProduct
+      ? true
+      : false,
+    true
+  >
+>;
+type _UndefinedProductSiblingIsAccepted = Expect<
+  Equal<
+    {
+      runtimeClient: NativeHostRuntimeProductOptions;
+      analysis: undefined;
+    } extends BrowserHostRequestedProduct
+      ? true
+      : false,
+    true
+  >
+>;
+// `products` is excluded on both sides because its ELEMENT type is exactly
+// what differs: the generated arm holds internally-tagged products, this one
+// holds the externally-tagged union pinned below. Every other field — the
+// identity and the framework's whole option surface — must be the generated
+// one verbatim.
+type _VueArmBodyIsTheGeneratedOne = Expect<
+  Equal<
+    Omit<BrowserHostVueCompileRequest, "products">,
+    Omit<NativeHostVueCompileRequest, "framework" | "products">
+  >
+>;
+type _SvelteArmBodyIsTheGeneratedOne = Expect<
+  Equal<
+    Omit<BrowserHostSvelteCompileRequest, "products">,
+    Omit<NativeHostSvelteCompileRequest, "framework" | "products">
+  >
+>;
+// …and the excluded slot is the local union, not something else entirely.
+type _VueArmProductsAreTheLocalUnion = Expect<
+  Equal<BrowserHostVueCompileRequest["products"], BrowserHostRequestedProduct[]>
+>;
+type _SvelteArmProductsAreTheLocalUnion = Expect<
+  Equal<BrowserHostSvelteCompileRequest["products"], BrowserHostRequestedProduct[]>
+>;
+
+// Each externally-tagged product arm carries exactly the generated arm's
+// options — the arm-set check above says the tags line up, not that the
+// payload behind a tag does. EVERY option-carrying arm is listed: the two
+// runtime arms share one option type locally, so a generated schema that
+// gave the server arm its own shape would otherwise type-check here and
+// refuse at run time.
+type ArmOptions<Tag extends string> =
+  Extract<BrowserHostRequestedProduct, Record<Tag, unknown>> extends Record<Tag, infer Options>
+    ? Options
+    : never;
+type GeneratedArmOptions<Tag extends string> = Omit<
+  Extract<NativeHostRequestedProduct, { kind: Tag }>,
+  "kind"
+>;
+
+type _RuntimeClientArmCarriesTheGeneratedOptions = Expect<
+  Equal<ArmOptions<"runtimeClient">, GeneratedArmOptions<"runtimeClient">>
+>;
+type _RuntimeServerArmCarriesTheGeneratedOptions = Expect<
+  Equal<ArmOptions<"runtimeServer">, GeneratedArmOptions<"runtimeServer">>
+>;
+type _IdeCompanionArmCarriesTheGeneratedOptions = Expect<
+  Equal<ArmOptions<"ideCompanion">, GeneratedArmOptions<"ideCompanion">>
+>;
+type _AnalysisArmCarriesTheGeneratedOptions = Expect<
+  Equal<ArmOptions<"analysis">, GeneratedArmOptions<"analysis">>
 >;

--- a/packages/wasm/src/index.ts
+++ b/packages/wasm/src/index.ts
@@ -80,6 +80,32 @@ import type {
   HostVirtualQuery,
 } from "./request-types";
 
+export type {
+  BrowserHostCompileRequest,
+  BrowserHostRequestedProduct,
+  BrowserHostSvelteCompileRequest,
+  BrowserHostVueCompileRequest,
+  HostAnalysisProductOptions,
+  HostCompileIdentity,
+  HostCompileRequestResponse,
+  HostCompiledAnalysisProduct,
+  HostCompiledIdeProduct,
+  HostCompiledProduct,
+  HostCompiledRuntimeProduct,
+  HostCompiledVirtualNode,
+  HostDestructuredBlockMeta,
+  HostIdeProductOptions,
+  HostRuntimeProductOptions,
+  HostSvelteCompileOptions,
+  HostTemplateAnalysisSnapshot,
+  HostVueCompileOptions,
+} from "./compile-request-types";
+
+import type {
+  BrowserHostCompileRequest,
+  HostCompileRequestResponse,
+} from "./compile-request-types";
+
 // =============================================================================
 // WASM binding types
 // =============================================================================
@@ -96,6 +122,10 @@ type WasmHostGetIdeFn = (
   profile?: HostCompileProfile,
 ) => HostIdeResponse | null;
 type WasmHostEnsureIdeCompiledFn = (canonicalId: string, profile?: HostCompileProfile) => boolean;
+type WasmHostCompileRequestFn = (
+  canonicalId: string,
+  request: BrowserHostCompileRequest,
+) => HostCompileRequestResponse;
 type WasmHostGetAnalysisFn = (canonicalOrAlias: string) => unknown | null;
 type WasmHostSetImportDependenciesFn = (
   canonicalOrAlias: string,
@@ -121,6 +151,7 @@ interface WasmHostBinding {
   applyBlockOverrides: WasmHostApplyBlockOverridesFn;
   getIde: WasmHostGetIdeFn;
   ensureIdeCompiled: WasmHostEnsureIdeCompiledFn;
+  compileRequest: WasmHostCompileRequestFn;
   getVirtualFile: WasmHostGetVirtualFileFn;
   listVirtualFiles: WasmHostListVirtualFilesFn;
   remove: WasmHostRemoveFn;
@@ -214,6 +245,47 @@ export class Host {
    */
   ensureIdeCompiled(canonicalId: string, profile?: HostCompileProfile): boolean {
     return this.inner.ensureIdeCompiled(canonicalId, profile);
+  }
+
+  /**
+   * Execute one typed compile request against an already-registered source.
+   *
+   * The whole transaction is one call: `upsert` the carrier once, source
+   * only, then hand this the canonical id and the request. There is no
+   * ensure-then-read pair to order correctly and no boolean to interpret.
+   *
+   * The request is the demand document end to end — its product set is what
+   * gets compiled, and no compile profile is built from it on any path. The
+   * source is never copied into it.
+   *
+   * Returns every requested product, in request order, each row tagged with
+   * the same `kind` spelling the request used. This route can produce
+   * `runtimeClient`, `runtimeServer`, `ideCompanion`, and `analysis`.
+   * `publicApi` and `declarations` remain shared-schema arms but are refused
+   * for both frameworks.
+   *
+   * Diagnostic spans and destructured binding source spans are UTF-16
+   * offsets into the registered source. Destructured block bounds are
+   * UTF-16 offsets into the IDE row's generated `code`; the `analysis` row's
+   * own spans are UTF-8 byte offsets into the source, exactly as
+   * `getAnalysis()` publishes them.
+   *
+   * Every call is a COMPLETE compile: this route consults and publishes no
+   * compile cache slot, so two identical calls compile twice. A per-keystroke
+   * loop that only needs the IDE surface should stay on the cached
+   * `ensureIdeCompiled()` / `getIde()` pair; reach for this when the demand
+   * is a fresh multi-product compile.
+   *
+   * Complete-only: a payload the schema refuses, a request the compiler
+   * refuses, a framework arm the registered carrier contradicts, an
+   * unproducible product, or an execution refusal all THROW the refusal
+   * message as a string — never a partial result, a `null`, or a boolean.
+   */
+  compileRequest(
+    canonicalId: string,
+    request: BrowserHostCompileRequest,
+  ): HostCompileRequestResponse {
+    return this.inner.compileRequest(canonicalId, request);
   }
 
   /**

--- a/packages/wasm/tsconfig.types.json
+++ b/packages/wasm/tsconfig.types.json
@@ -4,8 +4,14 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "exactOptionalPropertyTypes": false,
     "noEmit": true,
     "skipLibCheck": false
   },
-  "files": ["src/handoff-types.ts", "src/request-types.ts", "src/index.test-d.ts"]
+  "files": [
+    "src/handoff-types.ts",
+    "src/request-types.ts",
+    "src/compile-request-types.ts",
+    "src/index.test-d.ts"
+  ]
 }

--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -106,7 +106,7 @@ schema = 2
 "CCA1O3A" = { status = "pending" }
 "CCA1O3B" = { status = "pending" }
 "CCA1O3C" = { status = "implemented", commit_message = "feat(ci): execute the wasm JavaScript-boundary tests in the canonical gate", commit_date = "2026-09-01T02:10:00+01:00" }
-"CCA1O3D" = { status = "pending" }
+"CCA1O3D" = { status = "implemented", commit_message = "feat(wasm): expose a callable typed compile request on the browser host", commit_date = "2026-09-02T12:00:00+01:00", pull_request = 469 }
 "CCA1O3E" = { status = "implemented", commit_message = "test(*): check the committed carrier fixtures against the built wasm host", commit_date = "2026-09-01T09:00:00+01:00" }
 "CCA1O4" = { status = "pending" }
 "CCA1O4D" = { status = "pending" }


### PR DESCRIPTION
Autonomous candidate for one roadmap block.

Do not merge manually: the TAMA controller owns landing.

---
Closes #458


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser support for typed multi-product compilation through `Host.compileRequest()`.
  * Added Vue and Svelte request types with runtime, IDE, and analysis response data.
  * Added diagnostics, UTF-16 source mappings, virtual-node metadata, and refusal errors to compile responses.
  * Added generated API bindings and comprehensive TypeScript type exports.

* **Documentation**
  * Documented browser compile requests, responses, supported products, and usage guidance.

* **Tests**
  * Added coverage for browser invocation, response payloads, diagnostics, mappings, product handling, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->