### PR TITLE
refactor(compiler-execution): native SSR helper and model tool migration

### DIFF
--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -95,7 +95,7 @@ schema = 2
 "CCA1O2A" = { status = "implemented", commit_message = "feat(bench): drive native benchmark compiles through the typed host request", commit_date = "2026-09-04T18:00:00+01:00" }
 "CCA1O2B" = { status = "implemented", commit_message = "refactor(compiler-execution): native comparison-tool host-request migration", commit_date = "2026-09-04T21:50:00+01:00" }
 "CCA1O2C" = { status = "implemented", commit_message = "refactor(ssr-baseline): drive SSR casing and attribute probes through the typed host request", commit_date = "2026-09-04T22:30:00+01:00" }
-"CCA1O2D" = { status = "pending" }
+"CCA1O2D" = { status = "implemented", commit_message = "refactor(ssr-baseline): drive SSR helper and model probes through the typed host request", commit_date = "2026-09-04T23:10:00+01:00" }
 "CCA1O2E" = { status = "pending" }
 "CCA1O2F" = { status = "implemented", commit_message = "docs(session): name the framework-tagged host request in compile-lane comments", commit_date = "2026-09-02T01:28:36+01:00", pull_request = 466 }
 "CCA1O2G" = { status = "pending" }

--- a/scripts/ssr-baseline/_test-mergeProps.mjs
+++ b/scripts/ssr-baseline/_test-mergeProps.mjs
@@ -35,17 +35,23 @@ function compileVue(source, filename) {
 
 function compileVerter(source, filePath) {
   const upsertResult = host.upsert({ inputId: filePath, source, fileKind: "vue" });
-  const result = host.getVirtualFile({
-    canonicalId: upsertResult.canonicalId,
-    nodeKind: { kind: "main" },
-    compileProfile: {
+  const response = host.compileRequest(upsertResult.canonicalId, {
+    framework: "vue",
+    identity: {
       filename: path.basename(filePath),
-      ssr: true,
+      isProduction: false,
       forceJs: true,
-      sourceMap: false,
+    },
+    products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+    options: {
+      backend: "inferred",
+      ssr: true,
+      isCustomElement: [],
+      babelParserPlugins: [],
     },
   });
-  return result?.code;
+  const runtime = response.products.find((p) => p.kind === "runtimeServer");
+  return runtime?.nodes.find((n) => n.node.kind === "main")?.code;
 }
 
 function showDiff(label, source) {

--- a/scripts/ssr-baseline/_test-mergeProps2.mjs
+++ b/scripts/ssr-baseline/_test-mergeProps2.mjs
@@ -54,11 +54,15 @@ const vueNorm = normalizeForComparison(vueBody);
 
 // Compile with Verter
 const upsertResult = host.upsert({ inputId: file, source: content, fileKind: "vue" });
-const verterResult = host.getVirtualFile({
-  canonicalId: upsertResult.canonicalId,
-  nodeKind: { kind: "main" },
-  compileProfile: { filename, ssr: true, forceJs: true, sourceMap: false },
+const response = host.compileRequest(upsertResult.canonicalId, {
+  framework: "vue",
+  identity: { filename, isProduction: false, forceJs: true },
+  products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+  options: { backend: "inferred", ssr: true, isCustomElement: [], babelParserPlugins: [] },
 });
+const verterResult = response.products
+  .find((p) => p.kind === "runtimeServer")
+  ?.nodes.find((n) => n.node.kind === "main");
 const verterBody = extractSsrRenderBody(verterResult.code);
 const verterNorm = normalizeForComparison(verterBody);
 

--- a/scripts/ssr-baseline/_test-slot-props.mjs
+++ b/scripts/ssr-baseline/_test-slot-props.mjs
@@ -33,17 +33,23 @@ function compileVue(source, filename) {
 
 function compileVerter(source, filePath) {
   const upsertResult = host.upsert({ inputId: filePath, source, fileKind: "vue" });
-  const result = host.getVirtualFile({
-    canonicalId: upsertResult.canonicalId,
-    nodeKind: { kind: "main" },
-    compileProfile: {
+  const response = host.compileRequest(upsertResult.canonicalId, {
+    framework: "vue",
+    identity: {
       filename: path.basename(filePath),
-      ssr: true,
+      isProduction: false,
       forceJs: true,
-      sourceMap: false,
+    },
+    products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+    options: {
+      backend: "inferred",
+      ssr: true,
+      isCustomElement: [],
+      babelParserPlugins: [],
     },
   });
-  return result?.code;
+  const runtime = response.products.find((p) => p.kind === "runtimeServer");
+  return runtime?.nodes.find((n) => n.node.kind === "main")?.code;
 }
 
 function showDiff(label, source) {

--- a/scripts/ssr-baseline/_test-style-merge.mjs
+++ b/scripts/ssr-baseline/_test-style-merge.mjs
@@ -34,17 +34,23 @@ function compileVue(source, filename) {
 
 function compileVerter(source, filePath) {
   const upsertResult = host.upsert({ inputId: filePath, source, fileKind: "vue" });
-  const result = host.getVirtualFile({
-    canonicalId: upsertResult.canonicalId,
-    nodeKind: { kind: "main" },
-    compileProfile: {
+  const response = host.compileRequest(upsertResult.canonicalId, {
+    framework: "vue",
+    identity: {
       filename: path.basename(filePath),
-      ssr: true,
+      isProduction: false,
       forceJs: true,
-      sourceMap: false,
+    },
+    products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+    options: {
+      backend: "inferred",
+      ssr: true,
+      isCustomElement: [],
+      babelParserPlugins: [],
     },
   });
-  return result?.code;
+  const runtime = response.products.find((p) => p.kind === "runtimeServer");
+  return runtime?.nodes.find((n) => n.node.kind === "main")?.code;
 }
 
 function showDiff(label, source) {

--- a/scripts/ssr-baseline/_test-vmodel.mjs
+++ b/scripts/ssr-baseline/_test-vmodel.mjs
@@ -35,17 +35,23 @@ function compileVue(source, filename) {
 
 function compileVerter(source, filePath) {
   const upsertResult = host.upsert({ inputId: filePath, source, fileKind: "vue" });
-  const result = host.getVirtualFile({
-    canonicalId: upsertResult.canonicalId,
-    nodeKind: { kind: "main" },
-    compileProfile: {
+  const response = host.compileRequest(upsertResult.canonicalId, {
+    framework: "vue",
+    identity: {
       filename: path.basename(filePath),
-      ssr: true,
+      isProduction: false,
       forceJs: true,
-      sourceMap: false,
+    },
+    products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+    options: {
+      backend: "inferred",
+      ssr: true,
+      isCustomElement: [],
+      babelParserPlugins: [],
     },
   });
-  return result?.code;
+  const runtime = response.products.find((p) => p.kind === "runtimeServer");
+  return runtime?.nodes.find((n) => n.node.kind === "main")?.code;
 }
 
 function showDiff(label, source) {

--- a/scripts/ssr-baseline/_test-vmodel2.mjs
+++ b/scripts/ssr-baseline/_test-vmodel2.mjs
@@ -33,16 +33,24 @@ function compileVue(source, filename) {
 
 function compileVerter(source, filePath) {
   const upsertResult = host.upsert({ inputId: filePath, source, fileKind: "vue" });
-  return host.getVirtualFile({
-    canonicalId: upsertResult.canonicalId,
-    nodeKind: { kind: "main" },
-    compileProfile: {
+  const response = host.compileRequest(upsertResult.canonicalId, {
+    framework: "vue",
+    identity: {
       filename: path.basename(filePath),
-      ssr: true,
+      isProduction: false,
       forceJs: true,
-      sourceMap: false,
+    },
+    products: [{ kind: "runtimeServer", runtimeSourceMap: false }],
+    options: {
+      backend: "inferred",
+      ssr: true,
+      isCustomElement: [],
+      babelParserPlugins: [],
     },
   });
+  return response.products
+    .find((p) => p.kind === "runtimeServer")
+    ?.nodes.find((n) => n.node.kind === "main");
 }
 
 // v-model + explicit @update:model-value handler


### PR DESCRIPTION
## Summary

Migrated the six ssr-baseline helper/slot/style/v-model probe scripts from the legacy getVirtualFile(compileProfile) request to one typed host.compileRequest per script against the already-registered source, preserving filename, SSR, forceJs, source-map-off, and requested-main-product intent; main-product extraction selects the runtimeServer product then the main node; _test-mergeProps2's top-level and _test-vmodel2's whole-result shapes were adapted in place. Transitioned the node's ledger line to implemented in the same commit. Verified hermetically: node --check passes on all six files, no compileProfile/getVirtualFile remains in them, each script performs exactly one upsert plus one compileRequest with no source copy or extra native call, and nothing was deleted. Runtime execution was skipped because this worktree has no built native binary, which the charter explicitly makes optional supplemental evidence; the request field-set matches the landed sibling scripts byte-for-byte.

Part of #104.

<!-- roadmap:begin -->
Closes #136
<!-- roadmap:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated server-side rendering baseline checks to use the current compilation workflow.
  - Standardized Vue SSR test coverage across slot props, style merging, two-way binding, and property merging scenarios.
  - Improved validation of generated server-rendered output under explicit framework and runtime settings.

- **Chores**
  - Updated implementation tracking to reflect completed work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->