### PR TITLE
feat(session): flow-return partiality audit projection

### DIFF
--- a/.claude/skills/audit-infrastructure/SKILL.md
+++ b/.claude/skills/audit-infrastructure/SKILL.md
@@ -81,8 +81,8 @@ entry `VerterHost::get_flow_return_type_with_audit(function, demand)`
 `AuditedResult<Arc<FlowReturnResult>, FlowReturnError>` — the carrier's
 `audit` field is populated on BOTH arms. `FlowReturnInferencePayload`
 (`crates/verter_audit/src/payloads/flow_return.rs`) carries
-`function_symbol` plus three per-request counters mirroring the cold-path
-structured events one to one:
+`function_symbol`, three per-request counters mirroring the cold-path
+structured events one to one, and the typed partiality reason:
 
 | Counter | Paired structured event | Bumped when |
 | --- | --- | --- |
@@ -90,13 +90,50 @@ structured events one to one:
 | `budget_exceeded_events` | `FlowSliceBudgetExceeded { axis: FlowSliceBudgetAxisTag }` | a flow-slice budget refusal routes through `ReturnOnly` |
 | `cycle_reentry_holds` | `FlowCycleSentinelHit` | a coinductive re-entry hold is recorded on the shared obligation runtime |
 
+The counters report THAT a request did cold work, hit a budget, or held
+on a cycle. `partiality: Option<FlowPartialityTag>` reports WHY it came
+back incomplete, and is `None` for the complete, warm-admissible outcome
+(and on the default-filled filtered / audit-disabled record, where no
+payload was collected at all):
+
+| Arm | Carries | Populated from |
+| --- | --- | --- |
+| `FlowPartialityTag::Degraded(FlowDegradationTag)` | the degraded-but-usable `Ok` outcome's reason | `FlowReturnResult::degradation()` |
+| `FlowPartialityTag::NoValue(FlowFailureTag)` | the `Err` outcome's no-value reason | the typed `FlowReturnError` |
+
+`FlowDegradationTag` and `FlowFailureTag` are CLOSED MIRRORS of the
+session's `FlowReturnDegradation` / `FlowGap` and `FlowReturnFailure`
+vocabularies, so the leaf audit substrate keeps no back-edge to
+`verter_session`. Both flatten their domain's nested closed enums —
+`FlowReturnDegradation::FlowGap(_)` reduces through the gap variant
+(`GapGuardNarrowing`, `GapNominalRelation`, `GapClosureCapture`,
+`GapAbruptCompletion`, `GapUnmodeledExpression`), and
+`FlowReturnFailure`'s `Unsupported` / `CallResolution` / `Budget` arms
+reduce through their inner reason (`UnsupportedLoop`, `CallUndecidable`,
+`BudgetWorkExceeded`, …) — so every distinct reason keeps its own wire
+spelling instead of collapsing into a catch-all bucket. `FlowFailureTag`
+additionally carries `UnstableState` for the host's own
+`FlowReturnError::UnstableState` refusal, so the `Err` arm never reports
+an unexplained no-value.
+
+The projection lives at the ONE producer,
+`observed_partiality` in `crates/verter_session/src/host_flow_return_audit.rs`,
+and maps through exhaustive matches (a new domain variant is a compile
+error, never a silently collapsed reason). It is READ-ONLY telemetry: it
+runs after the outcome is bound, and no admission decision, warm/cold
+classification, or cache identity reads it back.
+
 Cold-vs-warm contract: a warm family hit emits NO `FlowReturnStarted` and
 bumps NO counter (`cold_computes == 0` is the counter-side witness), and
-allocates no audit payload without an active accumulator. Guards:
+allocates no audit payload without an active accumulator. A degraded
+success never warms at all, so it reports its partiality on every call.
+Guards:
 `crates/verter_session/tests/cases/g_type/flow_return_audit_contract.rs`
-(cold/warm event + payload contract) and
+(cold/warm event + payload contract, the partial-vs-complete partiality
+contract, and the audited-vs-unaudited admission equivalence) and
 `crates/verter_session/tests/cases/g_misc0/flow_return_audit_tls_propagation.rs`
-(TLS observer propagation across the dispatch's worker hops).
+(TLS observer propagation across the dispatch's worker hops); the wire
+surface is pinned by `crates/verter_audit/tests/cases/ts_bindings.rs`.
 
 ## `AuditedResult<T, E>` Carrier
 

--- a/.claude/skills/audit-infrastructure/SKILL.md
+++ b/.claude/skills/audit-infrastructure/SKILL.md
@@ -101,6 +101,12 @@ payload was collected at all):
 | `FlowPartialityTag::Degraded(FlowDegradationTag)` | the degraded-but-usable `Ok` outcome's reason | `FlowReturnResult::degradation()` |
 | `FlowPartialityTag::NoValue(FlowFailureTag)` | the `Err` outcome's no-value reason | the typed `FlowReturnError` |
 
+`partiality` reports exactly ONE reason, never a set: the producer's
+typed outcome already reduced every observed gap to the FIRST in source
+order, so a function carrying several distinct gaps still names only the
+earliest. Read it as "the reason this request was partial", never as
+"the complete inventory of what is missing".
+
 `FlowDegradationTag` and `FlowFailureTag` are CLOSED MIRRORS of the
 session's `FlowReturnDegradation` / `FlowGap` and `FlowReturnFailure`
 vocabularies, so the leaf audit substrate keeps no back-edge to
@@ -130,7 +136,10 @@ success never warms at all, so it reports its partiality on every call.
 Guards:
 `crates/verter_session/tests/cases/g_type/flow_return_audit_contract.rs`
 (cold/warm event + payload contract, the partial-vs-complete partiality
-contract, and the audited-vs-unaudited admission equivalence) and
+contract, and the filter-driven projected-vs-unprojected equivalence —
+denying `KindBit::FlowReturnInference` takes the `Noop` arm and removes
+the projection outright, and the served value, degradation verdict and
+warm/cold sequence are unchanged) and
 `crates/verter_session/tests/cases/g_misc0/flow_return_audit_tls_propagation.rs`
 (TLS observer propagation across the dispatch's worker hops); the wire
 surface is pinned by `crates/verter_audit/tests/cases/ts_bindings.rs`.

--- a/crates/verter_audit/src/lib.rs
+++ b/crates/verter_audit/src/lib.rs
@@ -111,9 +111,9 @@ pub use payloads::tags::{
 };
 pub use payloads::{
     AuditDiagnosticEntry, AuditDiagnosticKind, BundlerBatchPayload, CompilePayload,
-    ComponentMetaPayload, FlowReturnInferencePayload, LspRequestPayload, McpToolPayload,
-    SemanticAnalysisPayload, SlowRecordSummary, TypeResolutionPayload, WorkspaceOp,
-    WorkspacePayload,
+    ComponentMetaPayload, FlowDegradationTag, FlowFailureTag, FlowPartialityTag,
+    FlowReturnInferencePayload, LspRequestPayload, McpToolPayload, SemanticAnalysisPayload,
+    SlowRecordSummary, TypeResolutionPayload, WorkspaceOp, WorkspacePayload,
 };
 pub use record::{
     AuditCaptureState, Hash16, IncidentalFields, RequestAuditRecord, RequestKind,

--- a/crates/verter_audit/src/payloads/flow_return.rs
+++ b/crates/verter_audit/src/payloads/flow_return.rs
@@ -27,6 +27,12 @@ use serde::{Deserialize, Serialize};
 /// rides the `Err` arm. A request that produced a complete, non-degraded
 /// value carries no partiality at all
 /// ([`FlowReturnInferencePayload::partiality`] is `None`).
+///
+/// Exactly ONE reason is reported, never a set. The producer's typed
+/// outcome already reduced every observed gap to the FIRST one in
+/// source order, so a function carrying several distinct gaps still
+/// names only the earliest. Read the tag as "the reason this request
+/// was partial", never as "the complete inventory of what is missing".
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ts_rs::TS)]
 #[ts(export_to = "audit.generated.ts")]
 pub enum FlowPartialityTag {
@@ -45,12 +51,11 @@ pub enum FlowPartialityTag {
 /// The domain's `FlowGap(_)` arm is reduced through its own gap variant,
 /// so each detected flow-model gap keeps a distinct wire spelling
 /// instead of collapsing into one "gap" bucket.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ts_rs::TS)]
 #[ts(export_to = "audit.generated.ts")]
 pub enum FlowDegradationTag {
     /// A guard's subject arms could not be enumerated or classified, so
     /// the narrow retained a superset (`FlowGap::GuardNarrowing`).
-    #[default]
     GapGuardNarrowing,
     /// A nominal relation the flow model does not decide
     /// (`FlowGap::NominalRelation`).
@@ -99,11 +104,10 @@ pub enum FlowDegradationTag {
 /// enum (`Unsupported`, `CallResolution`, `Budget`) are reduced through
 /// that inner variant, so every distinct no-value reason keeps its own
 /// wire spelling.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ts_rs::TS)]
 #[ts(export_to = "audit.generated.ts")]
 pub enum FlowFailureTag {
     /// The function position has no served body.
-    #[default]
     Missing,
     /// A loop whose statement subtree contains a `return`.
     UnsupportedLoop,

--- a/crates/verter_audit/src/payloads/flow_return.rs
+++ b/crates/verter_audit/src/payloads/flow_return.rs
@@ -3,12 +3,149 @@
 //! [`crate::record::RequestKind::FlowReturnInference`] records.
 //!
 //! Populated by the session-side flow-return audited entry-point from
-//! per-request counters bumped at the cold-path emission sites. Every
-//! field is producer-populated per request; none is a reserved slot.
+//! per-request counters bumped at the cold-path emission sites, plus
+//! the typed partiality reason read off the outcome the evaluator
+//! already produced. Every field is producer-populated per request;
+//! none is a reserved slot.
+//!
+//! The tag enums below are CLOSED MIRRORS of the session-side flow
+//! vocabulary (`FlowGap`, `FlowReturnDegradation`,
+//! `FlowReturnFailure`). They live here so the leaf audit substrate
+//! stays free of a back-edge to `verter_session`; the producer maps its
+//! domain enums onto them at the one audit emission boundary
+//! (`VerterHost::get_flow_return_type_with_audit`) through exhaustive
+//! matches, so a new domain variant is a compile error rather than a
+//! silently collapsed reason.
 
 use serde::{Deserialize, Serialize};
 
-/// Per-request counters for one flow-return inference request.
+/// Why a flow-return request was not a clean, complete value.
+///
+/// The two arms mirror the audited entry-point's split result/carrier
+/// contract exactly: a DEGRADED SUCCESS is a usable value that refuses
+/// warm admission and rides the carrier's `Ok` arm; a NO-VALUE outcome
+/// rides the `Err` arm. A request that produced a complete, non-degraded
+/// value carries no partiality at all
+/// ([`FlowReturnInferencePayload::partiality`] is `None`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ts_rs::TS)]
+#[ts(export_to = "audit.generated.ts")]
+pub enum FlowPartialityTag {
+    /// The evaluation produced a USABLE value that is nonetheless
+    /// incomplete — the typed degradation reason attached to the `Ok`
+    /// outcome. Never warm-admitted.
+    Degraded(FlowDegradationTag),
+    /// The evaluation produced NO value — the typed reason on the `Err`
+    /// outcome.
+    NoValue(FlowFailureTag),
+}
+
+/// Closed mirror of the session's `FlowReturnDegradation` — the reason a
+/// usable flow-return value is incomplete.
+///
+/// The domain's `FlowGap(_)` arm is reduced through its own gap variant,
+/// so each detected flow-model gap keeps a distinct wire spelling
+/// instead of collapsing into one "gap" bucket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize, ts_rs::TS)]
+#[ts(export_to = "audit.generated.ts")]
+pub enum FlowDegradationTag {
+    /// A guard's subject arms could not be enumerated or classified, so
+    /// the narrow retained a superset (`FlowGap::GuardNarrowing`).
+    #[default]
+    GapGuardNarrowing,
+    /// A nominal relation the flow model does not decide
+    /// (`FlowGap::NominalRelation`).
+    GapNominalRelation,
+    /// A captured binding whose post-capture writes the model does not
+    /// track (`FlowGap::ClosureCapture`).
+    GapClosureCapture,
+    /// An abrupt completion crossing the modeled region
+    /// (`FlowGap::AbruptCompletion`).
+    GapAbruptCompletion,
+    /// An expression form the flow model does not represent
+    /// (`FlowGap::UnmodeledExpression`).
+    GapUnmodeledExpression,
+    /// A call on a binding that is neither callable nor `any` evaluated
+    /// to `any`.
+    NonCallableBinding,
+    /// A symbolic call carrier whose callee could not be represented or
+    /// resolved to a signature evaluated to `any`.
+    UnrepresentableCallee,
+    /// A binding whose initializer failed with a typed flow failure was
+    /// observed; the observation evaluated to `any`.
+    FailedBindingInitializer,
+    /// A whole-slot write effect the evaluator did not apply, so the
+    /// value may miss the assignment's narrowing.
+    UnappliedWriteEffect,
+    /// A function-scoped (`var`) binding defined inside a conditional
+    /// arm was observed after the arms rejoin, without branch-join
+    /// algebra over it.
+    ConditionalVarDefinition,
+    /// An annotated declarator's declared union could not be reduced to
+    /// the constituents its initializer selects; the binding holds the
+    /// whole declared union.
+    UnreducedDeclaredUnion,
+    /// The evaluated value reaches a semantic-miss carrier — an honest
+    /// local answer that is not a complete result.
+    UnresolvedValue,
+    /// A sub-expression position contributed the typed unresolved
+    /// marker and the enclosing structure composed around it.
+    UnmodeledPosition,
+}
+
+/// Closed mirror of the session's no-value flow-return reasons — the
+/// `FlowReturnFailure` class plus the host's own unstable-view refusal.
+///
+/// The three `FlowReturnFailure` variants that nest a further closed
+/// enum (`Unsupported`, `CallResolution`, `Budget`) are reduced through
+/// that inner variant, so every distinct no-value reason keeps its own
+/// wire spelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize, ts_rs::TS)]
+#[ts(export_to = "audit.generated.ts")]
+pub enum FlowFailureTag {
+    /// The function position has no served body.
+    #[default]
+    Missing,
+    /// A loop whose statement subtree contains a `return`.
+    UnsupportedLoop,
+    /// A `break` / `continue` crossing the modeled region.
+    UnsupportedJump,
+    /// A directly invoked closure statement whose captured flow effect
+    /// the sequential statement evaluator does not represent.
+    UnsupportedInvokedClosureEffect,
+    /// A `with` statement.
+    UnsupportedWith,
+    /// A module-level statement inside the body.
+    UnsupportedModuleDeclaration,
+    /// An in-flight dependency could not be decided (a torn view, a
+    /// missing non-cycle edge, or a nonconverging recursive component).
+    Unresolved,
+    /// The recursive component has no concrete semantic seed.
+    EmptyCycle,
+    /// The demanded `(demand, input)` point is beyond the whole-return /
+    /// empty-input point the evaluation models.
+    UnmodeledDemandPoint,
+    /// A call in the body had no signature in the requested bucket.
+    CallNotCallable,
+    /// Every visible call candidate was definitely inapplicable.
+    CallNoApplicableOverload,
+    /// Call applicability depended on unsupported or unresolved work.
+    CallUndecidable,
+    /// The call-resolution work envelope tripped.
+    CallBudget,
+    /// A depth budget stopped the evaluation.
+    BudgetDepthExceeded,
+    /// A work budget stopped the evaluation (the shallow expression
+    /// lowering's work budget, or the obligation runtime's
+    /// connected-demand cap surfaced as the work budget).
+    BudgetWorkExceeded,
+    /// The host could not pin a proven-current store view within the
+    /// bounded retry window, so the query was not resolved against
+    /// superseded state.
+    UnstableState,
+}
+
+/// Per-request counters and the typed partiality reason for one
+/// flow-return inference request.
 ///
 /// The three counters mirror the cold-path structured events one to
 /// one: each cold whole-function evaluation bumps `cold_computes`
@@ -19,6 +156,13 @@ use serde::{Deserialize, Serialize};
 /// `FlowCycleSentinelHit`). A warm family hit bumps nothing — the
 /// cold-vs-warm audit contract's counter-side witness is
 /// `cold_computes == 0`.
+///
+/// The counters report THAT a request did cold work, hit a budget, or
+/// held on a cycle; [`Self::partiality`] reports WHY the request came
+/// back degraded or with no value at all. It is read-only telemetry
+/// derived from the outcome the evaluator already produced — no
+/// admission decision, warm/cold classification, or cache identity
+/// consults it.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ts_rs::TS)]
 #[ts(export_to = "audit.generated.ts")]
 pub struct FlowReturnInferencePayload {
@@ -34,4 +178,10 @@ pub struct FlowReturnInferencePayload {
     /// Number of coinductive re-entry holds recorded on the shared
     /// obligation runtime (the flow-cycle sentinel).
     pub cycle_reentry_holds: u32,
+    /// Why the request was partial: the typed degradation reason on a
+    /// degraded-but-usable value, or the typed no-value reason on a
+    /// refusal. `None` is the complete, warm-admissible outcome — and
+    /// also the default-filled value on the filtered / audit-disabled
+    /// record, where no payload was collected at all.
+    pub partiality: Option<FlowPartialityTag>,
 }

--- a/crates/verter_audit/src/payloads/mod.rs
+++ b/crates/verter_audit/src/payloads/mod.rs
@@ -23,7 +23,9 @@ pub mod workspace;
 pub use bundler::{BundlerBatchPayload, SlowRecordSummary};
 pub use compile::CompilePayload;
 pub use component_meta::{AuditDiagnosticEntry, AuditDiagnosticKind, ComponentMetaPayload};
-pub use flow_return::FlowReturnInferencePayload;
+pub use flow_return::{
+    FlowDegradationTag, FlowFailureTag, FlowPartialityTag, FlowReturnInferencePayload,
+};
 pub use lsp::{LspRequestPayload, PositionInfo};
 pub use mcp::McpToolPayload;
 pub use semantic::SemanticAnalysisPayload;

--- a/crates/verter_audit/tests/cases/ts_bindings.rs
+++ b/crates/verter_audit/tests/cases/ts_bindings.rs
@@ -184,3 +184,84 @@ fn typeinfo_graph_payload_carries_every_documented_exactness_status() {
         "ExactnessTag must enumerate every closed status — missing: {missing:?}",
     );
 }
+
+#[test]
+fn flow_return_payload_exposes_its_typed_partiality_reason() {
+    let ts = read_audit_generated_ts();
+    assert!(
+        ts.contains("partiality: FlowPartialityTag | null"),
+        "FlowReturnInferencePayload must expose the typed partiality reason \
+         alongside its occurrence counters",
+    );
+    assert!(
+        ts.contains(
+            "export type FlowPartialityTag = { \"Degraded\": FlowDegradationTag } \
+             | { \"NoValue\": FlowFailureTag }"
+        ),
+        "FlowPartialityTag must split the degraded-but-usable arm from the \
+         no-value arm, each carrying its own closed reason tag",
+    );
+}
+
+/// Every flow-model gap, degradation, and no-value reason keeps a
+/// distinct wire spelling — no collapsed catch-all bucket, and no
+/// `Debug`-formatted string.
+///
+/// Discriminator: fold any two reasons onto one tag (or replace a nested
+/// `Unsupported` / `CallResolution` / `Budget` arm with a single bucket)
+/// and the corresponding name disappears from the generated union.
+#[test]
+fn flow_partiality_tags_enumerate_every_closed_reason() {
+    let ts = read_audit_generated_ts();
+    let expected = [
+        // Every `FlowGap` variant, reduced into the degradation tag.
+        "GapGuardNarrowing",
+        "GapNominalRelation",
+        "GapClosureCapture",
+        "GapAbruptCompletion",
+        "GapUnmodeledExpression",
+        // The remaining `FlowReturnDegradation` variants.
+        "NonCallableBinding",
+        "UnrepresentableCallee",
+        "FailedBindingInitializer",
+        "UnappliedWriteEffect",
+        "ConditionalVarDefinition",
+        "UnreducedDeclaredUnion",
+        "UnresolvedValue",
+        "UnmodeledPosition",
+        // Every `FlowReturnFailure` variant, nested reasons included.
+        "UnsupportedLoop",
+        "UnsupportedJump",
+        "UnsupportedInvokedClosureEffect",
+        "UnsupportedWith",
+        "UnsupportedModuleDeclaration",
+        "EmptyCycle",
+        "UnmodeledDemandPoint",
+        "CallNotCallable",
+        "CallNoApplicableOverload",
+        "CallUndecidable",
+        "CallBudget",
+        "BudgetDepthExceeded",
+        "BudgetWorkExceeded",
+        "UnstableState",
+    ];
+    let degradation = ts
+        .split_once("export type FlowDegradationTag = ")
+        .map(|(_, rest)| rest.split_once(';').map(|(line, _)| line).unwrap_or(rest))
+        .expect("audit.generated.ts must export FlowDegradationTag")
+        .to_string();
+    let failure = ts
+        .split_once("export type FlowFailureTag = ")
+        .map(|(_, rest)| rest.split_once(';').map(|(line, _)| line).unwrap_or(rest))
+        .expect("audit.generated.ts must export FlowFailureTag")
+        .to_string();
+    let unions = format!("{degradation}{failure}");
+    let missing: Vec<&str> = expected
+        .into_iter()
+        .filter(|reason| !unions.contains(&format!("\"{reason}\"")))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "the flow partiality tags must spell out every closed reason — missing: {missing:?}",
+    );
+}

--- a/crates/verter_audit/tests/cases/ts_bindings.rs
+++ b/crates/verter_audit/tests/cases/ts_bindings.rs
@@ -207,20 +207,24 @@ fn flow_return_payload_exposes_its_typed_partiality_reason() {
 /// distinct wire spelling — no collapsed catch-all bucket, and no
 /// `Debug`-formatted string.
 ///
-/// Discriminator: fold any two reasons onto one tag (or replace a nested
-/// `Unsupported` / `CallResolution` / `Budget` arm with a single bucket)
-/// and the corresponding name disappears from the generated union.
+/// The comparison is EXACT SET EQUALITY against the generated unions,
+/// not a containment check, so it discriminates drift in BOTH
+/// directions: folding two reasons onto one tag (or replacing a nested
+/// `Unsupported` / `CallResolution` / `Budget` arm with a single
+/// bucket) drops a member and fails; adding a reason to the Rust enum
+/// without recording its wire spelling here adds an unlisted member
+/// and fails.
 #[test]
 fn flow_partiality_tags_enumerate_every_closed_reason() {
     let ts = read_audit_generated_ts();
-    let expected = [
-        // Every `FlowGap` variant, reduced into the degradation tag.
+    // Every `FlowGap` variant, reduced into the degradation tag,
+    // followed by the remaining `FlowReturnDegradation` variants.
+    let expected_degradation = [
         "GapGuardNarrowing",
         "GapNominalRelation",
         "GapClosureCapture",
         "GapAbruptCompletion",
         "GapUnmodeledExpression",
-        // The remaining `FlowReturnDegradation` variants.
         "NonCallableBinding",
         "UnrepresentableCallee",
         "FailedBindingInitializer",
@@ -229,12 +233,19 @@ fn flow_partiality_tags_enumerate_every_closed_reason() {
         "UnreducedDeclaredUnion",
         "UnresolvedValue",
         "UnmodeledPosition",
-        // Every `FlowReturnFailure` variant, nested reasons included.
+    ];
+    // Every `FlowReturnFailure` variant with its nested `Unsupported` /
+    // `CallResolution` / `Budget` reasons expanded, plus the host's own
+    // unstable-view refusal (`UnstableState`), which is not a
+    // `FlowReturnFailure` variant but shares the no-value tag.
+    let expected_failure = [
+        "Missing",
         "UnsupportedLoop",
         "UnsupportedJump",
         "UnsupportedInvokedClosureEffect",
         "UnsupportedWith",
         "UnsupportedModuleDeclaration",
+        "Unresolved",
         "EmptyCycle",
         "UnmodeledDemandPoint",
         "CallNotCallable",
@@ -245,23 +256,40 @@ fn flow_partiality_tags_enumerate_every_closed_reason() {
         "BudgetWorkExceeded",
         "UnstableState",
     ];
-    let degradation = ts
-        .split_once("export type FlowDegradationTag = ")
-        .map(|(_, rest)| rest.split_once(';').map(|(line, _)| line).unwrap_or(rest))
-        .expect("audit.generated.ts must export FlowDegradationTag")
-        .to_string();
-    let failure = ts
-        .split_once("export type FlowFailureTag = ")
-        .map(|(_, rest)| rest.split_once(';').map(|(line, _)| line).unwrap_or(rest))
-        .expect("audit.generated.ts must export FlowFailureTag")
-        .to_string();
-    let unions = format!("{degradation}{failure}");
-    let missing: Vec<&str> = expected
-        .into_iter()
-        .filter(|reason| !unions.contains(&format!("\"{reason}\"")))
+
+    for (union_name, expected) in [
+        ("FlowDegradationTag", expected_degradation.as_slice()),
+        ("FlowFailureTag", expected_failure.as_slice()),
+    ] {
+        let members = string_union_members(&ts, union_name);
+        let mut expected_sorted: Vec<String> =
+            expected.iter().map(|name| (*name).to_string()).collect();
+        expected_sorted.sort_unstable();
+        assert_eq!(
+            members, expected_sorted,
+            "{union_name} must spell out exactly the closed reason set: a \
+             missing member is a collapsed reason, an extra member is a new \
+             reason whose wire spelling was never recorded",
+        );
+    }
+}
+
+/// Extract the sorted member names of a generated string-literal union
+/// (`export type Name = "A" | "B";`).
+fn string_union_members(ts: &str, union_name: &str) -> Vec<String> {
+    let needle = format!("export type {union_name} = ");
+    let rest = ts
+        .split_once(&needle)
+        .unwrap_or_else(|| panic!("audit.generated.ts must export {union_name}"))
+        .1;
+    let decl = rest
+        .split_once(';')
+        .unwrap_or_else(|| panic!("{union_name} declaration must be terminated"))
+        .0;
+    let mut members: Vec<String> = decl
+        .split('|')
+        .map(|member| member.trim().trim_matches('"').to_string())
         .collect();
-    assert!(
-        missing.is_empty(),
-        "the flow partiality tags must spell out every closed reason — missing: {missing:?}",
-    );
+    members.sort_unstable();
+    members
 }

--- a/crates/verter_session/src/host_flow_return_audit.rs
+++ b/crates/verter_session/src/host_flow_return_audit.rs
@@ -22,12 +22,23 @@
 //! `from_cache = true` with `cold_computes == 0`; the cold-path
 //! emission helpers construct no event payload without an installed
 //! accumulator (see [`crate::flow_return_audit`]).
+//!
+//! Partiality projection: `observed_partiality` reduces the outcome's
+//! OWN typed reason — the [`FlowReturnResult::degradation`] the
+//! finalizer refused to seal, or the [`FlowReturnError`] on the `Err`
+//! arm — onto the payload's `partiality` field, so a caller reading the
+//! record sees WHY a request was partial, not only THAT it was. This is
+//! the SOLE projection of that vocabulary onto the wire surface, and it
+//! is read-only: the outcome is already bound when it runs, and nothing
+//! in admission, warm/cold classification, or cache identity reads it
+//! back.
 
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use verter_audit::{
-    AuditedResult, FlowReturnInferencePayload, RequestAuditRecord, RequestKind, RequestKindPayload,
+    AuditedResult, FlowDegradationTag, FlowFailureTag, FlowPartialityTag,
+    FlowReturnInferencePayload, RequestAuditRecord, RequestKind, RequestKindPayload,
     RequestMemoryAudit, RequestStoreAudit, RequestTimingAudit, WaitAudit,
 };
 
@@ -35,7 +46,10 @@ use crate::host_audit_runtime::AuditRequestRegistration;
 use crate::instant::Instant;
 use crate::project_semantic_dispatch::ProjectSemanticDispatch;
 use crate::request_context::{RequestContext, RequestContextGuard};
-use crate::semantic_query::{FlowReturnFailure, FlowReturnResult, ReturnProjectionDemand};
+use crate::semantic_query::{
+    FlowGap, FlowReturnDegradation, FlowReturnFailure, FlowReturnResult, FlowReturnUnsupported,
+    ResolveCallFailure, ReturnProjectionDemand,
+};
 use crate::VerterHost;
 
 /// Typed `Err` arm of the flow-return [`AuditedResult`] carrier —
@@ -195,6 +209,7 @@ impl VerterHost {
             cold_computes,
             budget_exceeded_events: ctx.flow_return_budget_exceeded.load(Ordering::Relaxed),
             cycle_reentry_holds: ctx.flow_return_cycle_reentries.load(Ordering::Relaxed),
+            partiality: observed_partiality(&outcome),
         };
         // Cold-vs-warm contract, counter side: a request that produced
         // a value with ZERO cold evaluations was served warm.
@@ -253,6 +268,102 @@ impl VerterHost {
         let cloned = record.clone();
         registration.finalize(record);
         audited_from_outcome(outcome, cloned)
+    }
+}
+
+/// Project the outcome's OWN typed partiality reason onto the audit
+/// payload — the single observability projection of the flow
+/// vocabulary, and a pure read.
+///
+/// It reads the reason the evaluator and the finalizer already certified
+/// ([`FlowReturnResult::degradation`] on the usable arm, the typed
+/// [`FlowReturnError`] on the no-value arm); it never re-derives one,
+/// infers one from text, or guesses. Nothing here feeds admission: the
+/// outcome is already bound, `from_cache` is computed from the cold
+/// counter, and the returned tag is written into the audit record only.
+///
+/// `None` is the complete, warm-admissible outcome.
+fn observed_partiality(
+    outcome: &Result<Arc<FlowReturnResult>, FlowReturnError>,
+) -> Option<FlowPartialityTag> {
+    match outcome {
+        Ok(result) => result
+            .degradation()
+            .map(|reason| FlowPartialityTag::Degraded(degradation_tag(reason))),
+        Err(FlowReturnError::Failure(failure)) => {
+            Some(FlowPartialityTag::NoValue(failure_tag(*failure)))
+        }
+        Err(FlowReturnError::UnstableState { .. }) => {
+            Some(FlowPartialityTag::NoValue(FlowFailureTag::UnstableState))
+        }
+    }
+}
+
+/// Map one typed degradation reason onto its closed wire tag.
+///
+/// EXHAUSTIVE, with no wildcard arm and no `Debug` formatting: a new
+/// [`FlowReturnDegradation`] or [`FlowGap`] variant fails to compile
+/// here rather than silently collapsing into an existing bucket.
+fn degradation_tag(degradation: FlowReturnDegradation) -> FlowDegradationTag {
+    match degradation {
+        FlowReturnDegradation::FlowGap(gap) => match gap {
+            FlowGap::GuardNarrowing => FlowDegradationTag::GapGuardNarrowing,
+            FlowGap::NominalRelation => FlowDegradationTag::GapNominalRelation,
+            FlowGap::ClosureCapture => FlowDegradationTag::GapClosureCapture,
+            FlowGap::AbruptCompletion => FlowDegradationTag::GapAbruptCompletion,
+            FlowGap::UnmodeledExpression => FlowDegradationTag::GapUnmodeledExpression,
+        },
+        FlowReturnDegradation::NonCallableBinding => FlowDegradationTag::NonCallableBinding,
+        FlowReturnDegradation::UnrepresentableCallee => FlowDegradationTag::UnrepresentableCallee,
+        FlowReturnDegradation::FailedBindingInitializer => {
+            FlowDegradationTag::FailedBindingInitializer
+        }
+        FlowReturnDegradation::UnappliedWriteEffect => FlowDegradationTag::UnappliedWriteEffect,
+        FlowReturnDegradation::ConditionalVarDefinition => {
+            FlowDegradationTag::ConditionalVarDefinition
+        }
+        FlowReturnDegradation::UnreducedDeclaredUnion => FlowDegradationTag::UnreducedDeclaredUnion,
+        FlowReturnDegradation::UnresolvedValue => FlowDegradationTag::UnresolvedValue,
+        FlowReturnDegradation::UnmodeledPosition => FlowDegradationTag::UnmodeledPosition,
+    }
+}
+
+/// Map one typed no-value failure onto its closed wire tag.
+///
+/// EXHAUSTIVE through the nested closed enums too, so `Unsupported`,
+/// `CallResolution` and `Budget` each surface WHICH inner reason
+/// stopped the evaluation instead of one collapsed bucket.
+fn failure_tag(failure: FlowReturnFailure) -> FlowFailureTag {
+    match failure {
+        FlowReturnFailure::Missing => FlowFailureTag::Missing,
+        FlowReturnFailure::Unsupported(unsupported) => match unsupported {
+            FlowReturnUnsupported::Loop => FlowFailureTag::UnsupportedLoop,
+            FlowReturnUnsupported::Jump => FlowFailureTag::UnsupportedJump,
+            FlowReturnUnsupported::InvokedClosureEffect => {
+                FlowFailureTag::UnsupportedInvokedClosureEffect
+            }
+            FlowReturnUnsupported::With => FlowFailureTag::UnsupportedWith,
+            FlowReturnUnsupported::ModuleDeclaration => {
+                FlowFailureTag::UnsupportedModuleDeclaration
+            }
+        },
+        FlowReturnFailure::Unresolved => FlowFailureTag::Unresolved,
+        FlowReturnFailure::EmptyCycle => FlowFailureTag::EmptyCycle,
+        FlowReturnFailure::UnmodeledDemandPoint => FlowFailureTag::UnmodeledDemandPoint,
+        FlowReturnFailure::CallResolution(call) => match call {
+            ResolveCallFailure::NotCallable => FlowFailureTag::CallNotCallable,
+            ResolveCallFailure::NoApplicableOverload => FlowFailureTag::CallNoApplicableOverload,
+            ResolveCallFailure::Undecidable => FlowFailureTag::CallUndecidable,
+            ResolveCallFailure::Budget => FlowFailureTag::CallBudget,
+        },
+        FlowReturnFailure::Budget(reason) => match reason {
+            verter_type_expr::facts::InferenceUnavailableReason::DepthBudgetExceeded => {
+                FlowFailureTag::BudgetDepthExceeded
+            }
+            verter_type_expr::facts::InferenceUnavailableReason::WorkBudgetExceeded => {
+                FlowFailureTag::BudgetWorkExceeded
+            }
+        },
     }
 }
 

--- a/crates/verter_session/tests/cases/g_type/flow_return_audit_contract.rs
+++ b/crates/verter_session/tests/cases/g_type/flow_return_audit_contract.rs
@@ -27,6 +27,7 @@
 
 use std::sync::Arc;
 
+use verter_audit::payloads::flow_return::{FlowDegradationTag, FlowFailureTag, FlowPartialityTag};
 use verter_audit::{AuditCaptureState, RequestKind, StructuredAuditEvent};
 use verter_session::host_flow_return_audit::FlowReturnError;
 use verter_session::semantic_query::{demand, FlowReturnFailure, ReturnProjectionDemand};
@@ -301,4 +302,169 @@ fn filtered_kind_returns_cheap_noop_record_and_publishes_nothing() {
 
 fn whole() -> ReturnProjectionDemand {
     ReturnProjectionDemand::whole_return()
+}
+
+/// The audit record must explain WHY a request came back partial, not
+/// only THAT it did.
+///
+/// A `typeof`-guard over an unenumerable subject (`unknown`) retains a
+/// superset and records the typed guard-narrowing gap, so the value is
+/// usable but never warm: both calls recompute cold. Each record must
+/// name that reason. The `string | number` control classifies every arm,
+/// so it reports NO partiality and its second call is a warm hit.
+///
+/// Discrimination: against a payload that carries only the three
+/// occurrence counters, the `partiality` assertions fail on every leg —
+/// the counters are identical between the gapped subject and the control
+/// on the first call, so nothing else in the record distinguishes them.
+#[test]
+fn flow_return_audit_explains_partial_cold_recompute() {
+    let host = build_host(true, false);
+    let canonical = "/w/flow-audit-partiality.ts";
+    upsert(
+        &host,
+        canonical,
+        "export function gapped(x: unknown) { if (typeof x === \"string\") return x; return 0; }\n\
+         export function complete(x: string | number) { if (typeof x === \"string\") return x; return 0; }\n",
+    );
+
+    // Degraded-but-usable: two cold requests, each naming the gap.
+    let ident = identity(canonical, "gapped");
+    for call in 1..=2 {
+        let carrier = host.get_flow_return_type_with_audit(&ident, whole());
+        let record = carrier.audit();
+        let result = carrier
+            .as_result()
+            .unwrap_or_else(|err| panic!("call {call}: gap keeps the value usable, got {err:?}"));
+        assert!(
+            result.degradation().is_some(),
+            "call {call}: the retained superset is a degraded success"
+        );
+        assert!(
+            !record.from_cache,
+            "call {call}: a degraded result never warms"
+        );
+        let payload = record
+            .flow_return_inference_payload()
+            .expect("flow payload");
+        assert!(
+            payload.cold_computes >= 1,
+            "call {call}: a degraded result recomputes cold"
+        );
+        assert_eq!(
+            payload.partiality,
+            Some(FlowPartialityTag::Degraded(
+                FlowDegradationTag::GapGuardNarrowing
+            )),
+            "call {call}: the payload must name the guard-narrowing gap, \
+             not merely report counters"
+        );
+    }
+
+    // Complete control: no partiality, and the second call is warm.
+    let control = identity(canonical, "complete");
+    let cold = host.get_flow_return_type_with_audit(&control, whole());
+    assert!(cold.as_result().is_ok(), "control must resolve");
+    assert_eq!(
+        cold.audit()
+            .flow_return_inference_payload()
+            .expect("flow payload")
+            .partiality,
+        None,
+        "a complete evaluation reports no partiality"
+    );
+    let warm = host.get_flow_return_type_with_audit(&control, whole());
+    let warm_record = warm.audit();
+    assert!(
+        warm_record.from_cache,
+        "the complete control's second call is a warm hit"
+    );
+    assert_eq!(
+        warm_record
+            .flow_return_inference_payload()
+            .expect("flow payload")
+            .partiality,
+        None,
+        "a warm complete hit reports no partiality"
+    );
+}
+
+/// The typed no-value reason rides the `Err` arm's payload too: a
+/// narrower-than-whole-return demand fails closed, and the record names
+/// `UnmodeledDemandPoint` rather than leaving the caller to guess from
+/// three zero counters.
+#[test]
+fn flow_return_audit_names_the_no_value_failure_reason() {
+    let host = build_host(true, false);
+    let narrower = ReturnProjectionDemand {
+        point: demand::Demand::navigate(demand::ProjectionPath::empty()),
+    };
+    let carrier = host.get_flow_return_type_with_audit(&identity(CANONICAL, "makeThing"), narrower);
+    assert!(
+        matches!(
+            carrier.as_result(),
+            Err(FlowReturnError::Failure(
+                FlowReturnFailure::UnmodeledDemandPoint
+            ))
+        ),
+        "precondition: the narrower demand fails closed"
+    );
+    assert_eq!(
+        carrier
+            .audit()
+            .flow_return_inference_payload()
+            .expect("flow payload")
+            .partiality,
+        Some(FlowPartialityTag::NoValue(
+            FlowFailureTag::UnmodeledDemandPoint
+        )),
+        "the Err arm's payload must carry the typed no-value reason"
+    );
+}
+
+/// The partiality projection is READ-ONLY telemetry: it is derived from
+/// the outcome the evaluator already produced and is never consulted by
+/// admission. Disabling audit removes the projection entirely (the
+/// default-filled record reports no partiality), and the served value,
+/// the degradation verdict, and the cold/warm sequence must be
+/// byte-identical to the audited run.
+///
+/// Discrimination: against a tree where the projection feeds admission
+/// (or is computed before the outcome and mutates it), the audited and
+/// unaudited runs diverge on `from_cache` or on `degradation()`.
+#[test]
+fn partiality_projection_does_not_change_admission_or_warmth() {
+    let source = "export function gapped(x: unknown) { if (typeof x === \"string\") return x; return 0; }\n\
+                  export function complete(x: string | number) { if (typeof x === \"string\") return x; return 0; }\n";
+    let canonical = "/w/flow-audit-partiality-equiv.ts";
+
+    let observe = |audit_enabled: bool| {
+        let host = build_host(audit_enabled, false);
+        upsert(&host, canonical, source);
+        let mut trace = Vec::new();
+        for symbol in ["gapped", "complete"] {
+            let ident = identity(canonical, symbol);
+            for _ in 0..2 {
+                let carrier = host.get_flow_return_type_with_audit(&ident, whole());
+                let degradation = carrier.as_result().ok().and_then(|r| r.degradation());
+                trace.push((carrier.audit().from_cache, format!("{degradation:?}")));
+            }
+        }
+        trace
+    };
+
+    let audited = observe(true);
+    let unaudited = observe(false);
+    assert_eq!(
+        audited, unaudited,
+        "the partiality projection is observability only — admission, warmth \
+         and the degradation verdict must not depend on whether it ran"
+    );
+    // Precondition: the trace actually spans a degraded and a warm leg,
+    // so an equal-but-vacuous comparison cannot pass.
+    assert!(
+        audited.iter().any(|(warm, _)| *warm) && audited.iter().any(|(warm, _)| !*warm),
+        "the equivalence trace must cover both a never-warm degraded leg \
+         and a warm complete leg: {audited:?}"
+    );
 }

--- a/crates/verter_session/tests/cases/g_type/flow_return_audit_contract.rs
+++ b/crates/verter_session/tests/cases/g_type/flow_return_audit_contract.rs
@@ -16,9 +16,11 @@
 //! - a narrower-than-whole-return demand fails CLOSED with the typed
 //!   `UnmodeledDemandPoint` failure (never a silently widened
 //!   whole-return result);
-//! - with audit disabled the producer body still runs and the carrier
-//!   returns the cheap default-filled record
-//!   (`AuditCaptureState::AuditDisabled`, nothing published).
+//! - denying the kind at the consumer filter still runs the producer
+//!   body and returns the cheap default-filled record
+//!   (`AuditCaptureState::FilteredNoop`, nothing published) — that
+//!   filter, not `HostConfig::audit_enabled`, is what drives the
+//!   Active/Noop registration split.
 //!
 //! Discrimination: against a tree that emits `FlowReturnStarted` on
 //! the warm path, `warm_hit_emits_no_flow_return_started_event` fails
@@ -48,9 +50,9 @@ export function recurse(n: number) {
 }
 "#;
 
-fn build_host(audit_enabled: bool, footprint_capture: bool) -> Arc<VerterHost> {
+fn build_host(footprint_capture: bool) -> Arc<VerterHost> {
     let host = Arc::new(VerterHost::new_standalone(HostConfig {
-        audit_enabled,
+        audit_enabled: true,
         footprint_capture,
         ..HostConfig::default()
     }));
@@ -58,7 +60,7 @@ fn build_host(audit_enabled: bool, footprint_capture: bool) -> Arc<VerterHost> {
     host
 }
 
-fn upsert(host: &Arc<VerterHost>, canonical: &str, source: &str) {
+fn upsert(host: &VerterHost, canonical: &str, source: &str) {
     let _ = host.upsert(UpsertRequest {
         canonical_id: Some(canonical.to_string()),
         input_id: canonical.to_string(),
@@ -109,7 +111,7 @@ fn has_event(
 
 #[test]
 fn cold_inference_emits_started_event_and_counts_one_cold_compute() {
-    let host = build_host(true, true);
+    let host = build_host(true);
     let carrier = host.get_flow_return_type_with_audit(&identity(CANONICAL, "makeThing"), whole());
 
     let record = carrier.audit();
@@ -149,7 +151,7 @@ fn cold_inference_emits_started_event_and_counts_one_cold_compute() {
 
 #[test]
 fn warm_hit_emits_no_flow_return_started_event() {
-    let host = build_host(true, true);
+    let host = build_host(true);
     let ident = identity(CANONICAL, "makeThing");
 
     // Prime: cold inference publishes the family memo entry.
@@ -182,7 +184,7 @@ fn warm_hit_emits_no_flow_return_started_event() {
 
 #[test]
 fn budget_refusal_surfaces_typed_error_counter_and_event() {
-    let host = build_host(true, true);
+    let host = build_host(true);
     // 300 demand-origin return sites trips the ReturnSites budget (256).
     let canonical = "/w/flow-audit-budget.ts";
     let mut source = String::from("export function tooManyReturns(n: number) {\n");
@@ -218,7 +220,7 @@ fn budget_refusal_surfaces_typed_error_counter_and_event() {
 
 #[test]
 fn direct_recursion_records_cycle_sentinel() {
-    let host = build_host(true, true);
+    let host = build_host(true);
     let carrier = host.get_flow_return_type_with_audit(&identity(CANONICAL, "recurse"), whole());
     let record = carrier.audit();
     assert!(
@@ -243,7 +245,7 @@ fn direct_recursion_records_cycle_sentinel() {
 
 #[test]
 fn narrower_demand_fails_closed_with_unmodeled_demand_point() {
-    let host = build_host(true, false);
+    let host = build_host(false);
     let narrower = ReturnProjectionDemand {
         point: demand::Demand::navigate(demand::ProjectionPath::empty()),
     };
@@ -319,7 +321,7 @@ fn whole() -> ReturnProjectionDemand {
 /// on the first call, so nothing else in the record distinguishes them.
 #[test]
 fn flow_return_audit_explains_partial_cold_recompute() {
-    let host = build_host(true, false);
+    let host = build_host(false);
     let canonical = "/w/flow-audit-partiality.ts";
     upsert(
         &host,
@@ -395,7 +397,7 @@ fn flow_return_audit_explains_partial_cold_recompute() {
 /// three zero counters.
 #[test]
 fn flow_return_audit_names_the_no_value_failure_reason() {
-    let host = build_host(true, false);
+    let host = build_host(false);
     let narrower = ReturnProjectionDemand {
         point: demand::Demand::navigate(demand::ProjectionPath::empty()),
     };
@@ -422,49 +424,135 @@ fn flow_return_audit_names_the_no_value_failure_reason() {
     );
 }
 
-/// The partiality projection is READ-ONLY telemetry: it is derived from
-/// the outcome the evaluator already produced and is never consulted by
-/// admission. Disabling audit removes the projection entirely (the
-/// default-filled record reports no partiality), and the served value,
-/// the degradation verdict, and the cold/warm sequence must be
-/// byte-identical to the audited run.
+/// The partiality projection is READ-ONLY telemetry: removing it must
+/// change nothing a caller can observe about the VALUE.
 ///
-/// Discrimination: against a tree where the projection feeds admission
-/// (or is computed before the outcome and mutates it), the audited and
-/// unaudited runs diverge on `from_cache` or on `degradation()`.
+/// The axis that actually removes the projection is the consumer
+/// FILTER, not `HostConfig::audit_enabled` — the Active/Noop
+/// registration split is filter-driven (see
+/// `filtered_kind_returns_cheap_noop_record_and_publishes_nothing`), and
+/// a denied kind takes the `Noop` arm, where the payload is never built
+/// and the outcome is never inspected for a reason at all.
+///
+/// Both legs run the same request sequence over a degraded function and
+/// a complete control, then re-admit the kind for one probe per function
+/// so the warm/cold verdict is readable on BOTH legs. That probe's
+/// `from_cache` reports whether the preceding, differently-filtered
+/// sequence warm-admitted the complete value and refused to warm the
+/// degraded one — and, because a warm hit requires a key match, it is
+/// also the witness that the projection changed no cache identity.
+///
+/// Discrimination: against a tree where the projection feeds admission,
+/// warm/cold classification, or the flow-return key, the two legs
+/// diverge on the warm probe (or on a served verdict). Against a tree
+/// that stopped projecting, the `projected` precondition fails; against
+/// one where the filter no longer suppresses the projection, the
+/// `unprojected` precondition fails.
 #[test]
 fn partiality_projection_does_not_change_admission_or_warmth() {
+    /// Everything a caller can observe about the VALUE across one
+    /// request sequence — nothing audit-side.
+    #[derive(Debug, PartialEq, Eq)]
+    struct ServedTrace {
+        /// Per-call served outcome (`Ok` plus its degradation verdict,
+        /// or the typed failure) in request order.
+        outcomes: Vec<String>,
+        /// `from_cache` on a post-sequence probe of the degraded
+        /// function.
+        gapped_warm: bool,
+        /// `from_cache` on a post-sequence probe of the complete
+        /// control.
+        complete_warm: bool,
+    }
+
     let source = "export function gapped(x: unknown) { if (typeof x === \"string\") return x; return 0; }\n\
                   export function complete(x: string | number) { if (typeof x === \"string\") return x; return 0; }\n";
     let canonical = "/w/flow-audit-partiality-equiv.ts";
 
-    let observe = |audit_enabled: bool| {
-        let host = build_host(audit_enabled, false);
+    let observe = |filter: verter_audit::AuditConsumerFilter| {
+        let mut host = VerterHost::new_standalone(HostConfig {
+            audit_enabled: true,
+            footprint_capture: false,
+            ..HostConfig::default()
+        });
+        host.replace_host_audit_runtime_for_test(verter_audit::AuditConfig {
+            consumer_filter: filter,
+            ..verter_audit::AuditConfig::default()
+        });
         upsert(&host, canonical, source);
-        let mut trace = Vec::new();
+
+        let mut outcomes = Vec::new();
+        let mut projection = Vec::new();
         for symbol in ["gapped", "complete"] {
             let ident = identity(canonical, symbol);
             for _ in 0..2 {
                 let carrier = host.get_flow_return_type_with_audit(&ident, whole());
-                let degradation = carrier.as_result().ok().and_then(|r| r.degradation());
-                trace.push((carrier.audit().from_cache, format!("{degradation:?}")));
+                outcomes.push(match carrier.as_result() {
+                    Ok(result) => format!("ok:{:?}", result.degradation()),
+                    Err(err) => format!("err:{err:?}"),
+                });
+                let record = carrier.audit();
+                projection.push((
+                    record.capture_state,
+                    record
+                        .flow_return_inference_payload()
+                        .expect("flow payload")
+                        .partiality,
+                ));
             }
         }
-        trace
+
+        // Re-admit the kind so the warm/cold verdict of the sequence
+        // above is readable on both legs.
+        host.replace_host_audit_runtime_for_test(verter_audit::AuditConfig::default());
+        let probe = |symbol: &str| {
+            host.get_flow_return_type_with_audit(&identity(canonical, symbol), whole())
+                .audit()
+                .from_cache
+        };
+        let served = ServedTrace {
+            outcomes,
+            gapped_warm: probe("gapped"),
+            complete_warm: probe("complete"),
+        };
+        (served, projection)
     };
 
-    let audited = observe(true);
-    let unaudited = observe(false);
-    assert_eq!(
-        audited, unaudited,
-        "the partiality projection is observability only — admission, warmth \
-         and the degradation verdict must not depend on whether it ran"
-    );
-    // Precondition: the trace actually spans a degraded and a warm leg,
-    // so an equal-but-vacuous comparison cannot pass.
+    let (projected_trace, projected) = observe(verter_audit::AuditConsumerFilter::allow_all());
+    let denied = verter_audit::AuditConsumerFilter::default()
+        .deny(verter_audit::config::KindBit::FlowReturnInference);
+    let (unprojected_trace, unprojected) = observe(denied);
+
+    // Preconditions: the two legs really differ in whether the
+    // projection ran, and the sequence really spans a never-warm
+    // degraded leg plus a warm complete leg — otherwise an equal-but-
+    // vacuous comparison could pass.
     assert!(
-        audited.iter().any(|(warm, _)| *warm) && audited.iter().any(|(warm, _)| !*warm),
-        "the equivalence trace must cover both a never-warm degraded leg \
-         and a warm complete leg: {audited:?}"
+        projected
+            .iter()
+            .any(|(state, reason)| *state == AuditCaptureState::ActiveStored
+                && *reason
+                    == Some(FlowPartialityTag::Degraded(
+                        FlowDegradationTag::GapGuardNarrowing
+                    ))),
+        "precondition: the allowed leg must actually project a reason: {projected:?}"
+    );
+    assert!(
+        unprojected
+            .iter()
+            .all(|(state, reason)| *state == AuditCaptureState::FilteredNoop && reason.is_none()),
+        "precondition: the denied leg must build no payload at all: {unprojected:?}"
+    );
+    assert!(
+        !projected_trace.gapped_warm && projected_trace.complete_warm,
+        "precondition: the sequence must cover a never-warm degraded leg \
+         and a warm complete leg: {projected_trace:?}"
+    );
+
+    assert_eq!(
+        projected_trace, unprojected_trace,
+        "the partiality projection is observability only — the served \
+         value, the degradation verdict, the warm/cold sequence, and the \
+         cache identity behind it must not depend on whether it ran"
     );
 }

--- a/packages/types/audit.generated.ts
+++ b/packages/types/audit.generated.ts
@@ -996,7 +996,41 @@ lower_ms?: number | null, };
 export type FileRole = "Entry" | "DirectImport" | "TransitiveImport" | "TypeDep" | "IndexedReadyBuild" | "NotLoaded" | "ResolverWalk";
 
 /**
- * Per-request counters for one flow-return inference request.
+ * Closed mirror of the session's `FlowReturnDegradation` — the reason a
+ * usable flow-return value is incomplete.
+ *
+ * The domain's `FlowGap(_)` arm is reduced through its own gap variant,
+ * so each detected flow-model gap keeps a distinct wire spelling
+ * instead of collapsing into one "gap" bucket.
+ */
+export type FlowDegradationTag = "GapGuardNarrowing" | "GapNominalRelation" | "GapClosureCapture" | "GapAbruptCompletion" | "GapUnmodeledExpression" | "NonCallableBinding" | "UnrepresentableCallee" | "FailedBindingInitializer" | "UnappliedWriteEffect" | "ConditionalVarDefinition" | "UnreducedDeclaredUnion" | "UnresolvedValue" | "UnmodeledPosition";
+
+/**
+ * Closed mirror of the session's no-value flow-return reasons — the
+ * `FlowReturnFailure` class plus the host's own unstable-view refusal.
+ *
+ * The three `FlowReturnFailure` variants that nest a further closed
+ * enum (`Unsupported`, `CallResolution`, `Budget`) are reduced through
+ * that inner variant, so every distinct no-value reason keeps its own
+ * wire spelling.
+ */
+export type FlowFailureTag = "Missing" | "UnsupportedLoop" | "UnsupportedJump" | "UnsupportedInvokedClosureEffect" | "UnsupportedWith" | "UnsupportedModuleDeclaration" | "Unresolved" | "EmptyCycle" | "UnmodeledDemandPoint" | "CallNotCallable" | "CallNoApplicableOverload" | "CallUndecidable" | "CallBudget" | "BudgetDepthExceeded" | "BudgetWorkExceeded" | "UnstableState";
+
+/**
+ * Why a flow-return request was not a clean, complete value.
+ *
+ * The two arms mirror the audited entry-point's split result/carrier
+ * contract exactly: a DEGRADED SUCCESS is a usable value that refuses
+ * warm admission and rides the carrier's `Ok` arm; a NO-VALUE outcome
+ * rides the `Err` arm. A request that produced a complete, non-degraded
+ * value carries no partiality at all
+ * ([`FlowReturnInferencePayload::partiality`] is `None`).
+ */
+export type FlowPartialityTag = { "Degraded": FlowDegradationTag } | { "NoValue": FlowFailureTag };
+
+/**
+ * Per-request counters and the typed partiality reason for one
+ * flow-return inference request.
  *
  * The three counters mirror the cold-path structured events one to
  * one: each cold whole-function evaluation bumps `cold_computes`
@@ -1007,6 +1041,13 @@ export type FileRole = "Entry" | "DirectImport" | "TransitiveImport" | "TypeDep"
  * `FlowCycleSentinelHit`). A warm family hit bumps nothing — the
  * cold-vs-warm audit contract's counter-side witness is
  * `cold_computes == 0`.
+ *
+ * The counters report THAT a request did cold work, hit a budget, or
+ * held on a cycle; [`Self::partiality`] reports WHY the request came
+ * back degraded or with no value at all. It is read-only telemetry
+ * derived from the outcome the evaluator already produced — no
+ * admission decision, warm/cold classification, or cache identity
+ * consults it.
  */
 export type FlowReturnInferencePayload = {
 /**
@@ -1028,7 +1069,15 @@ budget_exceeded_events: number,
  * Number of coinductive re-entry holds recorded on the shared
  * obligation runtime (the flow-cycle sentinel).
  */
-cycle_reentry_holds: number, };
+cycle_reentry_holds: number,
+/**
+ * Why the request was partial: the typed degradation reason on a
+ * degraded-but-usable value, or the typed no-value reason on a
+ * refusal. `None` is the complete, warm-admissible outcome — and
+ * also the default-filled value on the filtered / audit-disabled
+ * record, where no payload was collected at all.
+ */
+partiality: FlowPartialityTag | null, };
 
 /**
  * Which flow-slice budget axis tripped — the substrate mirror of the

--- a/packages/types/audit.generated.ts
+++ b/packages/types/audit.generated.ts
@@ -1025,6 +1025,12 @@ export type FlowFailureTag = "Missing" | "UnsupportedLoop" | "UnsupportedJump" |
  * rides the `Err` arm. A request that produced a complete, non-degraded
  * value carries no partiality at all
  * ([`FlowReturnInferencePayload::partiality`] is `None`).
+ *
+ * Exactly ONE reason is reported, never a set. The producer's typed
+ * outcome already reduced every observed gap to the FIRST one in
+ * source order, so a function carrying several distinct gaps still
+ * names only the earliest. Read the tag as "the reason this request
+ * was partial", never as "the complete inventory of what is missing".
  */
 export type FlowPartialityTag = { "Degraded": FlowDegradationTag } | { "NoValue": FlowFailureTag };
 

--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -166,7 +166,7 @@ schema = 2
 "D1" = { status = "implemented", commit_message = "feat(session): add private hermetic flow completeness foundation", commit_date = "2026-08-29T20:05:00+01:00" }
 "D2A" = { status = "implemented", commit_message = "feat(session): canonical flow demand and proof substrate", commit_date = "2026-08-30T09:46:00+01:00" }
 "D2B" = { status = "implemented", commit_message = "feat(session): route flow-return admission through the sole completeness proof", commit_date = "2026-08-30T17:32:00+01:00" }
-"D2C" = { status = "pending" }
+"D2C" = { status = "implemented", commit_message = "feat(session): explain flow-return partiality in the audit payload", commit_date = "2026-09-02T09:00:00+01:00" }
 "D2D" = { status = "implemented", commit_message = "feat(session): make every surface producer return a typed resolution outcome", commit_date = "2026-09-01T19:15:00+01:00" }
 "D3C" = { status = "pending" }
 "D3I" = { status = "pending" }


### PR DESCRIPTION
Autonomous candidate for one roadmap block.

Do not merge manually: the TAMA controller owns landing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Flow-return audit records now report typed partiality details, distinguishing degraded results from no-value outcomes.
  - Added categorized reasons for degradation and failure, including guard narrowing, unsupported operations, resolution issues, budget limits, and unstable states.
  - Generated TypeScript bindings now expose partiality information and reason categories.

- **Bug Fixes**
  - Confirmed audit filtering does not change served results, cache behavior, or warm/cold status.

- **Documentation**
  - Expanded audit documentation for partiality, filtered records, degraded outcomes, and telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #480
