### PR TITLE
feat(wasm): drive the transport probe through the typed compile request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1345,10 +1345,11 @@ jobs:
 
   # Native + WASM transport-route comparison, executed. Clippy in
   # rust-build-configs only compiles the feature; this job builds the two
-  # artifacts the comparison drives, runs the suite, and fails unless the
+  # artifacts the comparison drives, runs the suite on an exact allowlist
+  # of the native/WASM/census names, and fails unless the
   # `running N tests` line proves the named comparisons ran. The bundler
-  # lane is skipped: it needs a matching unplugin freshness pin owned
-  # elsewhere.
+  # lane is not on that list: it needs a matching unplugin freshness pin
+  # owned elsewhere.
   transport-route-equivalence:
     name: Transport route equivalence
     needs: [detect-changes, wasm-build, build-native-node]
@@ -1387,10 +1388,26 @@ jobs:
         run: |
           set -euo pipefail
           out="$(mktemp)"
+          # Exact allowlist of the executed names, not substring skips over
+          # the bundler lane: a later test whose name merely contains a
+          # skipped token (or a bundler-lane test without "bundler" in its
+          # name) must never be silently dropped or need extra skip patches.
+          # A listed name that stops matching fails the floor check below
+          # rather than quietly not running.
+          executed=(
+            "framework::suite_census::the_transport_route_equivalence_suite_is_present_and_non_vacuous"
+            "framework::transport_route_equivalence_tests::this_suite_is_registered_with_the_census"
+            "framework::transport_route_equivalence_tests::the_napi_transport_matches_the_in_process_host_route"
+            "framework::transport_route_equivalence_tests::the_napi_batch_route_matches_the_in_process_batch_route_item_for_item"
+            "framework::transport_route_equivalence_tests::every_exported_napi_spelling_is_executed_or_classified_out_of_scope"
+            "framework::transport_route_equivalence_tests::the_wasm_transport_matches_the_in_process_host_route"
+            "framework::transport_route_equivalence_tests::every_exported_wasm_spelling_is_executed_or_classified_out_of_scope"
+            "framework::transport_route_equivalence_tests::the_audited_compile_spelling_captures_for_vue_and_not_for_svelte_on_both_transports"
+            "framework::transport_route_equivalence_tests::the_transports_report_a_missing_node_the_same_way"
+          )
           set +e
           cargo test -p verter_session --lib --features transport-authoritative \
-            transport_route_equivalence -- --test-threads=1 \
-            --skip bundler --skip the_non_vite --skip both_published_virtual_script \
+            -- --exact "${executed[@]}" --test-threads=1 \
             >"$out" 2>&1
           rc=$?
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,11 +347,11 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
   # ---------------------------------------------------------------------------
-  # The two build configurations no other job compiles.
+  # The build configurations no other job compiles.
   #
-  # Every other Rust job here builds the HOST target in DEBUG. Both of the
-  # configurations below have already shipped defects that were structurally
-  # invisible to that:
+  # Every other Rust job here builds the HOST target in DEBUG with default
+  # features. Each configuration below has already shipped a defect that was
+  # structurally invisible to that:
   #
   # - RELEASE. `debug_assert!` gates on `cfg!`, a RUNTIME constant, so its body
   #   still name-resolves in release. A `#[cfg(debug_assertions)]` helper called
@@ -365,6 +365,17 @@ jobs:
   #   `extensions/*` manifests; nothing linted the wasm32 build that the
   #   playground and `@verter/wasm` consumers actually run.
   #
+  # - The `transport-authoritative` FEATURE. Its suite compiles only when that
+  #   opt-in cargo feature is on, so no job above sees it: a signature change in
+  #   a crate it calls leaves it uncompilable while every default job stays
+  #   green, and the breakage surfaces only when someone runs the suite by hand.
+  #   That already happened — a `transform_vue_style` parameter addition and a
+  #   field-to-method change landed against call sites in that suite and nothing
+  #   failed. Checking the feature keeps the drift loud. Execution of the
+  #   native/WASM comparison lanes lives in `transport-route-equivalence`,
+  #   which consumes the `wasm-build` and `build-native-node` artifacts.
+  #   This clippy step is NOT that lane.
+  #
   # `cargo check` (not `build`) for release: this is a compile-configuration
   # gate, not an artifact producer, and skipping codegen keeps it cheap.
   # ---------------------------------------------------------------------------
@@ -373,7 +384,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.97.1
@@ -387,6 +398,8 @@ jobs:
         run: cargo check --workspace --release
       - name: Clippy (wasm32-unknown-unknown)
         run: cargo clippy --target wasm32-unknown-unknown -p verter_wasm -- -D warnings
+      - name: Clippy (transport-equivalence feature)
+        run: cargo clippy -p verter_session --tests --features transport-authoritative -- -D warnings
 
   # Build the provider-free default-feature Rust test universe once. Real
   # providers have separate serial libtest jobs below because each third-party
@@ -1330,6 +1343,77 @@ jobs:
       - name: Native-eval @verter/component-meta
         run: pnpm --filter @verter/component-meta test:native
 
+  # Native + WASM transport-route comparison, executed. Clippy in
+  # rust-build-configs only compiles the feature; this job builds the two
+  # artifacts the comparison drives, runs the suite, and fails unless the
+  # `running N tests` line proves the named comparisons ran. The bundler
+  # lane is skipped: it needs a matching unplugin freshness pin owned
+  # elsewhere.
+  transport-route-equivalence:
+    name: Transport route equivalence
+    needs: [detect-changes, wasm-build, build-native-node]
+    if: needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.wasm == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      CARGO_BUILD_JOBS: "4"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@1.97.1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: transport-route-equivalence
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Download WASM build
+        uses: actions/download-artifact@v7
+        with:
+          name: wasm-build
+          path: packages/wasm
+      - name: Download native binding
+        uses: actions/download-artifact@v7
+        with:
+          name: native-node
+          path: packages/native/dist
+      - name: Syntax-check the WASM transport probe
+        run: node --check packages/wasm/scripts/probe-transport-surface.mjs
+      - name: Execute native and WASM transport comparisons
+        env:
+          CARGO_TERM_COLOR: never
+        run: |
+          set -euo pipefail
+          out="$(mktemp)"
+          set +e
+          cargo test -p verter_session --lib --features transport-authoritative \
+            transport_route_equivalence -- --test-threads=1 \
+            --skip bundler --skip the_non_vite --skip both_published_virtual_script \
+            >"$out" 2>&1
+          rc=$?
+          set -e
+          cat "$out"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::transport route-equivalence tests failed"
+            exit "$rc"
+          fi
+          if ! grep -F -q 'the_wasm_transport_matches_the_in_process_host_route' "$out"; then
+            echo "::error::wasm transport comparison did not run; read the running N tests line, never the exit code"
+            exit 1
+          fi
+          if ! grep -F -q 'the_napi_transport_matches_the_in_process_host_route' "$out"; then
+            echo "::error::napi transport comparison did not run; read the running N tests line, never the exit code"
+            exit 1
+          fi
+          n="$(sed -n 's/^running \([0-9][0-9]*\) tests$/\1/p' "$out" | tail -n1)"
+          if [ -z "${n}" ] || [ "${n}" -lt 9 ]; then
+            echo "::error::expected at least 9 executed transport-equivalence tests, got running N tests line: ${n:-missing}"
+            exit 1
+          fi
+          echo "transport route-equivalence executed ${n} tests"
+
   dx-harness-hermetic:
     name: DX Harness (raw-LSP hermetic)
     needs: [detect-changes, build-lsp-debug]
@@ -1851,6 +1935,7 @@ jobs:
       - editor-neutral-lsp
       - vscode-e2e
       - native-test
+      - transport-route-equivalence
       - dx-harness-hermetic
       - build-lsp-debug
       - build-native-node

--- a/crates/verter_session/Cargo.toml
+++ b/crates/verter_session/Cargo.toml
@@ -82,10 +82,13 @@ external-corpus = []
 # `cargo test -p verter_session --lib --features bf2-authoritative authoritative_seed_matrix_contracts_share_one_verified_run`.
 bf2-authoritative = []
 # Opt-in: transport route-equivalence suite
-# (`src/transport_route_equivalence_tests.rs`). Drives built `@verter/native`
-# and wasm-bindgen through Node probes vs the in-process host. Artifacts
-# come from commands outside cargo; the default hermetic gate must not
-# enable this. A missing artifact fails loudly. Run:
+# (`src/framework/transport_route_equivalence_tests.rs`). Drives built
+# `@verter/native`, wasm-bindgen, and `@verter/unplugin` through Node
+# probes vs the in-process host. Artifacts come from commands outside
+# cargo; the default hermetic gate must not enable this. A missing
+# artifact fails loudly. The bundler lane additionally requires a
+# matching `packages/unplugin/scripts/probe-bundler-route.freshness.json`
+# pin. Run:
 # `cargo test -p verter_session --lib --features transport-authoritative
 # transport_route_equivalence`.
 transport-authoritative = []

--- a/crates/verter_session/src/framework/transport_route_equivalence_tests.rs
+++ b/crates/verter_session/src/framework/transport_route_equivalence_tests.rs
@@ -14,18 +14,41 @@
 //! Behind `transport-authoritative`. Missing artifacts FAIL (name the
 //! build command) — never skip.
 //!
+//! THREE artifacts, not two. Each transport this module compares is a
+//! separately built product, and a run missing any one of them fails a
+//! whole lane with that lane's build command — so build all three before
+//! reading any result as evidence about the route:
+//!
 //! ```text
 //! CARGO_BUILD_JOBS=4 pnpm --filter @verter/native run build:debug
 //! CARGO_BUILD_JOBS=4 cargo build -p verter_wasm --target wasm32-unknown-unknown \
 //!   && wasm-bindgen --target web --out-dir packages/wasm/wasm --out-name verter_wasm \
 //!      target/wasm32-unknown-unknown/debug/verter_wasm.wasm
+//! pnpm --filter @verter/unplugin build
 //! cargo test -p verter_session --lib --features transport-authoritative \
 //!   transport_route_equivalence -- --test-threads=1
 //! ```
 //!
+//! The bundler lane additionally pins the built plugin against a committed
+//! source/dist fingerprint (`packages/unplugin/scripts/
+//! probe-bundler-route.freshness.json`). Editing that package WITHOUT
+//! regenerating the record turns every bundler test into a `Build it first`
+//! failure that a correct build cannot clear, which reads as a missing
+//! artifact rather than as the stale pin it is. Rebuild the plugin, then
+//! rewrite the record from the observed hashes the probe reports.
+//!
 //! Without the feature this module is not compiled: a filter naming it
 //! matches ZERO tests and `cargo test` still exits 0. Read the
 //! `running N tests` line, never the exit code.
+//!
+//! CI executes the native and WASM comparison lanes (`Transport route
+//! equivalence` in `.github/workflows/ci.yml`) against freshly built
+//! `@verter/native` and wasm-bindgen web artifacts. That job fails if the
+//! `running N tests` line is missing, below the native/WASM floor (9), or
+//! does not name those two comparisons. It does not run the bundler lane:
+//! that lane also needs a matching `@verter/unplugin` freshness pin, a
+//! different surface. Clippy with `--features transport-authoritative`
+//! in `Rust Build Configurations` stays the cheap signature-drift check.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -290,6 +313,52 @@ fn host_node(
     }
 }
 
+/// The in-process host's answer to the SAME typed request the WASM probe
+/// issues for a Svelte carrier's mapped server runtime surface.
+///
+/// The binding this probe drives calls `VerterHost::compile_request`
+/// (`crates/verter_wasm/src/lib.rs`), so the comparison the typed route
+/// deserves is against this entry — not against a per-node profile read,
+/// which answers a different question about a different demand.
+///
+/// The request mirrors the probe's `runtimeRequest("svelte", { sourceMap:
+/// true, ssr: true })` field for field: production identity, no forced JS,
+/// one mapped `RuntimeServer` product, default Svelte options.
+fn host_server_runtime_request(host: &VerterHost, canonical: &str) -> HostOutcome {
+    use verter_compiler::compile_request::{
+        CompileProduct, CompileRequest, FrameworkCompileRequest, RuntimeProductRequest,
+        SvelteCompileRequest,
+    };
+
+    let request = CompileRequest::new(
+        vec![CompileProduct::RuntimeServer(RuntimeProductRequest {
+            runtime_source_map: true,
+            ..RuntimeProductRequest::default()
+        })],
+        FrameworkCompileRequest::Svelte(SvelteCompileRequest::default()),
+        None,
+        None,
+        None,
+        true,
+        false,
+    )
+    .unwrap_or_else(|error| {
+        panic!("{canonical}: the probe's own request shape no longer constructs: {error:?}")
+    });
+
+    match host.compile_request(canonical, request) {
+        Ok(response) => panic!(
+            "{canonical}: the typed server-runtime request now completes, so the refusal \
+             comparison decides nothing: {} product row(s)",
+            response.products.len()
+        ),
+        Err(crate::CompileRequestFailure::RuntimeSurfaceRefused {
+            diagnostic_code, ..
+        }) => HostOutcome::Refused { diagnostic_code },
+        Err(other) => panic!("{canonical}: unmodelled typed request outcome {other:?}"),
+    }
+}
+
 /// Assert one probe case equals the in-process host's answer for the same typed
 /// request.
 #[track_caller]
@@ -350,8 +419,27 @@ fn assert_case_matches_host(transport: &str, label: &str, case: &Value, expected
     }
 }
 
+/// How a transport's probe obtains a carrier's products.
+///
+/// The two routes answer the same questions about bytes, maps, languages
+/// and refusal codes, so every comparison below is shared. They differ in
+/// exactly two places, and only because the QUESTION differs: what happens
+/// to a node of a compile that was refused, and what an IDE demand means
+/// when nothing has been compiled for it yet.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ProductRoute {
+    /// Cached per-node reads, plus the ensure-then-read IDE pair. A node of
+    /// a refused compile reads as absent, and an IDE read for a profile
+    /// nothing ensured has no slot to serve.
+    ProfileCachedReads,
+    /// One complete typed compile request per demand. A refusal replaces
+    /// the whole transaction, so a node of it does not exist to be absent;
+    /// and every IDE demand compiles, so none of them is unserved.
+    TypedCompileRequest,
+}
+
 /// Every case the probes execute, compared against the in-process host.
-fn assert_transport_matches_the_host_route(transport: &str, record: &Value) {
+fn assert_transport_matches_the_host_route(transport: &str, record: &Value, route: ProductRoute) {
     // Success + optional-product axis (supported Svelte).
     let svelte = host_with(
         "/probe/Ok.svelte",
@@ -436,12 +524,21 @@ fn assert_transport_matches_the_host_route(transport: &str, record: &Value) {
         SUPPORTED_SVELTE,
         verter_language::FileLanguage::svelte(),
     );
-    let refusal = host_node(
-        &server,
-        "/probe/Server.svelte",
-        VirtualNodeKind::Main,
-        &probe_profile(true, true),
-    );
+    // Each route is compared against the host's answer to ITS OWN demand.
+    // On the typed arm a per-node profile read would compare two different
+    // questions and would not notice a different code or a different
+    // failure arm.
+    let refusal = match route {
+        ProductRoute::ProfileCachedReads => host_node(
+            &server,
+            "/probe/Server.svelte",
+            VirtualNodeKind::Main,
+            &probe_profile(true, true),
+        ),
+        ProductRoute::TypedCompileRequest => {
+            host_server_runtime_request(&server, "/probe/Server.svelte")
+        }
+    };
     assert_eq!(
         refusal,
         HostOutcome::Refused {
@@ -456,17 +553,50 @@ fn assert_transport_matches_the_host_route(transport: &str, record: &Value) {
         &record["cases"]["svelteServerRefusal"],
         &refusal,
     );
-    // No CSS survives the refusal, across the boundary.
+    // No CSS survives the refusal, across the boundary. What "no CSS" LOOKS
+    // like is the one place the two routes legitimately differ, and each is
+    // compared against the host's answer to ITS OWN demand — never against
+    // the other route's. Neither may carry bytes.
+    //
+    // What the complete-request route can no longer prove: with nothing
+    // assembled, there is no CSS-specific artifact to interrogate, so this
+    // case's record is byte-identical to `svelteServerRefusal`'s and its
+    // residual value is the no-bytes check below. That is the honest limit
+    // of a complete-only wire, not a gap to paper over; per-product refusal
+    // granularity returns here only if the wire ever gains partial-product
+    // responses, and is the owner of that wire change's job.
+    let expected_style = match route {
+        ProductRoute::ProfileCachedReads => {
+            // A cached per-node read of the refused compile finds no node.
+            let absent = host_node(
+                &server,
+                "/probe/Server.svelte",
+                VirtualNodeKind::Style { index: 0 },
+                &probe_profile(true, true),
+            );
+            assert_eq!(
+                absent,
+                HostOutcome::Missing,
+                "{transport}: the cached per-node read of a refused compile no longer answers \
+                 absent, so this comparison is measuring something else"
+            );
+            absent
+        }
+        ProductRoute::TypedCompileRequest => {
+            // The host's answer to the demand the probe ACTUALLY issued:
+            // the same typed server-runtime compile request, executed
+            // in-process. Comparing against the per-node read's refusal
+            // instead would compare two different questions and would not
+            // notice the typed route carrying a different code or a
+            // different failure arm.
+            host_server_runtime_request(&server, "/probe/Server.svelte")
+        }
+    };
     assert_case_matches_host(
         transport,
         "svelteServerStyle",
         &record["cases"]["svelteServerStyle"],
-        &host_node(
-            &server,
-            "/probe/Server.svelte",
-            VirtualNodeKind::Style { index: 0 },
-            &probe_profile(true, true),
-        ),
+        &expected_style,
     );
     assert!(
         record["cases"]["svelteServerStyle"]["code"] == Value::Null,
@@ -474,7 +604,9 @@ fn assert_transport_matches_the_host_route(transport: &str, record: &Value) {
         record["cases"]["svelteServerStyle"]
     );
 
-    // IDE/TSX: ensure + read vs host.
+    // IDE/TSX vs host. The BYTES, the map presence and the JSX flag are
+    // compared identically on both routes; what differs is what the
+    // producibility case reports and what a map-less IDE demand means.
     let ide_host = host_with(
         "/probe/Ide.svelte",
         SUPPORTED_SVELTE,
@@ -493,6 +625,21 @@ fn assert_transport_matches_the_host_route(transport: &str, record: &Value) {
         record["cases"]["ensureIdeCompiled"]["outcome"], "ok",
         "{transport}/ensureIdeCompiled: the transport errored: {}",
         record["cases"]["ensureIdeCompiled"]
+    );
+    // Both routes report the same fact — this carrier's IDE surface IS
+    // producible — even though one reaches it by ensuring a cached slot and
+    // the other by the demanded product row coming back from a complete
+    // compile. Both probes derive the value from something that can be
+    // false: the NAPI route from `ensureIdeCompiled`'s own boolean, the
+    // typed route from whether the response carries an `ideCompanion` row
+    // (read off the raw response, not through a projection that would abort
+    // the record instead of reporting an absent row). A route that quietly
+    // stopped producing the surface therefore reports `false` here and
+    // fails against the host's own answer.
+    assert!(
+        host_ensured,
+        "{transport}/ensureIdeCompiled: the host no longer produces this carrier's IDE surface, \
+         so the comparison below decides nothing"
     );
     assert_eq!(
         record["cases"]["ensureIdeCompiled"]["value"], host_ensured,
@@ -521,23 +668,67 @@ fn assert_transport_matches_the_host_route(transport: &str, record: &Value) {
         transported["isJsx"], host_ide.is_jsx,
         "{transport}/getIde: the reported JSX flag differs from the host's"
     );
-    // `get_ide` is a cached read: never-ensured profile has nothing to return.
-    let unensured_profile = CompileProfile {
+    // The map-less IDE demand. What it MEANS is route-decided, so each route
+    // is held to its own meaning against the host.
+    let unmapped_ide_profile = CompileProfile {
         source_map: false,
         ..ide_profile.clone()
     };
-    assert!(
-        ide_host
-            .get_ide("/probe/Ide.svelte", &unensured_profile)
-            .is_none(),
-        "{transport}: the host now serves an IDE product for a never-ensured profile, so the \
-         comparison below is stale"
-    );
-    assert_eq!(
-        record["cases"]["getIdeWithoutMap"]["outcome"], "missing",
-        "{transport}/getIde: the transport answered for a never-ensured profile: {}",
-        record["cases"]["getIdeWithoutMap"]
-    );
+    let unmapped = &record["cases"]["getIdeWithoutMap"];
+    match route {
+        ProductRoute::ProfileCachedReads => {
+            // A cached read of a profile nothing ensured has no slot to serve.
+            assert!(
+                ide_host
+                    .get_ide("/probe/Ide.svelte", &unmapped_ide_profile)
+                    .is_none(),
+                "{transport}: the host now serves an IDE product for a never-ensured profile, so \
+                 the comparison below is stale"
+            );
+            assert_eq!(
+                unmapped["outcome"], "missing",
+                "{transport}/getIde: the transport answered for a never-ensured profile: {unmapped}"
+            );
+        }
+        ProductRoute::TypedCompileRequest => {
+            // A complete compile always publishes the projection, so this is
+            // the IDE surface's optional-product axis: the map is withheld,
+            // and withholding it does not change the generated bytes.
+            ide_host
+                .ensure_ide_compiled("/probe/Ide.svelte", &unmapped_ide_profile)
+                .unwrap_or_else(|error| {
+                    panic!("{transport}: host map-less IDE compile failed: {error:?}")
+                });
+            let host_unmapped = ide_host
+                .get_ide("/probe/Ide.svelte", &unmapped_ide_profile)
+                .unwrap_or_else(|| {
+                    panic!("{transport}: the host published no map-less IDE product")
+                });
+            assert_eq!(
+                unmapped["outcome"], "published",
+                "{transport}/getIde: a complete IDE compile published nothing: {unmapped}"
+            );
+            assert_eq!(
+                unmapped["code"].as_str(),
+                Some(host_unmapped.code.as_ref()),
+                "{transport}/getIde: the map-less IDE bytes differ from the host's"
+            );
+            assert_eq!(
+                host_unmapped.source_map, None,
+                "{transport}: the host now emits a map for a map-less IDE demand, so this axis \
+                 decides nothing"
+            );
+            assert_eq!(
+                unmapped["hasMap"], false,
+                "{transport}/getIde: the transport published an IDE map that was never requested: \
+                 {unmapped}"
+            );
+            assert_eq!(
+                transported["code"], unmapped["code"],
+                "{transport}/getIde: the source-map axis changed the generated IDE bytes"
+            );
+        }
+    }
 
     // Option conversion: public-API `mode`.
     let vue = host_with(
@@ -588,17 +779,42 @@ fn assert_partition(
     exported: &[String],
     executed: &[&str],
     out_of_scope: &[(&str, &str)],
-    extra_out_of_scope: &[(&str, &str)],
+    extra_classified: &[&[(&str, &str)]],
 ) {
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet};
 
     let exported_set: BTreeSet<&str> = exported.iter().map(String::as_str).collect();
-    let executed_set: BTreeSet<&str> = executed.iter().copied().collect();
-    let classified_set: BTreeSet<&str> = out_of_scope
+    let mut executed_set: BTreeSet<&str> = BTreeSet::new();
+    let mut duplicate_executed: Vec<&str> = Vec::new();
+    for name in executed {
+        if !executed_set.insert(*name) {
+            duplicate_executed.push(*name);
+        }
+    }
+    assert!(
+        duplicate_executed.is_empty(),
+        "{transport}: {} spelling(s) are listed executed more than once, so the classification \
+         cannot prove uniqueness: {duplicate_executed:?}",
+        duplicate_executed.len()
+    );
+
+    let mut classified: BTreeMap<&str, &str> = BTreeMap::new();
+    let mut duplicate_classified: Vec<(&str, &str, &str)> = Vec::new();
+    for (name, reason) in out_of_scope
         .iter()
-        .chain(extra_out_of_scope.iter())
-        .map(|(name, _)| *name)
-        .collect();
+        .chain(extra_classified.iter().copied().flatten())
+    {
+        if let Some(prior) = classified.insert(*name, *reason) {
+            duplicate_classified.push((*name, prior, *reason));
+        }
+    }
+    assert!(
+        duplicate_classified.is_empty(),
+        "{transport}: {} spelling(s) appear in two classified lists, so the classification \
+         cannot prove uniqueness: {duplicate_classified:?}",
+        duplicate_classified.len()
+    );
+    let classified_set: BTreeSet<&str> = classified.keys().copied().collect();
 
     let both: Vec<&&str> = executed_set.intersection(&classified_set).collect();
     assert!(
@@ -719,7 +935,7 @@ fn the_napi_transport_matches_the_in_process_host_route() {
         "packages/native/scripts/probe-transport-surface.mjs",
         NAPI_BUILD,
     );
-    assert_transport_matches_the_host_route("napi", &record);
+    assert_transport_matches_the_host_route("napi", &record, ProductRoute::ProfileCachedReads);
 
     let transformed = &record["cases"]["transformVueStyle"];
     let parsed = verter_compiler::style_planner::parse_plain_css_for_verification(
@@ -732,6 +948,9 @@ fn the_napi_transport_matches_the_in_process_host_route() {
             .expect("the verification parser produced native CSS syntax IR");
     let expected_transform = verter_compiler::style_planner::transform_vue_style(
         verified,
+        // The probe hands over its own authored bytes with no external tool in
+        // front of them, so reported spans address exactly those bytes.
+        verter_compiler::style_planner::CascadeInput::Authored,
         "style.css",
         "style.css",
         "style.css",
@@ -743,7 +962,7 @@ fn the_napi_transport_matches_the_in_process_host_route() {
     assert!(expected_transform.stage_failures.is_empty());
     assert_eq!(
         transformed["code"].as_str(),
-        Some(expected_transform.code.as_str()),
+        Some(expected_transform.code()),
         "napi/transformVueStyle: the transported CSS differs from the in-process route's"
     );
     assert_eq!(
@@ -826,7 +1045,7 @@ fn the_napi_batch_route_matches_the_in_process_batch_route_item_for_item() {
             );
             assert_eq!(
                 entry["code"].as_str(),
-                Some(host_entry.code().as_ref()),
+                Some(host_entry.code()),
                 "napi/{label}[{index}]: the transport's module bytes differ from the host's"
             );
             assert_eq!(
@@ -836,7 +1055,7 @@ fn the_napi_batch_route_matches_the_in_process_batch_route_item_for_item() {
             );
             assert_eq!(
                 entry["lang"].as_str(),
-                host_entry.lang().as_deref(),
+                host_entry.lang(),
                 "napi/{label}[{index}]: the reported module language differs from the host's"
             );
             let errors: Vec<&str> = entry["errors"]
@@ -1056,6 +1275,47 @@ const WASM_OUT_OF_SCOPE: &[(&str, &str)] = &[
     ("setImportDependencies", "dependency-resolution input"),
 ];
 
+/// Live product routes this probe does not drive because ANOTHER suite
+/// drives them at the same JavaScript boundary.
+///
+/// A separate class from [`WASM_OUT_OF_SCOPE`] on purpose: every row there
+/// names a property of the METHOD ("audit records", "lint metadata") and
+/// stays true forever. These three are exported product routes a caller is
+/// steered toward for a per-keystroke loop, and the only reason they are
+/// absent here is this probe's own route choice — a reason that would also
+/// stay true forever, and would let the enumeration guard stop noticing a
+/// real coverage gap. The rows name the covering suite so a reader can
+/// check them; they are not mechanically linked to it. A structural
+/// coupling would be a name-keyed source scanner, which this repo does
+/// not land. Deleting `legacy_ide` would leave this enumeration green.
+///
+/// Covered today by `crates/verter_wasm/src/host_compile_request_route_tests.rs`
+/// (`legacy_virtual_file` / `legacy_ide`), which reads each spelling off the
+/// generated host object by its JavaScript name, invokes it with real JS
+/// values, and compares its product against the typed route's for the same
+/// demand. That suite runs on `wasm32-unknown-unknown` through
+/// wasm-bindgen-test-runner — a different JS host than this probe's Node
+/// import of the built `web`-target artifact. Equivalence is therefore
+/// transitive (legacy == typed there, typed == host here). Drift between
+/// the two suites' demands is silent.
+const WASM_COVERED_BY_THE_JS_BOUNDARY_SUITE: &[(&str, &str)] = &[
+    (
+        "ensureIdeCompiled",
+        "cached IDE compile, driven and compared against the typed route by the wasm \
+         JS-boundary suite's `legacy_ide`",
+    ),
+    (
+        "getIde",
+        "cached IDE read, driven and compared against the typed route by the wasm JS-boundary \
+         suite's `legacy_ide`",
+    ),
+    (
+        "getVirtualFile",
+        "cached per-node read, driven and compared against the typed route by the wasm \
+         JS-boundary suite's `legacy_virtual_file`",
+    ),
+];
+
 /// wasm-bindgen's own memory-management members on every generated class.
 /// They are binding-runtime plumbing, not product spellings.
 const WASM_BINDING_RUNTIME: &[(&str, &str)] = &[
@@ -1071,13 +1331,11 @@ const WASM_BINDING_RUNTIME: &[(&str, &str)] = &[
 
 /// The `VerterHost` methods the WASM probe actually executes.
 const WASM_EXECUTED: &[&str] = &[
+    "compileRequest",
     "compileWithAudit",
-    "getVirtualFile",
     "listVirtualFiles",
     "getPublicApi",
     "analyzeWithAudit",
-    "ensureIdeCompiled",
-    "getIde",
     "upsert",
 ];
 
@@ -1088,7 +1346,7 @@ fn the_wasm_transport_matches_the_in_process_host_route() {
         "packages/wasm/scripts/probe-transport-surface.mjs",
         WASM_BUILD,
     );
-    assert_transport_matches_the_host_route("wasm", &record);
+    assert_transport_matches_the_host_route("wasm", &record, ProductRoute::TypedCompileRequest);
 
     // wasm32 has no audited analysis; typed refusal, not empty success.
     let analyze = &record["cases"]["analyzeWithAudit"];
@@ -1134,7 +1392,7 @@ fn every_exported_wasm_spelling_is_executed_or_classified_out_of_scope() {
         &methods,
         WASM_EXECUTED,
         WASM_OUT_OF_SCOPE,
-        WASM_BINDING_RUNTIME,
+        &[WASM_BINDING_RUNTIME, WASM_COVERED_BY_THE_JS_BOUNDARY_SUITE],
     );
 }
 
@@ -1202,12 +1460,24 @@ fn the_audited_compile_spelling_captures_for_vue_and_not_for_svelte_on_both_tran
 
 // The missing-node transport contract
 
-/// Both transports report a missing node the same way: an absent response
-/// for `Err(HostError::MissingVirtualNode)`, never a throw. Absence is
-/// structural (no such node), not a failure — a throw would require matching
-/// error text. Driven both as structural absence (`style[0]` with no
-/// `<style>`) and through a refusal. A successful control on the same
-/// carrier proves the file loaded. Neither transport leaks a product.
+/// Both transports report STRUCTURAL absence the same way: an absent
+/// response for `Err(HostError::MissingVirtualNode)`, never a throw.
+/// Absence is structural (no such node), not a failure — a throw would
+/// require matching error text. A successful control on the same carrier
+/// proves the file loaded, and neither transport leaks a product.
+///
+/// The WASM probe's Vue-arm positive control is internal: a Vue carrier
+/// that HAS a `<style>` block must publish `style[0]` or the probe aborts
+/// the record. It is not a probe output key.
+///
+/// Absence reached THROUGH a refusal is a second lane, and there the two
+/// transports answer different questions. A cached per-node read of a
+/// refused compile still finds no node and reports it absent. A complete
+/// typed compile request has no such intermediate state: the refusal
+/// replaces the whole transaction, so the same demand carries the host's
+/// typed refusal code instead. Both are asserted, so a transport that
+/// silently swapped one class for the other fails here — what neither may
+/// do is publish a product.
 #[test]
 fn the_transports_report_a_missing_node_the_same_way() {
     let napi = probe(
@@ -1272,18 +1542,11 @@ fn the_transports_report_a_missing_node_the_same_way() {
         )
     };
 
-    for (label, napi_case, wasm_case) in [
-        (
-            "absence through a refusal",
-            &napi["cases"]["svelteServerStyle"],
-            &wasm["cases"]["svelteServerStyle"],
-        ),
-        (
-            "structural absence",
-            &napi["cases"]["vueMissingStyle"],
-            &wasm["cases"]["vueMissingStyle"],
-        ),
-    ] {
+    // Structural absence, where both transports still answer identically.
+    {
+        let label = "structural absence";
+        let napi_case = &napi["cases"]["vueMissingStyle"];
+        let wasm_case = &wasm["cases"]["vueMissingStyle"];
         // A missing node is never published as a product.
         for (transport, case) in [("napi", napi_case), ("wasm", wasm_case)] {
             assert_ne!(
@@ -1320,6 +1583,60 @@ fn the_transports_report_a_missing_node_the_same_way() {
         }
     }
 
+    // Absence reached THROUGH a refusal. The demand is the same on both
+    // transports — the CSS node of a server surface this carrier cannot
+    // emit — and neither may answer with bytes. What each reports is its own
+    // route's honest answer: the cached read finds no node in the refused
+    // compile, while the complete typed compile refuses the transaction and
+    // carries the host's diagnostic code.
+    //
+    // On the complete-request route this record is byte-identical to
+    // `svelteServerRefusal`'s: nothing was assembled, so the CSS demand and
+    // the main-node demand cannot produce different answers, and the
+    // `kind`/`index` the case asked for never gets consulted. This is
+    // therefore NOT a second independent rail there — its residual value is
+    // the no-bytes check above. Restoring per-product refusal granularity
+    // needs a wire that can answer per product, and belongs to whoever
+    // introduces partial-product responses.
+    let napi_refused = &napi["cases"]["svelteServerStyle"];
+    let wasm_refused = &wasm["cases"]["svelteServerStyle"];
+    for (transport, case) in [("napi", napi_refused), ("wasm", wasm_refused)] {
+        assert_ne!(
+            case["outcome"], "published",
+            "{transport}/absence through a refusal: a product was published for a refused \
+             compile: {case}"
+        );
+        assert_eq!(
+            case["code"],
+            Value::Null,
+            "{transport}/absence through a refusal: a product crossed the boundary for a refused \
+             compile: {case}"
+        );
+    }
+    assert_eq!(
+        napi_refused["outcome"], "missing",
+        "napi/absence through a refusal: the cached per-node read no longer reports the node of \
+         a refused compile as an absent response: {napi_refused}"
+    );
+    assert_eq!(
+        napi_refused["message"],
+        Value::Null,
+        "napi/absence through a refusal: the cached per-node read threw rather than answering \
+         absent: {napi_refused}"
+    );
+    assert_eq!(
+        wasm_refused["outcome"], "error",
+        "wasm/absence through a refusal: the typed compile request no longer surfaces the \
+         carrier's refusal for a node of the refused surface: {wasm_refused}"
+    );
+    assert!(
+        wasm_refused["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("svelte-runtime-unsupported-server-generate")),
+        "wasm/absence through a refusal: the refusal does not carry the host's typed diagnostic \
+         code: {wasm_refused}"
+    );
+
     // Control: the node that exists is published — absence is about the node.
     for (transport, record) in [("napi", &napi), ("wasm", &wasm)] {
         let case = &record["cases"]["vueMissingStyleControl"];
@@ -1335,6 +1652,11 @@ fn the_transports_report_a_missing_node_the_same_way() {
              own product"
         );
     }
+
+    // The WASM probe's Vue-arm positive control is internal to the probe
+    // (a Vue carrier with a `<style>` block must publish `style[0]` or the
+    // process aborts with no JSON). It is not a case key: adding one would
+    // change the probe's output set.
 }
 
 // The bundler route
@@ -3125,6 +3447,9 @@ fn the_non_vite_style_lane_scopes_through_the_shared_css_processor() {
             .expect("the verification parser produced native CSS syntax IR");
     let processed = verter_compiler::style_planner::transform_vue_style(
         verified,
+        // The probe hands over its own authored bytes with no external tool in
+        // front of them, so reported spans address exactly those bytes.
+        verter_compiler::style_planner::CascadeInput::Authored,
         "style.css",
         "style.css",
         "style.css",
@@ -3136,7 +3461,7 @@ fn the_non_vite_style_lane_scopes_through_the_shared_css_processor() {
     assert!(processed.stage_failures.is_empty());
     assert_eq!(
         scoped,
-        processed.code.as_str(),
+        processed.code(),
         "the non-Vite style lane's product is not the shared CSS processor's product for the same \
          bytes and scope id"
     );

--- a/crates/verter_session/src/framework/transport_route_equivalence_tests.rs
+++ b/crates/verter_session/src/framework/transport_route_equivalence_tests.rs
@@ -43,12 +43,15 @@
 //!
 //! CI executes the native and WASM comparison lanes (`Transport route
 //! equivalence` in `.github/workflows/ci.yml`) against freshly built
-//! `@verter/native` and wasm-bindgen web artifacts. That job fails if the
-//! `running N tests` line is missing, below the native/WASM floor (9), or
-//! does not name those two comparisons. It does not run the bundler lane:
-//! that lane also needs a matching `@verter/unplugin` freshness pin, a
-//! different surface. Clippy with `--features transport-authoritative`
-//! in `Rust Build Configurations` stays the cheap signature-drift check.
+//! `@verter/native` and wasm-bindgen web artifacts. That job runs an
+//! EXACT allowlist of the nine native/WASM/census names — substring
+//! skips are not used, so a later test cannot be silently dropped for
+//! its name's tokens — and fails if the `running N tests` line is
+//! missing, below the allowlist floor (9), or does not name those two
+//! comparisons. The bundler lane is not on the list: it also needs a
+//! matching `@verter/unplugin` freshness pin, a different surface. Clippy
+//! with `--features transport-authoritative` in `Rust Build
+//! Configurations` stays the cheap signature-drift check.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -313,29 +316,100 @@ fn host_node(
     }
 }
 
-/// The in-process host's answer to the SAME typed request the WASM probe
-/// issues for a Svelte carrier's mapped server runtime surface.
-///
-/// The binding this probe drives calls `VerterHost::compile_request`
-/// (`crates/verter_wasm/src/lib.rs`), so the comparison the typed route
-/// deserves is against this entry — not against a per-node profile read,
-/// which answers a different question about a different demand.
-///
-/// The request mirrors the probe's `runtimeRequest("svelte", { sourceMap:
-/// true, ssr: true })` field for field: production identity, no forced JS,
-/// one mapped `RuntimeServer` product, default Svelte options.
-fn host_server_runtime_request(host: &VerterHost, canonical: &str) -> HostOutcome {
-    use verter_compiler::compile_request::{
-        CompileProduct, CompileRequest, FrameworkCompileRequest, RuntimeProductRequest,
-        SvelteCompileRequest,
-    };
+/// Which framework arm of the WASM probe's typed request builders a
+/// mirrored in-process request states.
+#[derive(Clone, Copy)]
+enum ProbeFramework {
+    Svelte,
+    Vue,
+}
 
+/// The framework arm mirroring the probe's `runtimeRequest(fileKind, …)` /
+/// `ideRequest(fileKind, …)` option objects field for field: Svelte `{}`
+/// (all-default options), Vue `{ backend: "inferred", ssr, isCustomElement:
+/// [], babelParserPlugins: [] }`.
+fn probe_framework_request(
+    framework: ProbeFramework,
+    ssr: bool,
+) -> verter_compiler::compile_request::FrameworkCompileRequest {
+    use verter_compiler::compile_request::{
+        FrameworkCompileRequest, SvelteCompileRequest, VueBackendRequest, VueCompileRequest,
+    };
+    match framework {
+        ProbeFramework::Svelte => FrameworkCompileRequest::Svelte(SvelteCompileRequest::default()),
+        ProbeFramework::Vue => FrameworkCompileRequest::Vue(VueCompileRequest {
+            backend: VueBackendRequest::Inferred,
+            ssr,
+            is_custom_element: Vec::new(),
+            babel_parser_plugins: Vec::new(),
+            ..VueCompileRequest::default()
+        }),
+    }
+}
+
+/// The response's single product row, mirroring the probe's `soleProductRow`
+/// strictness: a one-product demand answered by anything else is a wire
+/// break on the comparison side too, not a datum.
+#[track_caller]
+fn sole_typed_row<'a>(
+    response: &'a crate::CompileRequestResponse,
+    canonical: &str,
+) -> &'a crate::CompiledProduct {
+    let [row] = response.products.as_slice() else {
+        panic!(
+            "{canonical}: expected exactly one typed product row, got {}: {:?}",
+            response.products.len(),
+            response
+                .products
+                .iter()
+                .map(|product| match product {
+                    crate::CompiledProduct::Runtime { kind, .. } => kind.wire_tag(),
+                    crate::CompiledProduct::Ide(_) => "ideCompanion",
+                    crate::CompiledProduct::Analysis(_) => "analysis",
+                })
+                .collect::<Vec<_>>()
+        )
+    };
+    row
+}
+
+/// The in-process host's answer to the SAME typed request the WASM probe
+/// issues for one node of a carrier's runtime surface — `runtimeRequest(
+/// fileKind, { sourceMap, ssr })` mirrored field for field: the stated
+/// identity (`isProduction: true`, `forceJs: false`, no filename, no
+/// component id), the one mapped runtime product, default style ownership,
+/// and the framework's own default options.
+///
+/// The binding this probe drives decodes its JS request into the canonical
+/// `CompileRequest` and calls `VerterHost::compile_request`
+/// (`crates/verter_wasm/src/lib.rs`), so the comparison the typed route
+/// deserves is against this entry — never against a per-node profile read,
+/// which answers a different question through a second option authority: a
+/// typed axis the profile happens not to model for this SFC would pass
+/// unnoticed.
+#[track_caller]
+fn host_typed_runtime_node(
+    host: &VerterHost,
+    canonical: &str,
+    framework: ProbeFramework,
+    ssr: bool,
+    source_map: bool,
+    node: VirtualNodeKind,
+) -> HostOutcome {
+    use verter_compiler::compile_request::{CompileProduct, CompileRequest, RuntimeProductRequest};
+
+    let runtime = RuntimeProductRequest {
+        runtime_source_map: source_map,
+        ..RuntimeProductRequest::default()
+    };
+    let product = if ssr {
+        CompileProduct::RuntimeServer(runtime)
+    } else {
+        CompileProduct::RuntimeClient(runtime)
+    };
     let request = CompileRequest::new(
-        vec![CompileProduct::RuntimeServer(RuntimeProductRequest {
-            runtime_source_map: true,
-            ..RuntimeProductRequest::default()
-        })],
-        FrameworkCompileRequest::Svelte(SvelteCompileRequest::default()),
+        vec![product],
+        probe_framework_request(framework, ssr),
         None,
         None,
         None,
@@ -347,15 +421,70 @@ fn host_server_runtime_request(host: &VerterHost, canonical: &str) -> HostOutcom
     });
 
     match host.compile_request(canonical, request) {
-        Ok(response) => panic!(
-            "{canonical}: the typed server-runtime request now completes, so the refusal \
-             comparison decides nothing: {} product row(s)",
-            response.products.len()
-        ),
+        Ok(response) => {
+            let crate::CompiledProduct::Runtime { nodes, .. } =
+                sole_typed_row(&response, canonical)
+            else {
+                panic!("{canonical}: the completed typed runtime request carried no runtime row");
+            };
+            match nodes.iter().find(|candidate| candidate.node == node) {
+                Some(row) => HostOutcome::Published {
+                    code: row.code.to_string(),
+                    source_map: row.source_map.as_ref().map(|map| map.to_string()),
+                    lang: row.lang.clone(),
+                },
+                // A completed compile whose product carries no such node is
+                // structural absence — the same class the cached read's
+                // `MissingVirtualNode` answers.
+                None => HostOutcome::Missing,
+            }
+        }
         Err(crate::CompileRequestFailure::RuntimeSurfaceRefused {
             diagnostic_code, ..
         }) => HostOutcome::Refused { diagnostic_code },
         Err(other) => panic!("{canonical}: unmodelled typed request outcome {other:?}"),
+    }
+}
+
+/// The in-process host's IDE projection for the SAME typed request the WASM
+/// probe issues — its `ideRequest("svelte", sourceMap)` mirrored field for
+/// field: `isProduction: false`, `forceJs: false`, default Svelte options,
+/// and one `ideCompanion` product with every axis stated (`wantSourceMap`,
+/// and `false` for `embedAmbientTypes`, `conditionalRootNarrowing`,
+/// `strictSlots`, and the carrier-bridge-substituted `ideChunkBoundaries`).
+#[track_caller]
+fn host_typed_ide(host: &VerterHost, canonical: &str, source_map: bool) -> crate::IdeResponse {
+    use verter_compiler::compile_request::{CompileProduct, CompileRequest, IdeProductRequest};
+
+    let request = CompileRequest::new(
+        vec![CompileProduct::IdeCompanion(IdeProductRequest {
+            want_source_map: source_map,
+            embed_ambient_types: false,
+            conditional_root_narrowing: false,
+            strict_slots: false,
+            types_module_name: None,
+            ide_chunk_boundaries: false,
+            ..IdeProductRequest::default()
+        })],
+        probe_framework_request(ProbeFramework::Svelte, false),
+        None,
+        None,
+        None,
+        false,
+        false,
+    )
+    .unwrap_or_else(|error| {
+        panic!("{canonical}: the probe's own request shape no longer constructs: {error:?}")
+    });
+
+    match host.compile_request(canonical, request) {
+        Ok(response) => {
+            let crate::CompiledProduct::Ide(ide) = sole_typed_row(&response, canonical) else {
+                panic!("{canonical}: the completed typed IDE request carried no ideCompanion row");
+            };
+            ide.clone()
+        }
+        Err(other) => panic!("{canonical}: the typed IDE request refused: {other:?}"),
     }
 }
 
@@ -440,44 +569,51 @@ enum ProductRoute {
 
 /// Every case the probes execute, compared against the in-process host.
 fn assert_transport_matches_the_host_route(transport: &str, record: &Value, route: ProductRoute) {
-    // Success + optional-product axis (supported Svelte).
+    // Success + optional-product axis (supported Svelte). Each route is
+    // compared against the host's answer to ITS OWN demand: the cached
+    // per-node read on NAPI, the identical typed compile request executed
+    // in-process on WASM. Comparing the typed arm against the profile-cache
+    // read would route the expected value through a second option authority
+    // — a typed axis the profile does not model for this SFC would pass
+    // unnoticed.
     let svelte = host_with(
         "/probe/Ok.svelte",
         SUPPORTED_SVELTE,
         verter_language::FileLanguage::svelte(),
     );
+    let expected_svelte_node = |source_map: bool, kind: VirtualNodeKind| match route {
+        ProductRoute::ProfileCachedReads => host_node(
+            &svelte,
+            "/probe/Ok.svelte",
+            kind,
+            &probe_profile(false, source_map),
+        ),
+        ProductRoute::TypedCompileRequest => host_typed_runtime_node(
+            &svelte,
+            "/probe/Ok.svelte",
+            ProbeFramework::Svelte,
+            false,
+            source_map,
+            kind,
+        ),
+    };
     assert_case_matches_host(
         transport,
         "svelteMainWithMap",
         &record["cases"]["svelteMainWithMap"],
-        &host_node(
-            &svelte,
-            "/probe/Ok.svelte",
-            VirtualNodeKind::Main,
-            &probe_profile(false, true),
-        ),
+        &expected_svelte_node(true, VirtualNodeKind::Main),
     );
     assert_case_matches_host(
         transport,
         "svelteMainWithoutMap",
         &record["cases"]["svelteMainWithoutMap"],
-        &host_node(
-            &svelte,
-            "/probe/Ok.svelte",
-            VirtualNodeKind::Main,
-            &probe_profile(false, false),
-        ),
+        &expected_svelte_node(false, VirtualNodeKind::Main),
     );
     assert_case_matches_host(
         transport,
         "svelteStyleWithMap",
         &record["cases"]["svelteStyleWithMap"],
-        &host_node(
-            &svelte,
-            "/probe/Ok.svelte",
-            VirtualNodeKind::Style { index: 0 },
-            &probe_profile(false, true),
-        ),
+        &expected_svelte_node(true, VirtualNodeKind::Style { index: 0 }),
     );
     // Optional-product axis both ways; no module-byte change.
     assert_eq!(
@@ -535,9 +671,14 @@ fn assert_transport_matches_the_host_route(transport: &str, record: &Value, rout
             VirtualNodeKind::Main,
             &probe_profile(true, true),
         ),
-        ProductRoute::TypedCompileRequest => {
-            host_server_runtime_request(&server, "/probe/Server.svelte")
-        }
+        ProductRoute::TypedCompileRequest => host_typed_runtime_node(
+            &server,
+            "/probe/Server.svelte",
+            ProbeFramework::Svelte,
+            true,
+            true,
+            VirtualNodeKind::Main,
+        ),
     };
     assert_eq!(
         refusal,
@@ -589,7 +730,14 @@ fn assert_transport_matches_the_host_route(transport: &str, record: &Value, rout
             // instead would compare two different questions and would not
             // notice the typed route carrying a different code or a
             // different failure arm.
-            host_server_runtime_request(&server, "/probe/Server.svelte")
+            host_typed_runtime_node(
+                &server,
+                "/probe/Server.svelte",
+                ProbeFramework::Svelte,
+                true,
+                true,
+                VirtualNodeKind::Style { index: 0 },
+            )
         }
     };
     assert_case_matches_host(
@@ -605,50 +753,60 @@ fn assert_transport_matches_the_host_route(transport: &str, record: &Value, rout
     );
 
     // IDE/TSX vs host. The BYTES, the map presence and the JSX flag are
-    // compared identically on both routes; what differs is what the
-    // producibility case reports and what a map-less IDE demand means.
+    // compared identically on both routes; each against the host's answer to
+    // that route's OWN demand — the cached ensure-then-read pair on NAPI,
+    // the identical typed IDE request executed in-process on WASM. What
+    // differs beyond that is what the producibility case reports and what a
+    // map-less IDE demand means.
     let ide_host = host_with(
         "/probe/Ide.svelte",
         SUPPORTED_SVELTE,
         verter_language::FileLanguage::svelte(),
     );
-    let ide_profile = CompileProfile {
-        target: crate::CompileTarget::IDE,
-        source_map: true,
-        hmr_strategy: crate::types::HmrStrategy::None,
-        ..CompileProfile::default()
-    };
-    let host_ensured = ide_host
-        .ensure_ide_compiled("/probe/Ide.svelte", &ide_profile)
-        .unwrap_or_else(|error| panic!("{transport}: host ensure_ide_compiled failed: {error:?}"));
     assert_eq!(
         record["cases"]["ensureIdeCompiled"]["outcome"], "ok",
         "{transport}/ensureIdeCompiled: the transport errored: {}",
         record["cases"]["ensureIdeCompiled"]
     );
-    // Both routes report the same fact — this carrier's IDE surface IS
-    // producible — even though one reaches it by ensuring a cached slot and
-    // the other by the demanded product row coming back from a complete
-    // compile. Both probes derive the value from something that can be
-    // false: the NAPI route from `ensureIdeCompiled`'s own boolean, the
-    // typed route from whether the response carries an `ideCompanion` row
-    // (read off the raw response, not through a projection that would abort
-    // the record instead of reporting an absent row). A route that quietly
-    // stopped producing the surface therefore reports `false` here and
-    // fails against the host's own answer.
-    assert!(
-        host_ensured,
-        "{transport}/ensureIdeCompiled: the host no longer produces this carrier's IDE surface, \
-         so the comparison below decides nothing"
-    );
-    assert_eq!(
-        record["cases"]["ensureIdeCompiled"]["value"], host_ensured,
-        "{transport}/ensureIdeCompiled: the transport's answer differs from the host's"
-    );
-
-    let host_ide = ide_host
-        .get_ide("/probe/Ide.svelte", &ide_profile)
-        .unwrap_or_else(|| panic!("{transport}: the host published no IDE product"));
+    let host_ide = match route {
+        ProductRoute::ProfileCachedReads => {
+            let ide_profile = CompileProfile {
+                target: crate::CompileTarget::IDE,
+                source_map: true,
+                hmr_strategy: crate::types::HmrStrategy::None,
+                ..CompileProfile::default()
+            };
+            // This route's transport case reports the cached spelling's own
+            // boolean, so it is pinned against the host's — a route that
+            // quietly stopped producing the surface reports `false` here
+            // and fails.
+            let host_ensured = ide_host
+                .ensure_ide_compiled("/probe/Ide.svelte", &ide_profile)
+                .unwrap_or_else(|error| {
+                    panic!("{transport}: host ensure_ide_compiled failed: {error:?}")
+                });
+            assert!(
+                host_ensured,
+                "{transport}/ensureIdeCompiled: the host no longer produces this carrier's IDE \
+                 surface, so the comparison below decides nothing"
+            );
+            assert_eq!(
+                record["cases"]["ensureIdeCompiled"]["value"], host_ensured,
+                "{transport}/ensureIdeCompiled: the transport's answer differs from the host's"
+            );
+            ide_host
+                .get_ide("/probe/Ide.svelte", &ide_profile)
+                .unwrap_or_else(|| panic!("{transport}: the host published no IDE product"))
+        }
+        ProductRoute::TypedCompileRequest => {
+            // No `value` pin exists on this route and none is invented: a
+            // completed response cannot lack the `ideCompanion` row (the
+            // probe's strict row reader aborts the record if it did), so
+            // `outcome === "ok"` plus the published mapped product below ARE
+            // the producibility proof.
+            host_typed_ide(&ide_host, "/probe/Ide.svelte", true)
+        }
+    };
     let transported = &record["cases"]["getIdeWithMap"];
     assert_eq!(
         transported["outcome"], "published",
@@ -670,14 +828,16 @@ fn assert_transport_matches_the_host_route(transport: &str, record: &Value, rout
     );
     // The map-less IDE demand. What it MEANS is route-decided, so each route
     // is held to its own meaning against the host.
-    let unmapped_ide_profile = CompileProfile {
-        source_map: false,
-        ..ide_profile.clone()
-    };
     let unmapped = &record["cases"]["getIdeWithoutMap"];
     match route {
         ProductRoute::ProfileCachedReads => {
             // A cached read of a profile nothing ensured has no slot to serve.
+            let unmapped_ide_profile = CompileProfile {
+                target: crate::CompileTarget::IDE,
+                source_map: false,
+                hmr_strategy: crate::types::HmrStrategy::None,
+                ..CompileProfile::default()
+            };
             assert!(
                 ide_host
                     .get_ide("/probe/Ide.svelte", &unmapped_ide_profile)
@@ -694,16 +854,7 @@ fn assert_transport_matches_the_host_route(transport: &str, record: &Value, rout
             // A complete compile always publishes the projection, so this is
             // the IDE surface's optional-product axis: the map is withheld,
             // and withholding it does not change the generated bytes.
-            ide_host
-                .ensure_ide_compiled("/probe/Ide.svelte", &unmapped_ide_profile)
-                .unwrap_or_else(|error| {
-                    panic!("{transport}: host map-less IDE compile failed: {error:?}")
-                });
-            let host_unmapped = ide_host
-                .get_ide("/probe/Ide.svelte", &unmapped_ide_profile)
-                .unwrap_or_else(|| {
-                    panic!("{transport}: the host published no map-less IDE product")
-                });
+            let host_unmapped = host_typed_ide(&ide_host, "/probe/Ide.svelte", false);
             assert_eq!(
                 unmapped["outcome"], "published",
                 "{transport}/getIde: a complete IDE compile published nothing: {unmapped}"
@@ -926,6 +1077,23 @@ const NAPI_EXECUTED: &[&str] = &[
     "ensureIdeCompiled",
     "getIde",
     "upsert",
+];
+
+/// Typed compile-route spellings this probe does not drive: it exercises
+/// NAPI's cached profile route (`getVirtualFile`/`ensureIdeCompiled`/
+/// `getIde`), which is the route this suite compares against the
+/// in-process host, and these exports are the typed-route vocabulary it
+/// states no case in. No coverage over them is claimed here — this probe
+/// neither executes them nor verifies that any other suite does.
+const NAPI_TYPED_ROUTES_NOT_DRIVEN: &[(&str, &str)] = &[
+    (
+        "compileRequest",
+        "typed single-carrier compile route; this probe drives the cached profile route instead",
+    ),
+    (
+        "compileRequests",
+        "typed batch compile route; this probe drives the cached profile route instead",
+    ),
 ];
 
 #[test]
@@ -1191,7 +1359,13 @@ fn every_exported_napi_spelling_is_executed_or_classified_out_of_scope() {
         "the enumeration found no VerterHost methods, so it proves nothing"
     );
 
-    assert_partition("napi", &methods, NAPI_EXECUTED, NAPI_OUT_OF_SCOPE, &[]);
+    assert_partition(
+        "napi",
+        &methods,
+        NAPI_EXECUTED,
+        NAPI_OUT_OF_SCOPE,
+        &[NAPI_TYPED_ROUTES_NOT_DRIVEN],
+    );
 
     // The module-level exports are accounted for too.
     let module_exports: Vec<String> = record["surface"]["moduleExports"]
@@ -1275,44 +1449,34 @@ const WASM_OUT_OF_SCOPE: &[(&str, &str)] = &[
     ("setImportDependencies", "dependency-resolution input"),
 ];
 
-/// Live product routes this probe does not drive because ANOTHER suite
-/// drives them at the same JavaScript boundary.
+/// Legacy cached-route spellings this probe does not drive: it demands
+/// every product through the typed `compileRequest`, and these exports are
+/// the binding-local cached route that route supersedes.
 ///
-/// A separate class from [`WASM_OUT_OF_SCOPE`] on purpose: every row there
-/// names a property of the METHOD ("audit records", "lint metadata") and
-/// stays true forever. These three are exported product routes a caller is
-/// steered toward for a per-keystroke loop, and the only reason they are
-/// absent here is this probe's own route choice — a reason that would also
-/// stay true forever, and would let the enumeration guard stop noticing a
-/// real coverage gap. The rows name the covering suite so a reader can
-/// check them; they are not mechanically linked to it. A structural
-/// coupling would be a name-keyed source scanner, which this repo does
-/// not land. Deleting `legacy_ide` would leave this enumeration green.
-///
-/// Covered today by `crates/verter_wasm/src/host_compile_request_route_tests.rs`
-/// (`legacy_virtual_file` / `legacy_ide`), which reads each spelling off the
-/// generated host object by its JavaScript name, invokes it with real JS
-/// values, and compares its product against the typed route's for the same
-/// demand. That suite runs on `wasm32-unknown-unknown` through
-/// wasm-bindgen-test-runner — a different JS host than this probe's Node
-/// import of the built `web`-target artifact. Equivalence is therefore
-/// transitive (legacy == typed there, typed == host here). Drift between
-/// the two suites' demands is silent.
-const WASM_COVERED_BY_THE_JS_BOUNDARY_SUITE: &[(&str, &str)] = &[
+/// A separate class from [`WASM_OUT_OF_SCOPE`] because the reason is this
+/// probe's route choice, not the method's product — each name IS a live
+/// product route a per-keystroke consumer is steered toward. The rows make
+/// NO coverage claim over them: this probe neither executes them nor
+/// verifies that any other suite does. A wasm-bindgen-test suite drives
+/// them on a different JS host than this Node web probe, and deleting its
+/// `legacy_ide` / `legacy_virtual_file` tests leaves this enumeration
+/// green — that is this classification's honest limit, stated here rather
+/// than papered over with a cross-suite coverage claim nothing enforces.
+const WASM_LEGACY_CACHED_ROUTES_NOT_DRIVEN: &[(&str, &str)] = &[
     (
         "ensureIdeCompiled",
-        "cached IDE compile, driven and compared against the typed route by the wasm \
-         JS-boundary suite's `legacy_ide`",
+        "legacy cached IDE-compile route; this probe demands IDE products through the typed \
+         `compileRequest` instead",
     ),
     (
         "getIde",
-        "cached IDE read, driven and compared against the typed route by the wasm JS-boundary \
-         suite's `legacy_ide`",
+        "legacy cached IDE read; this probe demands IDE products through the typed \
+         `compileRequest` instead",
     ),
     (
         "getVirtualFile",
-        "cached per-node read, driven and compared against the typed route by the wasm \
-         JS-boundary suite's `legacy_virtual_file`",
+        "legacy cached per-node read; this probe demands runtime products through the typed \
+         `compileRequest` instead",
     ),
 ];
 
@@ -1392,7 +1556,7 @@ fn every_exported_wasm_spelling_is_executed_or_classified_out_of_scope() {
         &methods,
         WASM_EXECUTED,
         WASM_OUT_OF_SCOPE,
-        &[WASM_BINDING_RUNTIME, WASM_COVERED_BY_THE_JS_BOUNDARY_SUITE],
+        &[WASM_BINDING_RUNTIME, WASM_LEGACY_CACHED_ROUTES_NOT_DRIVEN],
     );
 }
 
@@ -1527,20 +1691,23 @@ fn the_transports_report_a_missing_node_the_same_way() {
     );
 
     // The successful control, on the SAME carrier as the structural case.
-    let control = host_node(
+    // Each transport's control is the host's answer to that transport's OWN
+    // demand for the same node — the cached per-node read for NAPI, the
+    // identical typed runtime request executed in-process for WASM.
+    let napi_control = host_node(
         &no_style,
         "/probe/NoStyle.vue",
         VirtualNodeKind::Main,
         &probe_profile(false, true),
     );
-    let HostOutcome::Published {
-        code: control_code, ..
-    } = &control
-    else {
-        panic!(
-            "the host no longer publishes the control node, so absence proves nothing: {control:?}"
-        )
-    };
+    let wasm_control = host_typed_runtime_node(
+        &no_style,
+        "/probe/NoStyle.vue",
+        ProbeFramework::Vue,
+        false,
+        true,
+        VirtualNodeKind::Main,
+    );
 
     // Structural absence, where both transports still answer identically.
     {
@@ -1638,16 +1805,25 @@ fn the_transports_report_a_missing_node_the_same_way() {
     );
 
     // Control: the node that exists is published — absence is about the node.
-    for (transport, record) in [("napi", &napi), ("wasm", &wasm)] {
+    for (transport, record, control) in [
+        ("napi", &napi, &napi_control),
+        ("wasm", &wasm, &wasm_control),
+    ] {
         let case = &record["cases"]["vueMissingStyleControl"];
         assert_eq!(
             case["outcome"], "published",
             "{transport}: the successful control did not publish, so the absent answers above \
              cannot be attributed to the requested node: {case}"
         );
+        let HostOutcome::Published { code, .. } = control else {
+            panic!(
+                "{transport}: the host route no longer publishes the control node, so absence \
+                 proves nothing: {control:?}"
+            )
+        };
         assert_eq!(
             case["code"].as_str(),
-            Some(control_code.as_str()),
+            Some(code.as_str()),
             "{transport}: the successful control published something other than the host's \
              own product"
         );

--- a/packages/wasm/scripts/probe-transport-surface.mjs
+++ b/packages/wasm/scripts/probe-transport-surface.mjs
@@ -159,20 +159,6 @@ function compile(host, canonicalId, request) {
 }
 
 /**
- * Whether a completed compile's response carries a row for the named
- * product — the producibility question, read straight off the response.
- *
- * Deliberately NOT routed through `soleProductRow`: this answers `false`
- * for a response that carried no such row instead of aborting the record,
- * so it is a question the route can fail. `soleProductRow` stays the strict
- * reader for cases that go on to take BYTES out of a row.
- */
-function carriesProductRow(response, tag) {
-  const products = Array.isArray(response?.products) ? response.products : [];
-  return products.some((product) => product?.kind === tag);
-}
-
-/**
  * The single product row of a completed compile, taken by tag — never by
  * position.
  *
@@ -341,8 +327,12 @@ const results = { loaded: true, surface: enumerateSurface(module_), cases: {} };
 // There is no ensure-then-read pair here and no ordering for a caller to
 // get right: one typed call states the IDE demand and answers with the
 // projection. `ensureIdeCompiled` is that same call's producibility answer
-// — the demanded IDE product came back — read off the one response rather
-// than compiled a second time.
+// — the demanded IDE product came back. On this complete-only route that
+// answer is the error arm: a completed `compileRequest` response cannot
+// lack the `ideCompanion` row (`compile_request_response_to_wasm` maps
+// products 1:1 or errors), so no live boolean exists to report on the ok
+// arm and none is invented. `outcome: "ok"` plus the published
+// `getIdeWithMap` case below are the producibility proof.
 //
 // The map axis is a second demand, so it is a second call. It is no longer
 // a never-compiled slot that answers absent: a complete compile publishes
@@ -357,16 +347,10 @@ const results = { loaded: true, surface: enumerateSurface(module_), cases: {} };
   });
   const mappedIde = compile(host, "/probe/Ide.svelte", ideRequest("svelte", true));
   const unmappedIde = compile(host, "/probe/Ide.svelte", ideRequest("svelte", false));
-  // Producibility on this complete-only route is the error arm: if the IDE
-  // product is admitted and publishes nothing, `compileRequest` throws and
-  // this case is `{outcome: "error"}`. A completed response cannot lack the
-  // row (`compile_request_response_to_wasm` maps 1:1 or errors), so `value`
-  // on the ok arm is not independently falsifiable here. The host comparison
-  // still pins `true` against `ensure_ide_compiled`.
   results.cases.ensureIdeCompiled =
     mappedIde.refusal !== null
       ? { outcome: "error", message: mappedIde.refusal }
-      : { outcome: "ok", value: carriesProductRow(mappedIde.response, "ideCompanion") };
+      : { outcome: "ok" };
   results.cases.getIdeWithMap = ideCase(mappedIde);
   results.cases.getIdeWithoutMap = ideCase(unmappedIde);
 }

--- a/packages/wasm/scripts/probe-transport-surface.mjs
+++ b/packages/wasm/scripts/probe-transport-surface.mjs
@@ -2,8 +2,25 @@
 // Drive the WASM transport's representative cases and print JSON for
 // Rust-side comparison against the in-process host.
 //
+// Every compiled product here is demanded through the transport's typed
+// compile request: one call per demand, stating the products it wants, with
+// the case then selecting what it is about out of the response. No compile
+// profile is built, no ensure-then-read ordering is relied on, and no case
+// drives the module more than once.
+//
 // Enumerates the exported surface from the built artifact, never from
-// source. Exit: 0 probed, 2 module could not load (never a pass).
+// source.
+//
+// Exit: 0 probed with the whole record on stdout; 2 the module could not
+// load, with a `{loaded: false}` record naming why (never a pass). A third
+// state exists and is deliberate: a wire break a case cannot classify
+// (`soleProductRow`) throws out of the case and past the single
+// `process.stdout.write` at the end, so the process exits non-zero having
+// printed NOTHING — including every unrelated case. The Rust side reads
+// that as "the probe emitted no JSON" and fails with the captured stderr.
+// Aborting the record is the intent: a response whose product rows do not
+// match the demand makes every other case's reading of that response
+// unsafe.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -46,24 +63,174 @@ const SUPPORTED_SVELTE =
   '<script>\n  let count = $state(0);\n</script>\n\n<div class="root">{count}</div>\n\n<style>\n  .root { color: red; }\n</style>\n';
 const VUE_SFC =
   "<script setup>\nconst props = defineProps({ label: { type: String, required: true } });\n</script>\n\n<template>\n  <button>{{ label }}</button>\n</template>\n";
+// The same SFC WITH a `<style>` block. The structural-absence case below
+// reads `style[0]` out of a Vue runtime product; that absence only means
+// "this carrier has no such block" if a Vue runtime product WOULD carry the
+// row when the carrier does have one. This carrier is the positive control
+// that pins it, on the same framework arm and the same typed demand.
+const VUE_SFC_WITH_STYLE = `${VUE_SFC}\n<style>\n.root { color: red; }\n</style>\n`;
 
-function virtualFile(host, canonicalId, kind, compileProfile, index) {
-  const nodeKind = index === undefined ? { kind } : { kind, index };
+// ── The typed compile request ────────────────────────────────────────────
+//
+// One call carries the whole demand and answers with every product it asked
+// for, so a case about one node of a carrier's runtime surface selects that
+// node out of the response instead of issuing a read of its own. Sibling
+// cases over the SAME demand share one compile: this route consults and
+// publishes no compile cache slot, so re-stating a demand would compile it
+// a second time rather than hit a warm slot.
+//
+// The HMR strategy has no slot on this request. The route compiles with HMR
+// off, which is exactly what a `"none"` strategy asked for.
+
+/**
+ * A carrier's runtime surface, as one typed request.
+ *
+ * The requested product kind IS the client/server demand: on the Svelte arm
+ * there is no second bit that could disagree with it. The Vue arm keeps its
+ * own `options.ssr` row, which the request schema carries separately and
+ * which therefore CAN contradict the product tag; both are derived from the
+ * one `ssr` argument here so this probe never states that contradiction.
+ * The source-map axis is stated per product rather than once for the whole
+ * compile.
+ */
+function runtimeRequest(fileKind, { sourceMap, ssr }) {
+  const identity = { isProduction: true, forceJs: false };
+  const products = [
+    ssr
+      ? { runtimeServer: { runtimeSourceMap: sourceMap } }
+      : { runtimeClient: { runtimeSourceMap: sourceMap } },
+  ];
+  if (fileKind === "svelte") return { svelte: { identity, products, options: {} } };
+  return {
+    vue: {
+      identity,
+      products,
+      options: { backend: "inferred", ssr, isCustomElement: [], babelParserPlugins: [] },
+    },
+  };
+}
+
+/**
+ * A carrier's IDE surface, as one typed request.
+ *
+ * `ideChunkBoundaries` is REQUIRED to be false: the carrier bridge
+ * substitutes its own value derived from the selected template block, so
+ * the host route refuses the request outright when a caller asks for `true`
+ * and `false` is the only admitted value. The remaining axes are stated at
+ * the same values a bare IDE demand leaves them at.
+ */
+function ideRequest(fileKind, sourceMap) {
+  const identity = { isProduction: false, forceJs: false };
+  const products = [
+    {
+      ideCompanion: {
+        wantSourceMap: sourceMap,
+        embedAmbientTypes: false,
+        conditionalRootNarrowing: false,
+        strictSlots: false,
+        ideChunkBoundaries: false,
+      },
+    },
+  ];
+  if (fileKind === "svelte") return { svelte: { identity, products, options: {} } };
+  return {
+    vue: {
+      identity,
+      products,
+      options: { backend: "inferred", ssr: false, isCustomElement: [], babelParserPlugins: [] },
+    },
+  };
+}
+
+/**
+ * Execute ONE typed request.
+ *
+ * The route is complete-only: a refusal at any stage throws the refusal
+ * message as a string and publishes nothing, while a completed compile
+ * carries every requested product. The two are separated here so no case
+ * downstream has to infer which of them happened.
+ */
+function compile(host, canonicalId, request) {
   try {
-    const response = host.getVirtualFile({ canonicalId, nodeKind, compileProfile });
-    // A MISSING node comes back as a null/absent response; a REFUSED one
-    // throws. Both are recorded distinctly — collapsing them would hide which
-    // one the transport produced.
-    if (response === null || response === undefined) return { outcome: "missing" };
-    return {
-      outcome: "published",
-      code: response.code,
-      hasMap: response.sourceMap !== null && response.sourceMap !== undefined,
-      lang: response.lang ?? null,
-    };
+    return { refusal: null, response: host.compileRequest(canonicalId, request) };
   } catch (error) {
-    return { outcome: "error", message: String(error?.message ?? error) };
+    return { refusal: String(error?.message ?? error), response: null };
   }
+}
+
+/**
+ * Whether a completed compile's response carries a row for the named
+ * product — the producibility question, read straight off the response.
+ *
+ * Deliberately NOT routed through `soleProductRow`: this answers `false`
+ * for a response that carried no such row instead of aborting the record,
+ * so it is a question the route can fail. `soleProductRow` stays the strict
+ * reader for cases that go on to take BYTES out of a row.
+ */
+function carriesProductRow(response, tag) {
+  const products = Array.isArray(response?.products) ? response.products : [];
+  return products.some((product) => product?.kind === tag);
+}
+
+/**
+ * The single product row of a completed compile, taken by tag — never by
+ * position.
+ *
+ * A response carries one row per requested product, tagged with the
+ * request's own spelling, so a one-product demand answered by anything else
+ * is a wire break inside this probe. It fails the probe loudly rather than
+ * riding into the record as an absent product.
+ */
+function soleProductRow(response, tags) {
+  const products = Array.isArray(response?.products) ? response.products : [];
+  const observed = products.map((product) => product?.kind ?? "<untagged>");
+  if (products.length !== 1 || !tags.includes(observed[0])) {
+    throw new Error(
+      `expected exactly one [${tags.join("|")}] product row, got: [${observed.join(", ")}]`,
+    );
+  }
+  return products[0];
+}
+
+/**
+ * One node of a carrier's compiled runtime surface.
+ *
+ * Three classes, kept apart. A REFUSED compile is an `error` carrying the
+ * host's typed diagnostic code: the transaction produced nothing, so no
+ * node of it exists. A node the carrier simply does not have is `missing`:
+ * the compile completed and its product carries no such row. Everything
+ * else is the published node. Collapsing any two of these would hide which
+ * one the transport produced.
+ *
+ * `productTag` is the exact requested product (`runtimeClient` or
+ * `runtimeServer`). A completed compile whose sole row is the other tag
+ * is a wire break, not a pass.
+ */
+function runtimeNodeCase(compiled, productTag, kind, index) {
+  if (compiled.refusal !== null) return { outcome: "error", message: compiled.refusal };
+  const nodes = soleProductRow(compiled.response, [productTag]).nodes ?? [];
+  const node = nodes.find(
+    (row) => row?.node?.kind === kind && (row?.node?.index ?? null) === (index ?? null),
+  );
+  if (node === undefined) return { outcome: "missing" };
+  return {
+    outcome: "published",
+    code: node.code,
+    hasMap: node.sourceMap !== null && node.sourceMap !== undefined,
+    lang: node.lang ?? null,
+  };
+}
+
+/** The IDE projection of a completed compile, or the refusal that replaced it. */
+function ideCase(compiled) {
+  if (compiled.refusal !== null) return { outcome: "error", message: compiled.refusal };
+  const row = soleProductRow(compiled.response, ["ideCompanion"]);
+  return {
+    outcome: "published",
+    code: row.code,
+    hasMap: row.sourceMap !== null && row.sourceMap !== undefined,
+    isJsx: row.isJsx ?? null,
+  };
 }
 
 const results = { loaded: true, surface: enumerateSurface(module_), cases: {} };
@@ -77,23 +244,23 @@ const results = { loaded: true, surface: enumerateSurface(module_), cases: {} };
     source: SUPPORTED_SVELTE,
     fileKind: "svelte",
   });
-  results.cases.svelteMainWithMap = virtualFile(host, "/probe/Ok.svelte", "main", {
-    isProduction: true,
-    sourceMap: true,
-    hmrStrategy: "none",
-  });
-  results.cases.svelteMainWithoutMap = virtualFile(host, "/probe/Ok.svelte", "main", {
-    isProduction: true,
-    sourceMap: false,
-    hmrStrategy: "none",
-  });
-  results.cases.svelteStyleWithMap = virtualFile(
+  // One compile per DEMAND, not per case: the main and style cases below are
+  // two nodes of the one mapped runtime surface, so they read the same
+  // response rather than compiling that surface twice.
+  const mapped = compile(
     host,
     "/probe/Ok.svelte",
-    "style",
-    { isProduction: true, sourceMap: true, hmrStrategy: "none" },
-    0,
+    runtimeRequest("svelte", { sourceMap: true, ssr: false }),
   );
+  // The map axis is its own demand, so it is its own compile.
+  const unmapped = compile(
+    host,
+    "/probe/Ok.svelte",
+    runtimeRequest("svelte", { sourceMap: false, ssr: false }),
+  );
+  results.cases.svelteMainWithMap = runtimeNodeCase(mapped, "runtimeClient", "main");
+  results.cases.svelteMainWithoutMap = runtimeNodeCase(unmapped, "runtimeClient", "main");
+  results.cases.svelteStyleWithMap = runtimeNodeCase(mapped, "runtimeClient", "style", 0);
   results.cases.svelteNodeList = host.listVirtualFiles("/probe/Ok.svelte");
 }
 
@@ -106,28 +273,27 @@ const results = { loaded: true, surface: enumerateSurface(module_), cases: {} };
     source: SUPPORTED_SVELTE,
     fileKind: "svelte",
   });
-  results.cases.svelteServerRefusal = virtualFile(host, "/probe/Server.svelte", "main", {
-    isProduction: true,
-    sourceMap: true,
-    ssr: true,
-    hmrStrategy: "none",
-  });
-  results.cases.svelteServerStyle = virtualFile(
+  // The server surface is ONE demand, and the route refuses it as a whole:
+  // no product is assembled, so neither the main node nor the CSS node of
+  // that surface exists. Both cases therefore observe the same typed
+  // refusal, carrying the host's diagnostic code, and neither carries bytes.
+  const server = compile(
     host,
     "/probe/Server.svelte",
-    "style",
-    { isProduction: true, sourceMap: true, ssr: true, hmrStrategy: "none" },
-    0,
+    runtimeRequest("svelte", { sourceMap: true, ssr: true }),
   );
+  results.cases.svelteServerRefusal = runtimeNodeCase(server, "runtimeServer", "main");
+  results.cases.svelteServerStyle = runtimeNodeCase(server, "runtimeServer", "style", 0);
 }
 
 // STRUCTURAL ABSENCE: a node the carrier simply does not have
 //
-// The refusal case above reaches a missing node THROUGH a refused compilation.
-// This one never involves a refusal at all: the carrier compiles normally and
-// the requested node does not exist, because the SFC has no `<style>` block.
-// The two are distinct classes of "no product" and a transport can serialize
-// them differently, so both are probed.
+// The case above never produces a node because the whole compile is refused.
+// This one involves no refusal at all: the carrier compiles normally, its
+// runtime product is complete, and the requested node is still not in it —
+// the SFC has no `<style>` block. The two are distinct classes of "no
+// product" and the transport serializes them differently, so both are
+// probed and the successful control below proves the file loaded.
 {
   const host = new module_.VerterHost({});
   host.upsert({
@@ -136,24 +302,51 @@ const results = { loaded: true, surface: enumerateSurface(module_), cases: {} };
     source: VUE_SFC,
     fileKind: "vue",
   });
-  results.cases.vueMissingStyle = virtualFile(
+  const styleless = compile(
     host,
     "/probe/NoStyle.vue",
-    "style",
-    { isProduction: true, sourceMap: true, hmrStrategy: "none" },
-    0,
+    runtimeRequest("vue", { sourceMap: true, ssr: false }),
   );
-  // The SUCCESSFUL control on the same carrier: the node that DOES exist is
-  // published, so an absent answer above cannot be a host that failed to load
-  // the file at all.
-  results.cases.vueMissingStyleControl = virtualFile(host, "/probe/NoStyle.vue", "main", {
-    isProduction: true,
-    sourceMap: true,
-    hmrStrategy: "none",
+  results.cases.vueMissingStyle = runtimeNodeCase(styleless, "runtimeClient", "style", 0);
+  // The SUCCESSFUL control, out of the SAME completed compile: the node that
+  // DOES exist is published, so the absent answer above cannot be a host that
+  // failed to load the file at all.
+  results.cases.vueMissingStyleControl = runtimeNodeCase(styleless, "runtimeClient", "main");
+
+  // Internal positive control for the absent node itself. A Vue carrier that
+  // HAS a `<style>` block must publish `style[0]` on this same demand, or the
+  // absence above is vacuous. This is NOT a probe output key: adding one
+  // would change the case set. A miss aborts the record instead.
+  host.upsert({
+    canonicalId: "/probe/WithStyle.vue",
+    inputId: "/probe/WithStyle.vue",
+    source: VUE_SFC_WITH_STYLE,
+    fileKind: "vue",
   });
+  const styled = compile(
+    host,
+    "/probe/WithStyle.vue",
+    runtimeRequest("vue", { sourceMap: true, ssr: false }),
+  );
+  const styleControl = runtimeNodeCase(styled, "runtimeClient", "style", 0);
+  if (styleControl.outcome !== "published") {
+    throw new Error(
+      `Vue carrier with a style block produced ${styleControl.outcome}, so vueMissingStyle cannot discriminate a missing style node`,
+    );
+  }
 }
 
-// IDE/TSX: ensure + read, on the profile the LSP uses
+// IDE/TSX: the IDE surface as a requested product
+//
+// There is no ensure-then-read pair here and no ordering for a caller to
+// get right: one typed call states the IDE demand and answers with the
+// projection. `ensureIdeCompiled` is that same call's producibility answer
+// — the demanded IDE product came back — read off the one response rather
+// than compiled a second time.
+//
+// The map axis is a second demand, so it is a second call. It is no longer
+// a never-compiled slot that answers absent: a complete compile publishes
+// the projection either way, with the map only when it was asked for.
 {
   const host = new module_.VerterHost({});
   host.upsert({
@@ -162,37 +355,20 @@ const results = { loaded: true, surface: enumerateSurface(module_), cases: {} };
     source: SUPPORTED_SVELTE,
     fileKind: "svelte",
   });
-  const ideProfile = { target: "ide", sourceMap: true, hmrStrategy: "none" };
-  try {
-    results.cases.ensureIdeCompiled = {
-      outcome: "ok",
-      value: host.ensureIdeCompiled("/probe/Ide.svelte", ideProfile),
-    };
-  } catch (error) {
-    results.cases.ensureIdeCompiled = {
-      outcome: "error",
-      message: String(error?.message ?? error),
-    };
-  }
-  for (const [label, profile] of [
-    ["getIdeWithMap", ideProfile],
-    ["getIdeWithoutMap", { target: "ide", sourceMap: false, hmrStrategy: "none" }],
-  ]) {
-    try {
-      const ide = host.getIde("/probe/Ide.svelte", profile);
-      results.cases[label] =
-        ide === null || ide === undefined
-          ? { outcome: "missing" }
-          : {
-              outcome: "published",
-              code: ide.code,
-              hasMap: ide.sourceMap !== null && ide.sourceMap !== undefined,
-              isJsx: ide.isJsx ?? null,
-            };
-    } catch (error) {
-      results.cases[label] = { outcome: "error", message: String(error?.message ?? error) };
-    }
-  }
+  const mappedIde = compile(host, "/probe/Ide.svelte", ideRequest("svelte", true));
+  const unmappedIde = compile(host, "/probe/Ide.svelte", ideRequest("svelte", false));
+  // Producibility on this complete-only route is the error arm: if the IDE
+  // product is admitted and publishes nothing, `compileRequest` throws and
+  // this case is `{outcome: "error"}`. A completed response cannot lack the
+  // row (`compile_request_response_to_wasm` maps 1:1 or errors), so `value`
+  // on the ok arm is not independently falsifiable here. The host comparison
+  // still pins `true` against `ensure_ide_compiled`.
+  results.cases.ensureIdeCompiled =
+    mappedIde.refusal !== null
+      ? { outcome: "error", message: mappedIde.refusal }
+      : { outcome: "ok", value: carriesProductRow(mappedIde.response, "ideCompanion") };
+  results.cases.getIdeWithMap = ideCase(mappedIde);
+  results.cases.getIdeWithoutMap = ideCase(unmappedIde);
 }
 
 // PUBLIC API: option conversion of the `mode` argument

--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -104,7 +104,7 @@ schema = 2
 "CCA1O2J" = { status = "implemented", commit_message = "feat(napi): expose typed compile request routes", commit_date = "2026-09-03T01:15:00+01:00", pull_request = 471 }
 "CCA1O3" = { status = "implemented", commit_message = "feat(wasm): add a typed host compile-request adapter and local request DTOs", commit_date = "2026-08-31T22:30:00+01:00" }
 "CCA1O3A" = { status = "pending" }
-"CCA1O3B" = { status = "pending" }
+"CCA1O3B" = { status = "implemented", commit_message = "feat(wasm): drive the transport probe through the typed compile request", commit_date = "2026-09-03T10:30:00+01:00", pull_request = 483 }
 "CCA1O3C" = { status = "implemented", commit_message = "feat(ci): execute the wasm JavaScript-boundary tests in the canonical gate", commit_date = "2026-09-01T02:10:00+01:00" }
 "CCA1O3D" = { status = "implemented", commit_message = "feat(wasm): expose a callable typed compile request on the browser host", commit_date = "2026-09-02T12:00:00+01:00", pull_request = 469 }
 "CCA1O3E" = { status = "implemented", commit_message = "test(*): check the committed carrier fixtures against the built wasm host", commit_date = "2026-09-01T09:00:00+01:00" }

--- a/roadmap/0.1.0-tama/charters/compiler-compiler-bridge/CCA1O3B.md
+++ b/roadmap/0.1.0-tama/charters/compiler-compiler-bridge/CCA1O3B.md
@@ -69,3 +69,18 @@ Move the direct WASM transport-surface probe to CCA1O3's typed request while the
 ## Verification and review
 
 Run `node --check`, WASM request-conversion tests, the hermetic transport comparison, and `targeted-domain`. Add only CCA1O3B's ledger row and apply `public-3`.
+
+## Recorded deviation (awaiting ratification)
+
+The complete-only typed route this charter mandates admits no `missing`
+classification for two of the cases it also directs to preserve, so the
+implementation changed `svelteServerStyle` (`missing` → `error`) and
+`getIdeWithoutMap` (`missing` → `published`) on the WASM transport only. That
+is a deliberate departure from this charter's "missing-versus-refused
+classification … remain unchanged" surface line, its "classification …
+equivalent" acceptance line, and its "transport divergence" abort clause.
+
+The conflict, why no third answer exists, what the implementation did instead,
+the disclosed residual, and the three ratification options are recorded in
+`decisions/2026-09-03-complete-only-transport-probe-classification-deviation.md`.
+Nothing in this charter is amended by that record until a maintainer rules.

--- a/roadmap/0.1.0-tama/charters/compiler-compiler-bridge/CCA1O3B.md
+++ b/roadmap/0.1.0-tama/charters/compiler-compiler-bridge/CCA1O3B.md
@@ -45,7 +45,7 @@ Move the direct WASM transport-surface probe to CCA1O3's typed request while the
 
 - The sole production/tooling surface is `packages/wasm/scripts/probe-transport-surface.mjs`.
 - Owns every profile-bearing `getVirtualFile`, `getIde`, and `ensureIdeCompiled` probe case in that file, including Vue/Svelte success, optional-product, structural-absence, and refusal variants. Each becomes one typed `compileRequest`; the IDE cases stop being an ensure-then-read pair.
-- Exported-surface enumeration, missing-versus-refused classification, canonical IDs, output/map/diagnostic normalization, SFC-absolute span meaning, and JavaScript UTF-16 offsets remain unchanged.
+- Exported-surface enumeration, the structural missing-versus-refused distinction, canonical IDs, output/map/diagnostic normalization, SFC-absolute span meaning, and JavaScript UTF-16 offsets remain unchanged.
 
 ## Exact predecessor contract
 
@@ -57,30 +57,28 @@ Move the direct WASM transport-surface probe to CCA1O3's typed request while the
 ## Acceptance and evidence
 
 - The probe contains no legacy profile request or positional IDE profile and exercises the typed Vue/Svelte request variants. Every probe axis survives, and each former ensure-then-read IDE case is one typed call; no case gains a WASM call or copies a source into its request.
-- Probe output keys, ordering, output/map/refusal classification, canonical IDs, and serialized offsets are equivalent.
+- Probe output keys, ordering, canonical IDs, and serialized offsets are equivalent. Classification follows the two-route contract: wherever both routes answer the same demand — success, optional-product, structural absence, typed refusal — the transports classify identically. The routes' semantics differ in exactly two places, and in each the transport is held to the in-process host's answer to that route's own demand: a node of a refused compile (a cached per-node read answers `missing`; a complete-only typed request carries the refusal as `error`) and a map-less IDE demand (a cached read of a never-ensured profile answers `missing`; a complete typed compile publishes the projection without the map).
 - `node --check`, WASM request-conversion fixtures, and the existing native/WASM transport comparison prove shape and behavior.
 
 ## Deletions, budgets, and aborts
 
 - Delete no WASM compatibility type, binding decode, probe case, output key, or comparison rail.
 - Ceiling: 250 production/tooling LOC, 1 production/tooling file, 1 related package; rescope above 600 LOC, 3 files, 2 unrelated packages, or if fixture generation or playground runtime routing enters.
-- Abort on a deleted probe axis, duplicate WASM execution, changed normalization, or transport divergence.
+- Abort on a deleted probe axis, duplicate WASM execution, changed normalization, or a transport whose answer diverges from the in-process host's answer to the same demand on that transport's own route.
 
 ## Verification and review
 
 Run `node --check`, WASM request-conversion tests, the hermetic transport comparison, and `targeted-domain`. Add only CCA1O3B's ledger row and apply `public-3`.
 
-## Recorded deviation (awaiting ratification)
+## Recorded deviation (ratified: charter amended)
 
-The complete-only typed route this charter mandates admits no `missing`
-classification for two of the cases it also directs to preserve, so the
-implementation changed `svelteServerStyle` (`missing` → `error`) and
-`getIdeWithoutMap` (`missing` → `published`) on the WASM transport only. That
-is a deliberate departure from this charter's "missing-versus-refused
-classification … remain unchanged" surface line, its "classification …
-equivalent" acceptance line, and its "transport divergence" abort clause.
-
-The conflict, why no third answer exists, what the implementation did instead,
-the disclosed residual, and the three ratification options are recorded in
+The complete-only typed route this charter originally mandated admits no
+`missing` classification for two of the cases it also directed to preserve,
+so the implementation classifies `svelteServerStyle` (`missing` → `error`)
+and `getIdeWithoutMap` (`missing` → `published`) on the WASM transport
+only; the NAPI transport's classifications are unchanged. The conflict, why
+no third answer exists, and the ratification options are recorded in
 `decisions/2026-09-03-complete-only-transport-probe-classification-deviation.md`.
-Nothing in this charter is amended by that record until a maintainer rules.
+The architect ruling of 2026-09-04 selected option (b): the acceptance and
+abort clauses above now state the two-route contract, which is the invariant
+this charter enforces from here on.

--- a/roadmap/0.1.0-tama/decisions/2026-09-03-complete-only-transport-probe-classification-deviation.md
+++ b/roadmap/0.1.0-tama/decisions/2026-09-03-complete-only-transport-probe-classification-deviation.md
@@ -1,0 +1,195 @@
+# Recorded deviation: complete-only route classification on the WASM transport probe
+
+- Status: **recorded, awaiting maintainer ratification**
+- Date: 2026-09-03
+- Node: `CCA1O3B` — "WASM transport-probe host-request migration"
+  (`charters/compiler-compiler-bridge/CCA1O3B.md`)
+- Adds: this record, plus an amendment section appended to CCA1O3B's own charter
+  that points here. Amends no other node's charter, budgets, boundaries,
+  predecessors, or ledger line. Adds no DAG node.
+
+## Why this is recorded rather than decided locally
+
+`CLAUDE.md` — "Where implementing the plan appears impossible, record a
+deviation for maintainer ratification rather than substituting a local
+decision — an unrecorded deviation is far more expensive to unwind than a
+delay." The CCA1O3B implementation hit exactly that condition twice and
+resolved it in code. This record is the missing half.
+
+## The conflict
+
+CCA1O3B's charter states three things that cannot all hold at once for the
+route it mandates.
+
+1. **Surfaces:** "missing-versus-refused classification … remain unchanged."
+2. **Acceptance:** "Probe output keys, ordering, output/map/refusal
+   classification, canonical IDs, and serialized offsets are equivalent."
+3. **Aborts:** "Abort on a deleted probe axis, duplicate WASM execution,
+   changed normalization, or transport divergence."
+
+against, in the same charter:
+
+4. **Surfaces:** "Each becomes one typed `compileRequest`; the IDE cases stop
+   being an ensure-then-read pair."
+5. **Deletions:** "Delete no WASM compatibility type, binding decode, probe
+   case, output key, or comparison rail."
+
+The typed `compileRequest` route is complete-only by construction
+(`VerterHost::compile_request`, `crates/verter_session/src/host_resolve/compile_request_execute.rs`;
+the binding at `crates/verter_wasm/src/lib.rs`): a refusal at any stage fails
+the WHOLE request and publishes no product, and every accepted demand
+compiles. That eliminates two intermediate states the profile-cached route
+has, and two probe cases classified exactly those states.
+
+### Case A — `svelteServerStyle`: `missing` → `error`
+
+The demand is the CSS node of a Svelte server runtime surface the carrier
+refuses. On the profile-cached route the refused compile still leaves a
+per-node read that finds no such node, so the case classifies `missing`. On
+the complete-only route no product is assembled, so there is no node of it to
+be absent; the same demand surfaces the carrier's typed refusal
+(`svelte-runtime-unsupported-server-generate`), classified `error`.
+
+There is no third answer. Preserving `missing` would require the probe to
+fabricate a classification the wire does not produce.
+
+### Case B — `getIdeWithoutMap`: `missing` → `published`
+
+The demand is a map-less IDE surface. On the profile-cached route this was a
+`get_ide` read against a profile nothing had ensured, so there was no cache
+slot to serve and the case classified `missing` — an artifact of the
+ensure-then-read pair, which point 4 above explicitly directs this node to
+remove. On the complete-only route every IDE demand compiles, so the
+projection publishes and the case becomes the IDE surface's optional-product
+axis (the map is withheld; the bytes are unchanged).
+
+Preserving `missing` would require keeping the ensure-then-read pair the
+charter directs this node to remove, or issuing a demand the probe does not
+make.
+
+## What the implementation did
+
+`assert_transport_matches_the_host_route`
+(`crates/verter_session/src/framework/transport_route_equivalence_tests.rs`)
+gained a two-variant `ProductRoute` discriminator, and each transport is
+compared against the in-process host's answer to ITS OWN demand:
+
+- `ProfileCachedReads` (NAPI) — unchanged expectations, plus a new staleness
+  guard asserting the host still answers `Missing` for the refused compile's
+  style node.
+- `TypedCompileRequest` (WASM) — `svelteServerStyle` is compared against the
+  host's own `VerterHost::compile_request` failure for the identical typed
+  server-runtime demand (not against a per-node profile read, which answers a
+  different question); `getIdeWithoutMap` is compared against the host's
+  map-less IDE product, with the bytes pinned equal to the mapped demand's.
+
+No probe axis, output key, or comparison rail was deleted. Both cases still
+run on both transports, both are still compared against the host, and neither
+may carry bytes for a refusal.
+
+## What is asked of the maintainer
+
+Ratify ONE of:
+
+- **(a) Accept the deviation as scoped here.** The abort clause's "transport
+  divergence" is read as "a transport whose answer diverges from the host's
+  answer to the same demand", not "two transports classifying different
+  questions identically". The charter amendment below is the durable record.
+- **(b) Amend the charter.** Replace the "transport divergence" abort clause
+  and the "classification … equivalent" acceptance line with the explicit
+  two-route contract, so future work on this file reads the real invariant.
+- **(c) Reject.** Then CCA1O3B is not implementable as chartered and needs a
+  rescope — the complete-only route admits no other classification for these
+  two cases.
+
+Until ratified, this record stands as the disclosure; it is not itself an
+approval.
+
+## Known residual, disclosed
+
+On the complete-only route `svelteServerStyle` and `svelteServerRefusal`
+produce byte-identical records: with nothing assembled, the CSS demand and the
+main-node demand cannot differ, and the `kind`/`index` the case states is
+never consulted. Its residual value there is the no-bytes check. Restoring
+per-product refusal granularity requires a wire that can answer per product
+and belongs to whoever introduces partial-product responses; the limitation is
+stated at the assertion site so no reader mistakes it for a second rail.
+
+## Consequences
+
+- No other node's budget, boundary, predecessor list, or ledger line changes.
+- The NAPI transport's classifications are untouched.
+- The `ProductRoute` discriminator is the durable mechanism either ratification
+  branch (a) or (b) keeps; only branch (c) would remove it.
+
+## Disclosed adjacent gaps
+
+Three findings surfaced during review. Gap 2 is a mechanical compile repair
+this candidate had to carry. Gap 1 is this node's evidence obligation: the
+typed-vs-profile comparison cannot be proven by compilation. Gap 3 is not
+this node's work and is not repaired here.
+
+### 1. The suite needs an execution gate — `TRANSPORT-SUITE-UNGATED`
+
+- **Finding:** `transport-authoritative` compiled in no CI job and ran in no
+  `scripts/gate.mjs` lane. Syntax and Clippy cannot detect a behavioral
+  divergence between the typed WASM request and the in-process profile
+  route — the comparison this node now asserts for the first time.
+- **Disposition:** `ADOPT-NOW`. `.github/workflows/ci.yml` keeps the cheap
+  Clippy compile of the feature (signature drift) and adds
+  `transport-route-equivalence`, which downloads the `wasm-build` and
+  `build-native-node` artifacts, runs
+  `cargo test -p verter_session --lib --features transport-authoritative
+  transport_route_equivalence` with the bundler tests skipped, and fails
+  unless the `running N tests` line is present, at least 9, and names
+  `the_wasm_transport_matches_the_in_process_host_route` and
+  `the_napi_transport_matches_the_in_process_host_route`.
+- **Scope:** one extra workflow file. Related packages stay at one
+  (`@verter/wasm`). Under the charter's rescope trigger of 3 files / 2
+  unrelated packages. Recorded here rather than silently absorbed.
+- **Residual:** the bundler lane is not in that job (see gap 3). Clippy
+  still cannot prove it compiled the `cfg`-gated module if the `mod` line
+  is dropped; the execution job is that proof.
+
+### 2. The suite did not compile at the merge base — `TRANSPORT-SUITE-STALE-CALL`
+
+- **Finding:** `b71832360` (2026-09-02, "Exact style identity and owner-domain
+  reuse") inserted `input_stage: CascadeInput` as `transform_vue_style`'s
+  second parameter and turned the style outcome's `code` field into a `code()`
+  method. The suite's two call sites still passed the pre-change 8-argument
+  form and read `.code`, so the merge-base tree was UNCOMPILABLE under
+  `transport-authoritative`.
+- **Consequence for evidence:** this charter's acceptance leans on "the
+  existing native/WASM transport comparison" as prior proof. That comparison
+  could not have executed at the merge base, so no evidence is inheritable and
+  the suite must be run on this exact tree with freshly built artifacts.
+- **Disposition:** `ADOPT-NOW`, minimally. The patch repairs the two
+  call sites and the three accessor reads because the suite cannot run
+  otherwise. This is someone else's breakage carried by this candidate, not
+  this node's work, and it is disclosed here rather than folded in silently. It is
+  a mechanical signature update; it changes no assertion and no expectation.
+- **Root cause:** gap 1. A gated suite would have failed `b71832360`.
+
+### 3. The bundler lane of the same suite is red at HEAD — `BUNDLER-PROBE-FRESHNESS-PIN-STALE`
+
+- **Finding:** `packages/unplugin/scripts/probe-bundler-route.freshness.json` pins
+  the plugin source and dist digests the bundler probe requires. `4d92d368d`
+  (2026-08-29, "align Vue types and Vite style staging") changed
+  `packages/unplugin/src` without regenerating that pin, so all bundler-lane
+  tests in `transport_route_equivalence` fail their artifact-freshness check
+  before reaching any assertion — even with `pnpm --filter @verter/unplugin build`
+  freshly run.
+- **Not introduced here.** `4d92d368d` is an ancestor of this branch. This
+  candidate does not touch `packages/unplugin/`. The native, WASM,
+  audited-compile, missing-node and enumeration lanes are the lanes this
+  node needs, and they do not consume that pin.
+- **Disposition:** `DEFER`, deliberately NOT repaired here. Regenerating the
+  pin, or changing bundler cache-key handling, is a different package's
+  production surface. Absorbing a red the owning surface should see, or
+  landing unrelated plugin behavior in this node, is refused.
+- **Durable owner:** `@verter/unplugin` (the next production change to
+  `packages/unplugin/src`).
+- **Resolution gate:** no later than plan close; the acceptance test is the
+  `transport-authoritative` bundler lane going green against a pin produced
+  by a checked-in generator, not a hand-edited digest.
+- **Ruling reference:** this record.

--- a/roadmap/0.1.0-tama/decisions/2026-09-03-complete-only-transport-probe-classification-deviation.md
+++ b/roadmap/0.1.0-tama/decisions/2026-09-03-complete-only-transport-probe-classification-deviation.md
@@ -1,6 +1,7 @@
 # Recorded deviation: complete-only route classification on the WASM transport probe
 
-- Status: **recorded, awaiting maintainer ratification**
+- Status: **ratified 2026-09-04 — architect ruling, option (b), charter
+  amended to the two-route contract**
 - Date: 2026-09-03
 - Node: `CCA1O3B` — "WASM transport-probe host-request migration"
   (`charters/compiler-compiler-bridge/CCA1O3B.md`)
@@ -102,8 +103,15 @@ Ratify ONE of:
   rescope — the complete-only route admits no other classification for these
   two cases.
 
-Until ratified, this record stands as the disclosure; it is not itself an
+Until the ruling, this record stood as the disclosure; it was not itself an
 approval.
+
+**Ruling, 2026-09-04 (architect): option (b).** The charter's "classification …
+equivalent" acceptance line and "transport divergence" abort clause are
+replaced by the explicit two-route contract, so future work on this file
+reads the real invariant. The charter's deviation section now records the
+ruling; the implementation as scoped under "What the implementation did"
+is the shape the amended charter mandates.
 
 ## Known residual, disclosed
 
@@ -139,9 +147,11 @@ this node's work and is not repaired here.
   Clippy compile of the feature (signature drift) and adds
   `transport-route-equivalence`, which downloads the `wasm-build` and
   `build-native-node` artifacts, runs
-  `cargo test -p verter_session --lib --features transport-authoritative
-  transport_route_equivalence` with the bundler tests skipped, and fails
-  unless the `running N tests` line is present, at least 9, and names
+  `cargo test -p verter_session --lib --features transport-authoritative`
+  on an exact allowlist of the nine native/WASM/census test names (no
+  substring skips, so a later test cannot be silently dropped for its
+  name's tokens), and fails unless the `running N tests` line is present,
+  at least 9, and names
   `the_wasm_transport_matches_the_in_process_host_route` and
   `the_napi_transport_matches_the_in_process_host_route`.
 - **Scope:** one extra workflow file. Related packages stay at one


### PR DESCRIPTION
Closes #142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded transport compatibility coverage across native and WebAssembly builds.
  - Added validation for route equivalence, missing resources, refusals, IDE outputs, and source maps.
  - Improved checks to detect incomplete, duplicated, or mismatched transport results.

- **Documentation**
  - Clarified transport behavior, route classifications, accepted WebAssembly differences, and verification requirements.
  - Recorded the completed implementation and related architectural decision.

- **Chores**
  - Updated continuous integration to run the new transport checks and include them in required verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->