### PR TITLE
refactor(host-service-graph): typeScript-plugin native-signature

### DIFF
--- a/packages/typescript-plugin/src/tsc/mirrorHost.spec.ts
+++ b/packages/typescript-plugin/src/tsc/mirrorHost.spec.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { VerterHost } from "@verter/native";
+import type { HostCompileRequest } from "@verter/native";
 
 import {
   CarrierPublicApiProjectionFailure,
@@ -140,8 +141,7 @@ describe(
       };
       const failingHost: CarrierCodegenHost = {
         upsert: native.upsert.bind(native),
-        ensureIdeCompiled: native.ensureIdeCompiled.bind(native),
-        getIde: native.getIde.bind(native),
+        compileRequest: native.compileRequest.bind(native),
         getPublicApi: (canonicalId, mode) =>
           canonicalId === "Ordinal.vue"
             ? { value: null, error: projectionError }
@@ -170,6 +170,73 @@ describe(
         expect(result.materializedCarriers.has(later)).toBe(true);
       } finally {
         failingHost.close?.();
+      }
+    });
+
+    it("issues exactly ONE typed IDE call per source — framework-discriminated, single product, no extra compile", () => {
+      const fx = track(
+        createSingleProjectFixture([
+          {
+            rel: "src/One.vue",
+            content: `<script setup lang="ts">\nconst value = 1\n</script>`,
+          },
+          {
+            rel: "src/Two.svelte",
+            content: `<script lang="ts">\nconst value = 2\n</script>`,
+          },
+        ]),
+      );
+      const native = host();
+      const calls: { canonicalId: string; request: HostCompileRequest }[] = [];
+      const countingHost: CarrierCodegenHost = {
+        upsert: native.upsert.bind(native),
+        compileRequest: (canonicalId, request) => {
+          calls.push({ canonicalId, request });
+          return native.compileRequest(canonicalId, request);
+        },
+        getPublicApi: native.getPublicApi.bind(native),
+        close: native.close.bind(native),
+      };
+
+      try {
+        const one = path.join(fx.root, "src/One.vue").replace(/\\/g, "/");
+        const two = path.join(fx.root, "src/Two.svelte").replace(/\\/g, "/");
+        const result = runBatchTypecheck({
+          tsconfigPath: fx.tsconfigPath,
+          carrierSources: [
+            ideCarrier(fx.root, "src/One.vue", "vue"),
+            ideCarrier(fx.root, "src/Two.svelte", "svelte"),
+          ],
+          host: countingHost,
+        });
+
+        // Exactly one typed call per already-registered source, in carrier
+        // order — no second native compile anywhere on this route.
+        expect(calls.map((c) => c.canonicalId)).toEqual(["One.vue", "Two.svelte"]);
+        // The requests type-check against the generated native declaration
+        // (no cast): the framework arm is discriminated at compile time.
+        expect(calls[0].request.framework).toBe("vue");
+        expect(calls[1].request.framework).toBe("svelte");
+        for (const call of calls) {
+          // One product only — the IDE companion at the source-map intent the
+          // driver fixes on this route, every other IDE axis stated closed.
+          expect(call.request.products).toHaveLength(1);
+          expect(call.request.products[0]).toEqual({
+            kind: "ideCompanion",
+            wantSourceMap: true,
+            embedAmbientTypes: false,
+            conditionalRootNarrowing: false,
+            strictSlots: false,
+            ideChunkBoundaries: false,
+          });
+          // The canonical id binds on the route, not in a caller-stated name.
+          expect(call.request.identity).toEqual({ isProduction: false, forceJs: false });
+        }
+        // Both carriers materialised through their single call each.
+        expect(result.sourceOutcomes.get(one)).toMatchObject({ kind: "materialized" });
+        expect(result.sourceOutcomes.get(two)).toMatchObject({ kind: "materialized" });
+      } finally {
+        countingHost.close?.();
       }
     });
 

--- a/packages/typescript-plugin/src/tsc/mirrorHost.ts
+++ b/packages/typescript-plugin/src/tsc/mirrorHost.ts
@@ -72,12 +72,17 @@ import type * as TS from "typescript";
 
 import { VIRTUAL_FILE_NAMING, type VirtualPathPolicy } from "@verter/language-shared";
 import type {
+  HostCompileRequest,
+  HostCompileResponse,
+  HostIdeCompiledProduct,
   HostPublicApiProjectionError,
   HostPublicApiResult,
+  HostRequestedProduct,
   HostTscFailureSubject,
   HostTscDeclarationShapeReason,
   HostTscProjectionDetailCode,
   HostTscUnavailableOutcome,
+  VerterHost,
 } from "@verter/native";
 
 /**
@@ -112,20 +117,18 @@ export interface CarrierCodegenHost {
     aliases?: string[];
   }): unknown;
   /**
-   * Ensure the IDE (`CachedTsx`) projection exists for a file + profile.
-   * `getIde` is a PURE CACHED READ — it returns `null` until the IDE surface
-   * has been compiled, so the driver calls this first. Returns `true` when the
-   * projection now exists, `false` for a non-carrier.
+   * Execute ONE typed compile request against an already-registered source —
+   * the sole native compile route this driver consumes. The route is
+   * complete-only: a construction/admission/execution refusal THROWS (the
+   * batch aborts, exactly as the legacy ensure path aborted on a real
+   * failure), and a completed compile answers every requested product. The
+   * driver requests one `ideCompanion` product per source (see
+   * {@link IDE_COMPILE_REQUEST_BY_FRAMEWORK}); a completed compile whose
+   * products carry
+   * no IDE artifact (a non-carrier surface) is the driver's `absent`
+   * outcome, mirroring the legacy pure cached read's `null`.
    */
-  ensureIdeCompiled?(
-    canonicalId: string,
-    profile?: { target?: "bundler" | "ide" | "analysis"; sourceMap?: boolean },
-  ): boolean;
-  /** The IDE diagnostic carrier (`.vue.tsx`/`.svelte.tsx`) content + map. */
-  getIde(
-    canonicalId: string,
-    profile?: { target?: "bundler" | "ide" | "analysis"; sourceMap?: boolean },
-  ): { code: string; sourceMap?: string; isJsx: boolean } | null;
+  compileRequest(canonicalId: string, request: HostCompileRequest): HostCompileResponse;
   /**
    * The API (`.verter.ts`) / declaration (`.d.<ext>.ts`) carrier content + map
    * for referenced projects. Mirrors `@verter/native`'s `HostPublicApiMode`
@@ -176,6 +179,56 @@ export class CarrierPublicApiProjectionFailure extends Error {
 /** The framework of a carrier source — selects the virtual-file-naming row. */
 export type CarrierFramework = "vue" | "svelte";
 
+/**
+ * The ONE typed IDE request this driver issues per carrier source: a single
+ * `ideCompanion` product on the source's own framework arm, the dev identity
+ * (`isProduction: false`, `forceJs: false`), and the framework's default
+ * compile options (Vue: inferred backend, no SSR, no custom elements, no Babel
+ * plugins; Svelte: all-default). The canonical id is the route argument, NOT a
+ * request field — leaving `identity.filename` unset lets the native route bind
+ * the canonical id itself (a caller-stated name would pin path spelling/casing
+ * the mirror host deliberately does not own).
+ *
+ * Every IDE axis is stated (`wantSourceMap` from the caller's source-map
+ * intent; `false` for the rest) at the values the legacy positional
+ * `{ target: "ide", sourceMap }` profile resolved to — the native real-host
+ * boundary test asserts the typed route answers the profile route byte-for-byte
+ * at exactly these values. `ideChunkBoundaries: false` is the only admitted
+ * value there: the carrier bridge substitutes its own.
+ *
+ * Keyed by the closed `CarrierFramework` union (the `NAMING_KEY_BY_FRAMEWORK`
+ * shape): adding a framework is a single-row change with no literal arm gate.
+ */
+const IDE_COMPILE_REQUEST_BY_FRAMEWORK: Record<
+  CarrierFramework,
+  (wantSourceMap: boolean) => HostCompileRequest
+> = {
+  vue: (wantSourceMap) => ({
+    framework: "vue",
+    identity: { isProduction: false, forceJs: false },
+    products: [ideCompanionProduct(wantSourceMap)],
+    options: { backend: "inferred", ssr: false, isCustomElement: [], babelParserPlugins: [] },
+  }),
+  svelte: (wantSourceMap) => ({
+    framework: "svelte",
+    identity: { isProduction: false, forceJs: false },
+    products: [ideCompanionProduct(wantSourceMap)],
+    options: {},
+  }),
+};
+
+/** The single `ideCompanion` product: the driver's IDE demand, every axis stated. */
+function ideCompanionProduct(wantSourceMap: boolean): HostRequestedProduct {
+  return {
+    kind: "ideCompanion",
+    wantSourceMap,
+    embedAmbientTypes: false,
+    conditionalRootNarrowing: false,
+    strictSlots: false,
+    ideChunkBoundaries: false,
+  };
+}
+
 /** Project-ownership disposition for a `.vue`/`.svelte` (from the §2.6 resolver). */
 export type CarrierOwnership = "Owned" | "NoProject" | "Ambiguous";
 
@@ -194,7 +247,8 @@ export interface CarrierSource {
   ownership: CarrierOwnership;
   /**
    * The carrier role to materialise:
-   * - `"ide"` — the leaf diagnostic carrier (`getIde` → `.vue.tsx`).
+   * - `"ide"` — the leaf diagnostic carrier (one typed `ideCompanion`
+   *   compile request → `.vue.tsx`).
    * - `"api"` — a referenced project's declaration carrier (`getPublicApi` →
    *   `.verter.ts`), the surface build mode emits a `.d.ts` from.
    */
@@ -610,7 +664,7 @@ export function runBatchTypecheck(args: RunBatchTypecheckArgs): BatchTypecheckRe
     args.host ??
     (() => {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const native = require("@verter/native") as { VerterHost: new () => CarrierCodegenHost };
+      const native = require("@verter/native") as { VerterHost: new () => VerterHost };
       return new native.VerterHost();
     })();
 
@@ -729,10 +783,20 @@ export function runBatchTypecheck(args: RunBatchTypecheckArgs): BatchTypecheckRe
       const group = groupFor(src.projectTsconfigPath ?? leafTsconfigPath);
 
       if (src.role === "ide") {
-        // `getIde` is a pure cached read — populate the IDE projection first.
-        const ideProfile = { target: "ide" as const, sourceMap: true };
-        host.ensureIdeCompiled?.(canonical, ideProfile);
-        const ide = host.getIde(canonical, ideProfile);
+        // Exactly ONE typed IDE call against the already-registered source —
+        // no second native compile, no source copy. The complete-only route
+        // throws on a refusal (aborting the batch, as the legacy ensure path
+        // did); a completed compile with no IDE artifact (a non-carrier
+        // surface) is this source's `absent`, as the legacy pure cached
+        // read's `null` was.
+        const response = host.compileRequest(
+          canonical,
+          IDE_COMPILE_REQUEST_BY_FRAMEWORK[src.framework](true),
+        );
+        const ide =
+          response.products.find(
+            (product): product is HostIdeCompiledProduct => product.kind === "ideCompanion",
+          )?.ide ?? null;
         if (!ide) {
           result.sourceOutcomes.set(sourcePath, { kind: "absent" });
           continue;

--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -98,7 +98,7 @@ schema = 2
 "CCA1O2D" = { status = "implemented", commit_message = "refactor(ssr-baseline): drive SSR helper and model probes through the typed host request", commit_date = "2026-09-04T23:10:00+01:00" }
 "CCA1O2E" = { status = "pending" }
 "CCA1O2F" = { status = "implemented", commit_message = "docs(session): name the framework-tagged host request in compile-lane comments", commit_date = "2026-09-02T01:28:36+01:00", pull_request = 466 }
-"CCA1O2G" = { status = "pending" }
+"CCA1O2G" = { status = "implemented", commit_message = "refactor(compiler-bridge): typescript-plugin mirror host typed IDE request migration", commit_date = "2026-09-05T00:30:00+01:00" }
 "CCA1O2H" = { status = "implemented", commit_message = "fix(napi): refuse a request key stated as undefined", commit_date = "2026-09-01T00:56:27+01:00" }
 "CCA1O2I" = { status = "implemented", commit_message = "refactor(napi): generate the published host compile-request declaration", commit_date = "2026-09-01T14:00:00+01:00" }
 "CCA1O2J" = { status = "implemented", commit_message = "feat(napi): expose typed compile request routes", commit_date = "2026-09-03T01:15:00+01:00", pull_request = 471 }


### PR DESCRIPTION
## Summary

Migrates the typescript-plugin batch-tsc mirror host from the positional native IDE profile ({ target: "ide", sourceMap }) onto the typed, framework-discriminated host compile request. The plugin-local CarrierCodegenHost interface now exposes the native typed compileRequest route (typed as the real VerterHost, so the assignment is a true structural check with no compatibility-hiding cast); the legacy ensureIdeCompiled/getIde pair is deleted from the plugin consumer only and remains installed on the native surface. One ideCompanion product request is built per source from its framework (keyed Record over the closed CarrierFramework union, matching the file's carrier-generic idiom so the repo's no-hardcoded-Vue-gate guard stays green), the dev identity, and the framework defaults — the exact option values the native real-host boundary test proves byte-equal to the legacy profile route, which I also verified empirically against the built binary for both Vue and Svelte (identical code/sourceMap/isJsx). Behavior is preserved: exactly one typed call per already-registered source with no source copy, refusals still abort the batch as the legacy ensure path did, a completed compile without an IDE artifact maps to the same 'absent' outcome the pure cached read's null produced, lazy native loading and injected fake-host compatibility are unchanged, and diagnostics/mirror-materialisation semantics are untouched. Verified with the full @verter/typescript-plugin build + 364/364 unit tests (including the tsc-b parity spike), and the ledger line is transitioned to implemented.

Part of #104.

<!-- roadmap:begin -->
Closes #139
<!-- roadmap:end -->
