### PR TITLE
refactor(compiler-execution): native SSR casing and attribute tool

### DIFF
--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -94,7 +94,7 @@ schema = 2
 "CCA1O2" = { status = "implemented", commit_message = "feat(napi): add a tagged native host compile-request adapter", commit_date = "2026-08-31T21:14:14+01:00" }
 "CCA1O2A" = { status = "implemented", commit_message = "feat(bench): drive native benchmark compiles through the typed host request", commit_date = "2026-09-04T18:00:00+01:00" }
 "CCA1O2B" = { status = "implemented", commit_message = "refactor(compiler-execution): native comparison-tool host-request migration", commit_date = "2026-09-04T21:50:00+01:00" }
-"CCA1O2C" = { status = "pending" }
+"CCA1O2C" = { status = "implemented", commit_message = "refactor(ssr-baseline): drive SSR casing and attribute probes through the typed host request", commit_date = "2026-09-04T22:30:00+01:00" }
 "CCA1O2D" = { status = "pending" }
 "CCA1O2E" = { status = "pending" }
 "CCA1O2F" = { status = "implemented", commit_message = "docs(session): name the framework-tagged host request in compile-lane comments", commit_date = "2026-09-02T01:28:36+01:00", pull_request = 466 }

--- a/scripts/ssr-baseline/_test-casing.mjs
+++ b/scripts/ssr-baseline/_test-casing.mjs
@@ -37,17 +37,23 @@ function compileVue(source, filename) {
 
 function compileVerter(source, filePath) {
   const upsertResult = host.upsert({ inputId: filePath, source, fileKind: "vue" });
-  const result = host.getVirtualFile({
-    canonicalId: upsertResult.canonicalId,
-    nodeKind: { kind: "main" },
-    compileProfile: {
+  const response = host.compileRequest(upsertResult.canonicalId, {
+    framework: "vue",
+    identity: {
       filename: path.basename(filePath),
-      ssr: true,
+      isProduction: false,
       forceJs: true,
-      sourceMap: false,
+    },
+    products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+    options: {
+      backend: "inferred",
+      ssr: true,
+      isCustomElement: [],
+      babelParserPlugins: [],
     },
   });
-  return result?.code;
+  const runtime = response.products.find((p) => p.kind === "runtimeServer");
+  return runtime?.nodes.find((n) => n.node.kind === "main")?.code;
 }
 
 // Test: component imported via setup with kebab-case tag

--- a/scripts/ssr-baseline/_test-casing2.mjs
+++ b/scripts/ssr-baseline/_test-casing2.mjs
@@ -43,17 +43,23 @@ function compileVue(source, filename) {
 
 function compileVerter(source, filePath) {
   const upsertResult = host.upsert({ inputId: filePath, source, fileKind: "vue" });
-  const result = host.getVirtualFile({
-    canonicalId: upsertResult.canonicalId,
-    nodeKind: { kind: "main" },
-    compileProfile: {
+  const response = host.compileRequest(upsertResult.canonicalId, {
+    framework: "vue",
+    identity: {
       filename: path.basename(filePath),
-      ssr: true,
+      isProduction: false,
       forceJs: true,
-      sourceMap: false,
+    },
+    products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+    options: {
+      backend: "inferred",
+      ssr: true,
+      isCustomElement: [],
+      babelParserPlugins: [],
     },
   });
-  return result?.code;
+  const runtime = response.products.find((p) => p.kind === "runtimeServer");
+  return runtime?.nodes.find((n) => n.node.kind === "main")?.code;
 }
 
 // Test: Simulated element-plus pattern — compileScript will fail because deps are missing

--- a/scripts/ssr-baseline/_test-casing3.mjs
+++ b/scripts/ssr-baseline/_test-casing3.mjs
@@ -44,17 +44,23 @@ function compileVue(source, filename) {
 
 function compileVerter(source, filePath) {
   const upsertResult = host.upsert({ inputId: filePath, source, fileKind: "vue" });
-  const result = host.getVirtualFile({
-    canonicalId: upsertResult.canonicalId,
-    nodeKind: { kind: "main" },
-    compileProfile: {
+  const response = host.compileRequest(upsertResult.canonicalId, {
+    framework: "vue",
+    identity: {
       filename: path.basename(filePath),
-      ssr: true,
+      isProduction: false,
       forceJs: true,
-      sourceMap: false,
+    },
+    products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+    options: {
+      backend: "inferred",
+      ssr: true,
+      isCustomElement: [],
+      babelParserPlugins: [],
     },
   });
-  return result?.code;
+  const runtime = response.products.find((p) => p.kind === "runtimeServer");
+  return runtime?.nodes.find((n) => n.node.kind === "main")?.code;
 }
 
 const VERTER_TEST_REPOS = process.env.VERTER_TEST_REPOS;

--- a/scripts/ssr-baseline/_test-input-value.mjs
+++ b/scripts/ssr-baseline/_test-input-value.mjs
@@ -33,17 +33,23 @@ function compileVue(source, filename) {
 
 function compileVerter(source, filePath) {
   const upsertResult = host.upsert({ inputId: filePath, source, fileKind: "vue" });
-  const result = host.getVirtualFile({
-    canonicalId: upsertResult.canonicalId,
-    nodeKind: { kind: "main" },
-    compileProfile: {
+  const response = host.compileRequest(upsertResult.canonicalId, {
+    framework: "vue",
+    identity: {
       filename: path.basename(filePath),
-      ssr: true,
+      isProduction: false,
       forceJs: true,
-      sourceMap: false,
+    },
+    products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+    options: {
+      backend: "inferred",
+      ssr: true,
+      isCustomElement: [],
+      babelParserPlugins: [],
     },
   });
-  return result?.code;
+  const runtime = response.products.find((p) => p.kind === "runtimeServer");
+  return runtime?.nodes.find((n) => n.node.kind === "main")?.code;
 }
 
 function showDiff(label, source) {

--- a/scripts/ssr-baseline/_test-vbind-attrs.mjs
+++ b/scripts/ssr-baseline/_test-vbind-attrs.mjs
@@ -35,17 +35,23 @@ function compileVue(source, filename) {
 
 function compileVerter(source, filePath) {
   const upsertResult = host.upsert({ inputId: filePath, source, fileKind: "vue" });
-  const result = host.getVirtualFile({
-    canonicalId: upsertResult.canonicalId,
-    nodeKind: { kind: "main" },
-    compileProfile: {
+  const response = host.compileRequest(upsertResult.canonicalId, {
+    framework: "vue",
+    identity: {
       filename: path.basename(filePath),
-      ssr: true,
+      isProduction: false,
       forceJs: true,
-      sourceMap: false,
+    },
+    products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+    options: {
+      backend: "inferred",
+      ssr: true,
+      isCustomElement: [],
+      babelParserPlugins: [],
     },
   });
-  return result?.code;
+  const runtime = response.products.find((p) => p.kind === "runtimeServer");
+  return runtime?.nodes.find((n) => n.node.kind === "main")?.code;
 }
 
 function showDiff(label, source) {

--- a/scripts/ssr-baseline/_test-vbind-attrs2.mjs
+++ b/scripts/ssr-baseline/_test-vbind-attrs2.mjs
@@ -37,11 +37,15 @@ const rules = [() => true]
 
 const filePath = "d:/test/test.vue";
 const upsertResult = host.upsert({ inputId: filePath, source, fileKind: "vue" });
-const result = host.getVirtualFile({
-  canonicalId: upsertResult.canonicalId,
-  nodeKind: { kind: "main" },
-  compileProfile: { filename: "test.vue", ssr: true, forceJs: true, sourceMap: false },
+const response = host.compileRequest(upsertResult.canonicalId, {
+  framework: "vue",
+  identity: { filename: "test.vue", isProduction: false, forceJs: true },
+  products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+  options: { backend: "inferred", ssr: true, isCustomElement: [], babelParserPlugins: [] },
 });
+const result = response.products
+  .find((p) => p.kind === "runtimeServer")
+  ?.nodes.find((n) => n.node.kind === "main");
 
 console.log("Verter SSR output:");
 console.log(result.code);

--- a/scripts/ssr-baseline/_test-vbind-attrs3.mjs
+++ b/scripts/ssr-baseline/_test-vbind-attrs3.mjs
@@ -49,12 +49,16 @@ const vueBody = extractSsrRenderBody(vueResult.code);
 
 // Verter compile
 const upsertResult = host.upsert({ inputId: file, source: content, fileKind: "vue" });
-const verterResult = host.getVirtualFile({
-  canonicalId: upsertResult.canonicalId,
-  nodeKind: { kind: "main" },
-  compileProfile: { filename, ssr: true, forceJs: true, sourceMap: false },
+const response = host.compileRequest(upsertResult.canonicalId, {
+  framework: "vue",
+  identity: { filename, isProduction: false, forceJs: true },
+  products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+  options: { backend: "inferred", ssr: true, isCustomElement: [], babelParserPlugins: [] },
 });
-const verterBody = extractSsrRenderBody(verterResult.code);
+const verterMain = response.products
+  .find((p) => p.kind === "runtimeServer")
+  ?.nodes.find((n) => n.node.kind === "main");
+const verterBody = extractSsrRenderBody(verterMain?.code);
 
 // Show the BalTextInput _ssrRenderComponent call for both
 function findComponentCall(body, compName) {


### PR DESCRIPTION
## Summary

Migrates the seven ssr-baseline diagnostic scripts (SSR casing, input-value, v-bind-attrs) from the legacy getVirtualFile/compileProfile request onto the typed native compileRequest route. Each script now issues one typed Vue request per compile — identity { filename (unchanged expression), isProduction: false, forceJs: true }, products [{ kind: "runtimeServer", runtimeSourceMap: false }], options { backend: "inferred", ssr: true, isCustomElement: [], babelParserPlugins: [] } — and reads the SSR module from the runtimeServer product's node.kind === "main". Legacy omitted profile fields became explicit schema defaults; no source copy, no second native call, no getVirtualFile leftover. Fixture discovery, official Vue compilation, normalization, and unused imports are untouched. node --check passes on all seven; the five hermetic scripts produce byte-identical output before and after migration against a locally built native module; the two corpus-dependent scripts are syntax- and shape-verified only, as the charter makes external fixture execution optional.

Part of #104.

## Model attribution

| Role | Runtime | Model | Effort |
| --- | --- | --- | --- |
| implementer | zcode | glm-5.3 | medium |
| reviewer | zcode | glm-5.3 | medium |
| reviewer | kimi | kimi-code/kimi-for-coding | medium |
| reviewer | grok | grok-4.6 | medium |

Review history: http://THE-DESKTOP:7350/api/events?nodeId=CCA1O2C

Landing is automated once reviews, CI and CodeRabbit are green; do not merge manually.

<!-- roadmap:begin -->
Closes #135
<!-- roadmap:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated SSR baseline compilation checks to use the current request-based compilation flow.
  - Standardized Vue SSR compilation options across baseline scenarios.
  - Updated result handling to validate the primary server-runtime output.
- **Chores**
  - Marked the SSR baseline typed host-request migration as implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->