### PR TITLE
feat(play): migrate WASM fixture capture to typed compile request

### DIFF
--- a/packages/playground/scripts/capture-wasm-carrier-fixtures.mjs
+++ b/packages/playground/scripts/capture-wasm-carrier-fixtures.mjs
@@ -6,7 +6,8 @@
  * ships) over a small set of committed carrier sources and snapshots the three
  * generated surfaces per source:
  *
- *   - IDE carrier      — `getIde(id, profile)`             → `Comp.vue.tsx`
+ *   - IDE carrier      — `compileRequest(id, { vue|svelte: {...} })`
+ *                        an `ideCompanion` product                 → `Comp.vue.tsx`
  *   - declaration      — `getPublicApi(id, "declaration")` → `Comp.d.vue.ts`
  *   - API carrier      — `getPublicApi(id)`                → `Comp.vue.verter.ts`
  *
@@ -151,6 +152,35 @@ function publicApiSurface(result) {
   return surface(result.value);
 }
 
+/**
+ * The single requested product: the IDE surface, with source maps on and
+ * every axis the legacy `{ sourceMap: true, target: "ide", forceJs: true }`
+ * profile implied left at its (false) default — the same values the typed
+ * host-request route's own equivalence tests pin against that profile.
+ */
+function ideRequest(fileKind) {
+  const identity = { isProduction: false, forceJs: true };
+  const products = [
+    {
+      ideCompanion: {
+        wantSourceMap: true,
+        embedAmbientTypes: false,
+        conditionalRootNarrowing: false,
+        strictSlots: false,
+        ideChunkBoundaries: false,
+      },
+    },
+  ];
+  if (fileKind === "svelte") return { svelte: { identity, products, options: {} } };
+  return {
+    vue: {
+      identity,
+      products,
+      options: { backend: "inferred", ssr: false, isCustomElement: [], babelParserPlugins: [] },
+    },
+  };
+}
+
 function capture(wasmModule, { filename, fileKind, source }) {
   // A fresh host per fixture keeps every entry independent of capture order.
   const host = new wasmModule.VerterHost({
@@ -158,16 +188,17 @@ function capture(wasmModule, { filename, fileKind, source }) {
     compileErrorPolicy: "devServeLastKnownGood",
     maxProfilesPerFile: 8,
   });
-  const profile = { filename, sourceMap: true, target: "ide", forceJs: true };
-  // Registration carries source only. Compile demand is stated on the compile
-  // calls below, which is the only place the host reads a profile from.
+  // Registration carries source only, no compile demand — the compile demand
+  // is stated on the typed request below, by canonical id, never by copying
+  // the source into it.
   host.upsert({ inputId: filename, source, fileKind, aliases: [] });
 
   let ide = null;
   let ideUnavailable = null;
   try {
-    host.ensureIdeCompiled(filename, profile);
-    ide = surface(host.getIde(filename, profile));
+    const response = host.compileRequest(filename, ideRequest(fileKind));
+    // Exactly one product was requested, so it is the sole row, in order.
+    ide = surface(response.products[0]);
   } catch (err) {
     // An IDE compile failure is recorded explicitly (`ideUnavailable`) so the
     // fixture stays honest about what the host produced — a guard asserting

--- a/packages/playground/scripts/capture-wasm-carrier-fixtures.mjs
+++ b/packages/playground/scripts/capture-wasm-carrier-fixtures.mjs
@@ -155,8 +155,12 @@ function publicApiSurface(result) {
 /**
  * The single requested product: the IDE surface, with source maps on and
  * every axis the legacy `{ sourceMap: true, target: "ide", forceJs: true }`
- * profile implied left at its (false) default — the same values the typed
- * host-request route's own equivalence tests pin against that profile.
+ * profile implied left at its (false) default. The typed host-request
+ * route's equivalence tests pin these axis values verbatim, but against a
+ * `{ target: "full", sourceMap: true, isProduction: false }` legacy demand
+ * with `forceJs` at its identity — this tool's `forceJs: true` +
+ * `target: "ide"` pairing is covered only indirectly, through the shared
+ * IDE response projection and this script's own fixture freshness rail.
  */
 function ideRequest(fileKind) {
   const identity = { isProduction: false, forceJs: true };
@@ -181,6 +185,23 @@ function ideRequest(fileKind) {
   };
 }
 
+/**
+ * The IDE row of a compile response, taken by kind tag — never by position.
+ * The response carries one row per requested product, tagged and in request
+ * order, so a capture that requested exactly one IDE product must find
+ * exactly one `ideCompanion` row. Anything else is a wire break inside this
+ * tool, so it fails the capture loudly instead of snapshotting the
+ * silent-null `ide: null` shape the fixture must never carry.
+ */
+function ideProductRow(response) {
+  const products = Array.isArray(response?.products) ? response.products : [];
+  const kinds = products.map((product) => product?.kind ?? "<untagged>");
+  if (products.length !== 1 || kinds[0] !== "ideCompanion") {
+    throw new Error(`expected exactly one ideCompanion product row, got: [${kinds.join(", ")}]`);
+  }
+  return products[0];
+}
+
 function capture(wasmModule, { filename, fileKind, source }) {
   // A fresh host per fixture keeps every entry independent of capture order.
   const host = new wasmModule.VerterHost({
@@ -195,16 +216,20 @@ function capture(wasmModule, { filename, fileKind, source }) {
 
   let ide = null;
   let ideUnavailable = null;
+  let response;
   try {
-    const response = host.compileRequest(filename, ideRequest(fileKind));
-    // Exactly one product was requested, so it is the sole row, in order.
-    ide = surface(response.products[0]);
+    response = host.compileRequest(filename, ideRequest(fileKind));
   } catch (err) {
     // An IDE compile failure is recorded explicitly (`ideUnavailable`) so the
     // fixture stays honest about what the host produced — a guard asserting
     // IDE parity fails on the recorded gap instead of a silent null.
     ideUnavailable = String(err?.message ?? err).split("\n")[0];
   }
+  // Row selection runs OUTSIDE the failure catch above: a malformed (or
+  // missing) product list is this tool's wire break, not a host compile
+  // failure, and must fail the capture rather than ride into the fixture
+  // as a silent `ide: null`.
+  if (ideUnavailable === null) ide = surface(ideProductRow(response));
   const decl = publicApiSurface(host.getPublicApi(filename, "declaration"));
   const api = publicApiSurface(host.getPublicApi(filename));
   // No explicit `host.free()`: if an IDE compile trapped, the host borrow is

--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -103,7 +103,7 @@ schema = 2
 "CCA1O2I" = { status = "implemented", commit_message = "refactor(napi): generate the published host compile-request declaration", commit_date = "2026-09-01T14:00:00+01:00" }
 "CCA1O2J" = { status = "pending" }
 "CCA1O3" = { status = "implemented", commit_message = "feat(wasm): add a typed host compile-request adapter and local request DTOs", commit_date = "2026-08-31T22:30:00+01:00" }
-"CCA1O3A" = { status = "implemented", commit_message = "feat(play): migrate WASM fixture capture to typed compile request", commit_date = "2026-09-03" }
+"CCA1O3A" = { status = "implemented", commit_message = "feat(play): migrate WASM fixture capture to typed compile request", commit_date = "2026-09-03T09:30:00+01:00" }
 "CCA1O3B" = { status = "pending" }
 "CCA1O3C" = { status = "implemented", commit_message = "feat(ci): execute the wasm JavaScript-boundary tests in the canonical gate", commit_date = "2026-09-01T02:10:00+01:00" }
 "CCA1O3D" = { status = "implemented", commit_message = "feat(wasm): expose a callable typed compile request on the browser host", commit_date = "2026-09-02T12:00:00+01:00", pull_request = 469 }

--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -103,7 +103,7 @@ schema = 2
 "CCA1O2I" = { status = "implemented", commit_message = "refactor(napi): generate the published host compile-request declaration", commit_date = "2026-09-01T14:00:00+01:00" }
 "CCA1O2J" = { status = "pending" }
 "CCA1O3" = { status = "implemented", commit_message = "feat(wasm): add a typed host compile-request adapter and local request DTOs", commit_date = "2026-08-31T22:30:00+01:00" }
-"CCA1O3A" = { status = "pending" }
+"CCA1O3A" = { status = "implemented", commit_message = "feat(play): migrate WASM fixture capture to typed compile request", commit_date = "2026-09-03" }
 "CCA1O3B" = { status = "pending" }
 "CCA1O3C" = { status = "implemented", commit_message = "feat(ci): execute the wasm JavaScript-boundary tests in the canonical gate", commit_date = "2026-09-01T02:10:00+01:00" }
 "CCA1O3D" = { status = "implemented", commit_message = "feat(wasm): expose a callable typed compile request on the browser host", commit_date = "2026-09-02T12:00:00+01:00", pull_request = 469 }


### PR DESCRIPTION
Closes #141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WASM fixture capture for Vue and Svelte projects by using typed compile requests with explicit compiler settings.
  * Added validation to ensure IDE responses contain exactly one compatible result.
  * Compile failures are consistently recorded as unavailable instead of being silently ignored.

* **Documentation**
  * Updated implementation tracking to reflect the completed fixture-capture migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->