### PR TITLE
refactor(compiler-execution): native comparison-tool host-request

### DIFF
--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -93,7 +93,7 @@ schema = 2
 "CCA1O1B" = { status = "implemented", commit_message = "feat(*): execute a caller-supplied canonical compile request", commit_date = "2026-09-01T18:00:00+01:00" }
 "CCA1O2" = { status = "implemented", commit_message = "feat(napi): add a tagged native host compile-request adapter", commit_date = "2026-08-31T21:14:14+01:00" }
 "CCA1O2A" = { status = "implemented", commit_message = "feat(bench): drive native benchmark compiles through the typed host request", commit_date = "2026-09-04T18:00:00+01:00" }
-"CCA1O2B" = { status = "pending" }
+"CCA1O2B" = { status = "implemented", commit_message = "refactor(compiler-execution): native comparison-tool host-request migration", commit_date = "2026-09-04T21:50:00+01:00" }
 "CCA1O2C" = { status = "pending" }
 "CCA1O2D" = { status = "pending" }
 "CCA1O2E" = { status = "pending" }

--- a/scripts/compare-per-file.mjs
+++ b/scripts/compare-per-file.mjs
@@ -527,39 +527,37 @@ function compileWithVerter(host, source, filename, mode) {
       }
     }
 
-    // Get the main virtual file (script + template combined)
-    const profile = {
-      filename,
-      isProduction: isProd,
-      ssr: isSsr,
-      hmrStrategy: 'none',
-      sourceMap: false,
-      forceJs: false,
-    };
+    // One typed compile request against the already-registered source. The
+    // legacy profile's hmrStrategy 'none' is the typed route's own fixed
+    // shape, and its unset axes are that route's defaults, so only the axes
+    // the old profile stated carry over.
+    const runtimeKind = isSsr ? 'runtimeServer' : 'runtimeClient';
+    const compiled = host.compileRequest(upsertResult.canonicalId, {
+      framework: 'vue',
+      identity: { filename, isProduction: isProd, forceJs: false },
+      products: [{ kind: runtimeKind, runtimeSourceMap: false }],
+      options: {
+        backend: 'inferred',
+        ssr: isSsr,
+        isCustomElement: [],
+        babelParserPlugins: [],
+      },
+    });
+    const runtime = compiled.products.find((product) => product.kind === runtimeKind);
+    const nodeByKind = (kind) =>
+      runtime?.nodes.find((node) => node.node.kind === kind);
 
     // Try getting separate script + template blocks
     let code = '';
-    const scriptFile = host.getVirtualFile({
-      canonicalId: upsertResult.canonicalId,
-      nodeKind: { kind: 'script' },
-      compileProfile: profile,
-    });
+    const scriptFile = nodeByKind('script');
     if (scriptFile) code += scriptFile.code;
 
-    const templateFile = host.getVirtualFile({
-      canonicalId: upsertResult.canonicalId,
-      nodeKind: { kind: 'template' },
-      compileProfile: profile,
-    });
+    const templateFile = nodeByKind('template');
     if (templateFile) code += (code ? '\\n\\n' : '') + templateFile.code;
 
     // If no script or template, try 'main'
     if (!code) {
-      const mainFile = host.getVirtualFile({
-        canonicalId: upsertResult.canonicalId,
-        nodeKind: { kind: 'main' },
-        compileProfile: profile,
-      });
+      const mainFile = nodeByKind('main');
       if (mainFile) code = mainFile.code;
     }
 

--- a/scripts/ssr-baseline/compare.mjs
+++ b/scripts/ssr-baseline/compare.mjs
@@ -221,25 +221,30 @@ function compileWithVerter(source, filePath) {
       fileKind: "vue",
     });
 
-    const profile = {
-      filename,
-      ssr: true,
-      forceJs: true,
-      sourceMap: false,
-    };
-
-    const result = host.getVirtualFile({
-      canonicalId: upsertResult.canonicalId,
-      nodeKind: { kind: "main" },
-      compileProfile: profile,
+    // One typed compile request against the already-registered source. The
+    // legacy profile's unset axes (isProduction, hmrStrategy, runtime module
+    // name) are the typed route's own defaults, so only the axes the old
+    // profile stated carry over.
+    const compiled = host.compileRequest(upsertResult.canonicalId, {
+      framework: "vue",
+      identity: { filename, isProduction: false, forceJs: true },
+      products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+      options: {
+        backend: "inferred",
+        ssr: true,
+        isCustomElement: [],
+        babelParserPlugins: [],
+      },
     });
+    const runtime = compiled.products.find((product) => product.kind === "runtimeServer");
+    const result = runtime?.nodes.find((node) => node.node.kind === "main");
 
     if (!result || !result.code) {
       return { error: "null response from getVirtualFile" };
     }
 
-    if (result.diagnostics?.hasErrors) {
-      const msgs = (result.diagnostics.diagnostics || [])
+    if (compiled.diagnostics?.hasErrors) {
+      const msgs = (compiled.diagnostics.diagnostics || [])
         .filter((d) => d.severity === "error")
         .map((d) => d.message)
         .join("; ");

--- a/scripts/vue-behavior-compare/run.mjs
+++ b/scripts/vue-behavior-compare/run.mjs
@@ -318,21 +318,28 @@ function verterCompile(source, filePath, { ssr, vapor }) {
       source,
       fileKind: "vue",
     });
-    const profile = {
-      filename,
-      ssr: !!ssr,
-      forceJs: true,
-      forceVapor: !!vapor,
-      sourceMap: false,
-    };
-    const result = host.getVirtualFile({
-      canonicalId: upsert.canonicalId,
-      nodeKind: { kind: "main" },
-      compileProfile: profile,
+    // One typed compile request against the already-registered source. The
+    // legacy profile's unset axes (isProduction, hmrStrategy, runtime module
+    // name) are the typed route's own defaults, so only the axes the old
+    // profile stated carry over.
+    const ssrOn = !!ssr;
+    const runtimeKind = ssrOn ? "runtimeServer" : "runtimeClient";
+    const compiled = host.compileRequest(upsert.canonicalId, {
+      framework: "vue",
+      identity: { filename, isProduction: false, forceJs: true },
+      products: [{ kind: runtimeKind, runtimeSourceMap: false }],
+      options: {
+        backend: vapor ? "vapor" : "inferred",
+        ssr: ssrOn,
+        isCustomElement: [],
+        babelParserPlugins: [],
+      },
     });
+    const runtime = compiled.products.find((product) => product.kind === runtimeKind);
+    const result = runtime?.nodes.find((node) => node.node.kind === "main");
     if (!result?.code) return { error: "empty verter output" };
-    if (result.diagnostics?.hasErrors) {
-      const msgs = (result.diagnostics.diagnostics || [])
+    if (compiled.diagnostics?.hasErrors) {
+      const msgs = (compiled.diagnostics.diagnostics || [])
         .filter((d) => d.severity === "error")
         .map((d) => d.message)
         .join("; ");


### PR DESCRIPTION
## Summary

Migrates the three repository comparison tools (scripts/compare-per-file.mjs, scripts/ssr-baseline/compare.mjs, scripts/vue-behavior-compare/run.mjs) from legacy getVirtualFile({compileProfile}) calls onto the typed host compileRequest route: each tool now issues one Vue-framework typed request (identity carries filename/isProduction/forceJs; a single runtimeClient or runtimeServer product carries runtimeSourceMap; options carry backend/ssr/isCustomElement/babelParserPlugins) against the already-registered source and reads script/template/main nodes from the returned runtime product, preserving compare-per-file's script+template then main fallback control flow. Legacy axes with no typed wire slot (hmrStrategy 'none', unset runtimeModuleName, isProduction) were verified equal to the typed route's own fixed defaults, so nothing silently drops. Evidence: node --check on all three scripts; a byte-parity harness (debug NAPI build, 5-file corpus incl. a style-only SFC exercising the main fallback and a vapor-marker SFC) showing byte-identical emitted code, diffs, and reports old-vs-new across dev/prod/ssr and client/ssr/vapor modes; hermetic conversion fixtures cargo test -p verter_ffi host_compile_request pass 38/38. The implementation ledger row is transitioned to implemented.

Part of #104.

## Model attribution

| Role | Runtime | Model | Effort |
| --- | --- | --- | --- |
| implementer | kimi | kimi-code/kimi-for-coding | medium |
| reviewer | kimi | kimi-code/kimi-for-coding | medium |
| reviewer | zcode | glm-5.3 | medium |
| reviewer | grok | grok-4.6 | medium |

Review history: http://THE-DESKTOP:7350/api/events?nodeId=CCA1O2B

Landing is automated once reviews, CI and CodeRabbit are green; do not merge manually.

<!-- roadmap:begin -->
Closes #134
<!-- roadmap:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated compilation workflows used by comparison and validation tools.
  - Improved handling of runtime-specific compilation settings and compiled output.
  - Preserved existing script, template, fallback, and diagnostic reporting behavior.

- **Chores**
  - Updated the implementation roadmap to reflect completed work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->