### PR TITLE
chore(ledger): mark CCA1O3A implemented

### DIFF
--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -103,7 +103,7 @@ schema = 2
 "CCA1O2I" = { status = "implemented", commit_message = "refactor(napi): generate the published host compile-request declaration", commit_date = "2026-09-01T14:00:00+01:00" }
 "CCA1O2J" = { status = "implemented", commit_message = "feat(napi): expose typed compile request routes", commit_date = "2026-09-03T01:15:00+01:00", pull_request = 471 }
 "CCA1O3" = { status = "implemented", commit_message = "feat(wasm): add a typed host compile-request adapter and local request DTOs", commit_date = "2026-08-31T22:30:00+01:00" }
-"CCA1O3A" = { status = "pending" }
+"CCA1O3A" = { status = "implemented", commit_message = "feat(play): migrate WASM fixture capture to typed compile request", commit_date = "2026-09-03T06:21:57+01:00", pull_request = 482 }
 "CCA1O3B" = { status = "implemented", commit_message = "feat(wasm): drive the transport probe through the typed compile request", commit_date = "2026-09-03T10:30:00+01:00", pull_request = 483 }
 "CCA1O3C" = { status = "implemented", commit_message = "feat(ci): execute the wasm JavaScript-boundary tests in the canonical gate", commit_date = "2026-09-01T02:10:00+01:00" }
 "CCA1O3D" = { status = "implemented", commit_message = "feat(wasm): expose a callable typed compile request on the browser host", commit_date = "2026-09-02T12:00:00+01:00", pull_request = 469 }


### PR DESCRIPTION
Records CCA1O3A as implemented in the implementation ledger (landed via #482).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the implementation status of a roadmap item to reflect completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->