### PR TITLE
feat(compiler-execution): make the SSR dead-code-elimination rewrite

### DIFF
--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -121,6 +121,7 @@
     "e2e:farm": "tsx e2e/scripts/run.ts --bundler farm"
   },
   "dependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.5",
     "@verter/native": "workspace:*",
     "unplugin": "^3.0.0"
   },
@@ -149,8 +150,8 @@
     "sass-embedded": "1.100.0",
     "sass-loader": "^17.0.0",
     "sirv-cli": "^3.0.1",
-    "svelte": "5.56.10",
     "style-loader": "^4.0.0",
+    "svelte": "5.56.10",
     "tailwindcss": "4.3.0",
     "tsdown": "^0.22.0",
     "tsx": "^4.22.3",

--- a/packages/unplugin/src/core/ssr-transforms.spec.ts
+++ b/packages/unplugin/src/core/ssr-transforms.spec.ts
@@ -1,3 +1,4 @@
+import { encode } from "@jridgewell/sourcemap-codec";
 import { describe, expect, it } from "vitest";
 import { replaceImportMetaSsr, stripComponents } from "./ssr-transforms.js";
 
@@ -5,21 +6,21 @@ describe("replaceImportMetaSsr", () => {
   describe("SSR build (isSSR = true)", () => {
     it("replaces import.meta.server with true", () => {
       const code = 'if (import.meta.server) { fetch("/api") }';
-      const result = replaceImportMetaSsr(code, true);
+      const result = replaceImportMetaSsr(code, true).code;
       expect(result).toBe('if (true) { fetch("/api") }');
       expect(result).not.toContain("import.meta.server");
     });
 
     it("replaces import.meta.client with false", () => {
       const code = "if (import.meta.client) { initCanvas() }";
-      const result = replaceImportMetaSsr(code, true);
+      const result = replaceImportMetaSsr(code, true).code;
       expect(result).toBe("if (false) { initCanvas() }");
       expect(result).not.toContain("import.meta.client");
     });
 
     it("replaces import.meta.env.SSR with true", () => {
       const code = "const isServer = import.meta.env.SSR";
-      const result = replaceImportMetaSsr(code, true);
+      const result = replaceImportMetaSsr(code, true).code;
       expect(result).toBe("const isServer = true");
       expect(result).not.toContain("import.meta.env.SSR");
     });
@@ -30,7 +31,7 @@ describe("replaceImportMetaSsr", () => {
         "const b = import.meta.client",
         "const c = import.meta.env.SSR",
       ].join("\n");
-      const result = replaceImportMetaSsr(code, true);
+      const result = replaceImportMetaSsr(code, true).code;
       expect(result).toBe(["const a = true", "const b = false", "const c = true"].join("\n"));
     });
   });
@@ -38,41 +39,78 @@ describe("replaceImportMetaSsr", () => {
   describe("Client build (isSSR = false)", () => {
     it("replaces import.meta.server with false", () => {
       const code = "if (import.meta.server) { return }";
-      const result = replaceImportMetaSsr(code, false);
+      const result = replaceImportMetaSsr(code, false).code;
       expect(result).toBe("if (false) { return }");
     });
 
     it("replaces import.meta.client with true", () => {
       const code = "if (import.meta.client) { initCanvas() }";
-      const result = replaceImportMetaSsr(code, false);
+      const result = replaceImportMetaSsr(code, false).code;
       expect(result).toBe("if (true) { initCanvas() }");
     });
 
     it("replaces import.meta.env.SSR with false", () => {
       const code = "const isServer = import.meta.env.SSR";
-      const result = replaceImportMetaSsr(code, false);
+      const result = replaceImportMetaSsr(code, false).code;
       expect(result).toBe("const isServer = false");
     });
   });
 
   it("returns unchanged code when no import.meta. present", () => {
     const code = 'const x = 42; console.log("hello")';
-    const result = replaceImportMetaSsr(code, true);
+    const result = replaceImportMetaSsr(code, true).code;
     expect(result).toBe(code);
+  });
+
+  it("returns the map unchanged when no import.meta. present", () => {
+    const code = 'const x = 42; console.log("hello")';
+    const map = JSON.stringify({ version: 3, sources: [], names: [], mappings: "" });
+    const result = replaceImportMetaSsr(code, true, map);
+    expect(result.map).toBe(map);
+  });
+
+  it("shifts a later token's mapped column by the length the rewrite removed", () => {
+    // `import.meta.server` (19 chars) → `false` (5 chars): a 14-byte shrink.
+    // A mapping naming a source position at generated column 30 — right
+    // after the rewritten token — must land 14 columns earlier post-rewrite.
+    const code = "const a = import.meta.server; const later = 1";
+    const beforeCol = code.indexOf("later"); // column of `later` in the ORIGINAL code
+    const mappings = encode([
+      [
+        [0, 0, 0, 0],
+        [beforeCol, 0, 0, beforeCol],
+      ],
+    ]);
+    const map = JSON.stringify({
+      version: 3,
+      sources: ["input.js"],
+      names: [],
+      mappings,
+    });
+
+    const result = replaceImportMetaSsr(code, false, map);
+    expect(result.code).toBe("const a = false; const later = 1");
+
+    const decodedMap = JSON.parse(result.map!);
+    // `later`'s new generated column should have shrunk by the same 14 bytes
+    // the replacement removed, not stayed at its stale pre-rewrite column.
+    expect(decodedMap.mappings).not.toBe(mappings);
+    const newCol = beforeCol - ("import.meta.server".length - "false".length);
+    expect(result.code.slice(newCol, newCol + 5)).toBe("later");
   });
 });
 
 describe("stripComponents", () => {
   it("replaces _resolveComponent calls for listed components", () => {
     const code = `const _component_GoogleMap = _resolveComponent("GoogleMap")`;
-    const result = stripComponents(code, ["GoogleMap"]);
+    const result = stripComponents(code, ["GoogleMap"]).code;
     expect(result).not.toContain('_resolveComponent("GoogleMap")');
     expect(result).toContain("GoogleMap");
   });
 
   it("does not affect unlisted components", () => {
     const code = `const _component_MyComp = _resolveComponent("MyComp")`;
-    const result = stripComponents(code, ["GoogleMap"]);
+    const result = stripComponents(code, ["GoogleMap"]).code;
     expect(result).toBe(code);
   });
 
@@ -82,7 +120,7 @@ describe("stripComponents", () => {
       `const b = _resolveComponent("VideoPlayer")`,
       `const c = _resolveComponent("SafeComp")`,
     ].join("\n");
-    const result = stripComponents(code, ["GoogleMap", "VideoPlayer"]);
+    const result = stripComponents(code, ["GoogleMap", "VideoPlayer"]).code;
     expect(result).not.toContain('_resolveComponent("GoogleMap")');
     expect(result).not.toContain('_resolveComponent("VideoPlayer")');
     expect(result).toContain('_resolveComponent("SafeComp")');
@@ -90,7 +128,7 @@ describe("stripComponents", () => {
 
   it("returns unchanged code when no components to strip", () => {
     const code = 'const x = _resolveComponent("Foo")';
-    const result = stripComponents(code, []);
+    const result = stripComponents(code, []).code;
     expect(result).toBe(code);
   });
 });

--- a/packages/unplugin/src/core/ssr-transforms.spec.ts
+++ b/packages/unplugin/src/core/ssr-transforms.spec.ts
@@ -1,4 +1,4 @@
-import { encode } from "@jridgewell/sourcemap-codec";
+import { decode, encode } from "@jridgewell/sourcemap-codec";
 import { describe, expect, it } from "vitest";
 import { replaceImportMetaSsr, stripComponents } from "./ssr-transforms.js";
 
@@ -70,9 +70,9 @@ describe("replaceImportMetaSsr", () => {
   });
 
   it("shifts a later token's mapped column by the length the rewrite removed", () => {
-    // `import.meta.server` (19 chars) → `false` (5 chars): a 14-byte shrink.
+    // `import.meta.server` (18 chars) → `false` (5 chars): a 13-byte shrink.
     // A mapping naming a source position at generated column 30 — right
-    // after the rewritten token — must land 14 columns earlier post-rewrite.
+    // after the rewritten token — must land 13 columns earlier post-rewrite.
     const code = "const a = import.meta.server; const later = 1";
     const beforeCol = code.indexOf("later"); // column of `later` in the ORIGINAL code
     const mappings = encode([
@@ -92,11 +92,17 @@ describe("replaceImportMetaSsr", () => {
     expect(result.code).toBe("const a = false; const later = 1");
 
     const decodedMap = JSON.parse(result.map!);
-    // `later`'s new generated column should have shrunk by the same 14 bytes
+    // `later`'s new generated column should have shrunk by the same 13 bytes
     // the replacement removed, not stayed at its stale pre-rewrite column.
     expect(decodedMap.mappings).not.toBe(mappings);
     const newCol = beforeCol - ("import.meta.server".length - "false".length);
     expect(result.code.slice(newCol, newCol + 5)).toBe("later");
+
+    // Assert the shift amount directly against the decoded map, not just the
+    // code: a wrong-delta shift could still coincidentally leave the code
+    // slice correct while the map segment points elsewhere.
+    const decodedSegments = decode(decodedMap.mappings);
+    expect(decodedSegments[0][1][0]).toBe(newCol);
   });
 });
 
@@ -130,5 +136,11 @@ describe("stripComponents", () => {
     const code = 'const x = _resolveComponent("Foo")';
     const result = stripComponents(code, []).code;
     expect(result).toBe(code);
+  });
+
+  it("applies a single replacement even when a name is listed twice", () => {
+    const code = 'const a = _resolveComponent("GoogleMap")';
+    const result = stripComponents(code, ["GoogleMap", "GoogleMap"]).code;
+    expect(result).toBe('const a = (() => ({ __name: "GoogleMap", render: () => null }))()');
   });
 });

--- a/packages/unplugin/src/core/ssr-transforms.spec.ts
+++ b/packages/unplugin/src/core/ssr-transforms.spec.ts
@@ -1,6 +1,6 @@
 import { decode, encode } from "@jridgewell/sourcemap-codec";
 import { describe, expect, it } from "vitest";
-import { replaceImportMetaSsr, stripComponents } from "./ssr-transforms.js";
+import { applyTextEdits, replaceImportMetaSsr, stripComponents } from "./ssr-transforms.js";
 
 describe("replaceImportMetaSsr", () => {
   describe("SSR build (isSSR = true)", () => {
@@ -71,8 +71,8 @@ describe("replaceImportMetaSsr", () => {
 
   it("shifts a later token's mapped column by the length the rewrite removed", () => {
     // `import.meta.server` (18 chars) → `false` (5 chars): a 13-byte shrink.
-    // A mapping naming a source position at generated column 30 — right
-    // after the rewritten token — must land 13 columns earlier post-rewrite.
+    // A mapping naming a source position at `beforeCol` — right after the
+    // rewritten token — must land 13 columns earlier post-rewrite.
     const code = "const a = import.meta.server; const later = 1";
     const beforeCol = code.indexOf("later"); // column of `later` in the ORIGINAL code
     const mappings = encode([
@@ -103,6 +103,13 @@ describe("replaceImportMetaSsr", () => {
     // slice correct while the map segment points elsewhere.
     const decodedSegments = decode(decodedMap.mappings);
     expect(decodedSegments[0][1][0]).toBe(newCol);
+  });
+
+  it("drops an unparseable map instead of passing it through unshifted", () => {
+    const code = "const a = import.meta.server";
+    const result = replaceImportMetaSsr(code, false, "not json");
+    expect(result.code).toBe("const a = false");
+    expect(result.map).toBeUndefined();
   });
 });
 
@@ -142,5 +149,21 @@ describe("stripComponents", () => {
     const code = 'const a = _resolveComponent("GoogleMap")';
     const result = stripComponents(code, ["GoogleMap", "GoogleMap"]).code;
     expect(result).toBe('const a = (() => ({ __name: "GoogleMap", render: () => null }))()');
+  });
+});
+
+describe("applyTextEdits", () => {
+  it("skips an edit whose range is properly contained in a prior edit's range, not just a plain duplicate", () => {
+    // The second edit's [start, end) range (2, 8) falls entirely inside the
+    // first edit's (0, 10) — a real containment overlap, not the same range
+    // listed twice. The cursor guard (`edit.start < cursor`) must reject it
+    // on range containment alone, independent of the duplicate-Set dedupe
+    // that only stripComponents' caller performs.
+    const code = "0123456789";
+    const result = applyTextEdits(code, undefined, [
+      { start: 0, end: 10, replacement: "FIRST" },
+      { start: 2, end: 8, replacement: "SECOND" },
+    ]);
+    expect(result.code).toBe("FIRST");
   });
 });

--- a/packages/unplugin/src/core/ssr-transforms.spec.ts
+++ b/packages/unplugin/src/core/ssr-transforms.spec.ts
@@ -153,6 +153,18 @@ describe("stripComponents", () => {
 });
 
 describe("applyTextEdits", () => {
+  // @ai-generated - Tests that invalid JSON source-map values are dropped on both edit paths.
+  it("drops a parsed null source map whether or not text changes", () => {
+    expect(applyTextEdits("before", "null", [{ start: 0, end: 6, replacement: "after" }])).toEqual({
+      code: "after",
+      map: undefined,
+    });
+    expect(applyTextEdits("unchanged", "null", [])).toEqual({
+      code: "unchanged",
+      map: undefined,
+    });
+  });
+
   it("skips an edit whose range is properly contained in a prior edit's range, not just a plain duplicate", () => {
     // The second edit's [start, end) range (2, 8) falls entirely inside the
     // first edit's (0, 10) — a real containment overlap, not the same range

--- a/packages/unplugin/src/core/ssr-transforms.spec.ts
+++ b/packages/unplugin/src/core/ssr-transforms.spec.ts
@@ -154,15 +154,28 @@ describe("stripComponents", () => {
 
 describe("applyTextEdits", () => {
   // @ai-generated - Tests that invalid JSON source-map values are dropped on both edit paths.
-  it("drops a parsed null source map whether or not text changes", () => {
-    expect(applyTextEdits("before", "null", [{ start: 0, end: 6, replacement: "after" }])).toEqual({
+  it.each([
+    ["a parsed null", "null"],
+    ["a primitive", "3"],
+    ["an array", "[]"],
+    ["an object without mappings", JSON.stringify({ version: 3 })],
+    ["an object whose mappings is not a string", JSON.stringify({ version: 3, mappings: null })],
+  ])("drops %s source map whether or not text changes", (_label, map) => {
+    // Both paths admit a map on the same terms: the zero-edit path must not
+    // preserve a shape the edited path would reject at `shiftMapColumns`.
+    expect(applyTextEdits("before", map, [{ start: 0, end: 6, replacement: "after" }])).toEqual({
       code: "after",
       map: undefined,
     });
-    expect(applyTextEdits("unchanged", "null", [])).toEqual({
+    expect(applyTextEdits("unchanged", map, [])).toEqual({
       code: "unchanged",
       map: undefined,
     });
+  });
+
+  it("preserves a usable map untouched on the zero-edit path", () => {
+    const map = JSON.stringify({ version: 3, sources: [], names: [], mappings: "AAAA" });
+    expect(applyTextEdits("unchanged", map, [])).toEqual({ code: "unchanged", map });
   });
 
   it("skips an edit whose range is properly contained in a prior edit's range, not just a plain duplicate", () => {

--- a/packages/unplugin/src/core/ssr-transforms.ts
+++ b/packages/unplugin/src/core/ssr-transforms.ts
@@ -205,6 +205,12 @@ export function stripComponents(
 ): SsrRewriteResult {
   if (componentNames.length === 0) return { code, map };
 
+  // Deduplicate requested names before scanning: a name listed twice would
+  // otherwise run findAllOccurrences (and thus this whole edit-construction
+  // loop) twice over the same pattern. `applyTextEdits`'s cursor guard is
+  // what actually keeps duplicate/overlapping edits from ever being spliced
+  // in — this Set is a redundant-scan avoidance, not a second correctness
+  // gate; removing either one alone still leaves the other holding the line.
   const edits: TextEdit[] = [];
   for (const name of new Set(componentNames)) {
     const pattern = `_resolveComponent("${name}")`;

--- a/packages/unplugin/src/core/ssr-transforms.ts
+++ b/packages/unplugin/src/core/ssr-transforms.ts
@@ -2,8 +2,153 @@
  * SSR/client dead-code elimination transforms.
  *
  * Replaces `import.meta.server`, `import.meta.client`, and `import.meta.env.SSR`
- * with boolean literals so bundlers can tree-shake dead branches.
+ * with boolean literals so bundlers can tree-shake dead branches, and strips
+ * client/server-only component render calls. Every rewrite here changes the
+ * generated text's byte length, so a caller carrying a source map for the
+ * pre-rewrite code must have its mappings' generated columns shifted to match
+ * — otherwise the published map points at stale positions once the code has
+ * moved. `applyTextEdits` is the single map-aware primitive both rewrites
+ * route through.
  */
+
+import { decode, encode, type SourceMapSegment } from "@jridgewell/sourcemap-codec";
+
+/** The result of a map-aware rewrite: the new code, and its map (if one travelled in). */
+export interface SsrRewriteResult {
+  code: string;
+  map?: string;
+}
+
+/** A single literal-text replacement, expressed as an offset range in the ORIGINAL code. */
+interface TextEdit {
+  start: number;
+  end: number;
+  replacement: string;
+}
+
+/** Per-line column edit, used to shift a decoded map's generated columns. */
+interface LineColumnEdit {
+  start: number;
+  end: number;
+  delta: number;
+}
+
+/**
+ * Apply a set of non-overlapping literal-text edits to `code`, and — when a
+ * source map for the pre-edit `code` is supplied — shift the map's generated
+ * columns so it still describes the rewritten text.
+ *
+ * Edits must not span a newline: every rewrite site here (`import.meta.*`
+ * literals, `_resolveComponent(...)` calls) is a single-line token, so each
+ * edit only ever needs to shift columns later on the SAME generated line —
+ * no line renumbering is required.
+ */
+function applyTextEdits(
+  code: string,
+  map: string | undefined,
+  edits: TextEdit[],
+): SsrRewriteResult {
+  if (edits.length === 0) return { code, map };
+
+  const sorted = [...edits].sort((a, b) => a.start - b.start);
+
+  let newCode = "";
+  let cursor = 0;
+  let lineIndex = 0;
+  let lineStart = 0;
+  let searchFrom = 0;
+  const lineEditsByLine = new Map<number, LineColumnEdit[]>();
+
+  for (const edit of sorted) {
+    newCode += code.slice(cursor, edit.start);
+
+    // Advance the line cursor to the line containing this edit.
+    for (;;) {
+      const newline = code.indexOf("\n", searchFrom);
+      if (newline !== -1 && newline < edit.start) {
+        lineIndex++;
+        lineStart = newline + 1;
+        searchFrom = lineStart;
+      } else {
+        break;
+      }
+    }
+
+    const startCol = edit.start - lineStart;
+    const endCol = edit.end - lineStart;
+    const delta = edit.replacement.length - (edit.end - edit.start);
+    const lineEdits = lineEditsByLine.get(lineIndex) ?? [];
+    lineEdits.push({ start: startCol, end: endCol, delta });
+    lineEditsByLine.set(lineIndex, lineEdits);
+
+    newCode += edit.replacement;
+    cursor = edit.end;
+  }
+  newCode += code.slice(cursor);
+
+  return {
+    code: newCode,
+    map: map === undefined ? undefined : shiftMapColumns(map, lineEditsByLine),
+  };
+}
+
+/**
+ * Shift the generated-column field of every mapping segment past an edit by
+ * that edit's length delta. A segment whose original column falls strictly
+ * inside a replaced span is clamped to the replacement's new start column —
+ * the token it named no longer exists, and the closest still-meaningful
+ * position is where its replacement begins.
+ */
+function shiftMapColumns(mapJson: string, lineEditsByLine: Map<number, LineColumnEdit[]>): string {
+  let parsed: { mappings?: unknown; [key: string]: unknown };
+  try {
+    parsed = JSON.parse(mapJson);
+  } catch {
+    return mapJson;
+  }
+  if (typeof parsed.mappings !== "string") return mapJson;
+
+  const decoded = decode(parsed.mappings);
+  for (const [lineIndex, rawEdits] of lineEditsByLine) {
+    const segments = decoded[lineIndex];
+    if (!segments) continue;
+    const edits = [...rawEdits].sort((a, b) => a.start - b.start);
+    for (const segment of segments as SourceMapSegment[]) {
+      const col = segment[0];
+      let shift = 0;
+      let clamped = false;
+      for (const edit of edits) {
+        if (col >= edit.end) {
+          shift += edit.delta;
+        } else if (col > edit.start) {
+          segment[0] = edit.start + shift;
+          clamped = true;
+          break;
+        } else {
+          break;
+        }
+      }
+      if (!clamped) segment[0] = col + shift;
+    }
+  }
+
+  parsed.mappings = encode(decoded);
+  return JSON.stringify(parsed);
+}
+
+/** Find every non-overlapping occurrence of a literal string, as `[start, end)` ranges. */
+function findAllOccurrences(code: string, literal: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  if (literal.length === 0) return ranges;
+  let from = 0;
+  for (;;) {
+    const index = code.indexOf(literal, from);
+    if (index === -1) break;
+    ranges.push([index, index + literal.length]);
+    from = index + literal.length;
+  }
+  return ranges;
+}
 
 /**
  * Replace SSR-related `import.meta` expressions with boolean literals.
@@ -11,20 +156,27 @@
  * - SSR build: `import.meta.server` → `true`, `import.meta.client` → `false`, `import.meta.env.SSR` → `true`
  * - Client build: `import.meta.server` → `false`, `import.meta.client` → `true`, `import.meta.env.SSR` → `false`
  */
-export function replaceImportMetaSsr(code: string, isSSR: boolean): string {
+export function replaceImportMetaSsr(code: string, isSSR: boolean, map?: string): SsrRewriteResult {
   // Only process if the code contains import.meta references
-  if (!code.includes("import.meta.")) return code;
+  if (!code.includes("import.meta.")) return { code, map };
 
-  let result = code;
+  const edits: TextEdit[] = [];
 
-  // Replace import.meta.env.SSR first (longer match, avoids partial replacement)
-  result = result.replaceAll("import.meta.env.SSR", isSSR ? "true" : "false");
+  // import.meta.env.SSR is matched first (longer literal, avoids partial
+  // replacement) by excluding it from the import.meta.server/client scans
+  // below: those two literals are not substrings of it, so scan order does
+  // not matter for correctness, only for readability.
+  for (const [start, end] of findAllOccurrences(code, "import.meta.env.SSR")) {
+    edits.push({ start, end, replacement: isSSR ? "true" : "false" });
+  }
+  for (const [start, end] of findAllOccurrences(code, "import.meta.server")) {
+    edits.push({ start, end, replacement: isSSR ? "true" : "false" });
+  }
+  for (const [start, end] of findAllOccurrences(code, "import.meta.client")) {
+    edits.push({ start, end, replacement: isSSR ? "false" : "true" });
+  }
 
-  // Replace import.meta.server and import.meta.client
-  result = result.replaceAll("import.meta.server", isSSR ? "true" : "false");
-  result = result.replaceAll("import.meta.client", isSSR ? "false" : "true");
-
-  return result;
+  return applyTextEdits(code, map, edits);
 }
 
 /**
@@ -34,16 +186,21 @@ export function replaceImportMetaSsr(code: string, isSSR: boolean): string {
  * Replaces `_resolveComponent("ComponentName")` calls with a no-op that renders
  * an empty comment node.
  */
-export function stripComponents(code: string, componentNames: string[]): string {
-  if (componentNames.length === 0) return code;
+export function stripComponents(
+  code: string,
+  componentNames: string[],
+  map?: string,
+): SsrRewriteResult {
+  if (componentNames.length === 0) return { code, map };
 
-  let result = code;
+  const edits: TextEdit[] = [];
   for (const name of componentNames) {
-    // Replace _resolveComponent("Name") with a function returning comment VNode
     const pattern = `_resolveComponent("${name}")`;
-    if (result.includes(pattern)) {
-      result = result.replaceAll(pattern, `(() => ({ __name: "${name}", render: () => null }))()`);
+    const replacement = `(() => ({ __name: "${name}", render: () => null }))()`;
+    for (const [start, end] of findAllOccurrences(code, pattern)) {
+      edits.push({ start, end, replacement });
     }
   }
-  return result;
+
+  return applyTextEdits(code, map, edits);
 }

--- a/packages/unplugin/src/core/ssr-transforms.ts
+++ b/packages/unplugin/src/core/ssr-transforms.ts
@@ -20,7 +20,7 @@ export interface SsrRewriteResult {
 }
 
 /** A single literal-text replacement, expressed as an offset range in the ORIGINAL code. */
-interface TextEdit {
+export interface TextEdit {
   start: number;
   end: number;
   replacement: string;
@@ -43,7 +43,7 @@ interface LineColumnEdit {
  * edit only ever needs to shift columns later on the SAME generated line —
  * no line renumbering is required.
  */
-function applyTextEdits(
+export function applyTextEdits(
   code: string,
   map: string | undefined,
   edits: TextEdit[],

--- a/packages/unplugin/src/core/ssr-transforms.ts
+++ b/packages/unplugin/src/core/ssr-transforms.ts
@@ -48,7 +48,9 @@ export function applyTextEdits(
   map: string | undefined,
   edits: TextEdit[],
 ): SsrRewriteResult {
-  if (edits.length === 0) return { code, map };
+  if (edits.length === 0) {
+    return { code, map: map === undefined || parseSourceMap(map) ? map : undefined };
+  }
 
   const sorted = [...edits].sort((a, b) => a.start - b.start);
 
@@ -112,13 +114,8 @@ function shiftMapColumns(
   mapJson: string,
   lineEditsByLine: Map<number, LineColumnEdit[]>,
 ): string | undefined {
-  let parsed: { mappings?: unknown; [key: string]: unknown };
-  try {
-    parsed = JSON.parse(mapJson);
-  } catch {
-    return undefined;
-  }
-  if (typeof parsed.mappings !== "string") return undefined;
+  const parsed = parseSourceMap(mapJson);
+  if (!parsed || typeof parsed.mappings !== "string") return undefined;
 
   const decoded = decode(parsed.mappings);
   for (const [lineIndex, rawEdits] of lineEditsByLine) {
@@ -146,6 +143,20 @@ function shiftMapColumns(
 
   parsed.mappings = encode(decoded);
   return JSON.stringify(parsed);
+}
+
+/** Parse a source map JSON value only when it is safe to access object properties. */
+function parseSourceMap(
+  mapJson: string,
+): { mappings?: unknown; [key: string]: unknown } | undefined {
+  try {
+    const parsed: unknown = JSON.parse(mapJson);
+    return parsed !== null && typeof parsed === "object"
+      ? (parsed as { mappings?: unknown; [key: string]: unknown })
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /** Find every non-overlapping occurrence of a literal string, as `[start, end)` ranges. */

--- a/packages/unplugin/src/core/ssr-transforms.ts
+++ b/packages/unplugin/src/core/ssr-transforms.ts
@@ -60,6 +60,11 @@ function applyTextEdits(
   const lineEditsByLine = new Map<number, LineColumnEdit[]>();
 
   for (const edit of sorted) {
+    // Edits must be non-overlapping and non-duplicate. A duplicate/overlapping
+    // edit (e.g. the same component name listed twice) would otherwise splice
+    // its replacement in twice, producing invalid output — skip it instead.
+    if (edit.start < cursor) continue;
+
     newCode += code.slice(cursor, edit.start);
 
     // Advance the line cursor to the line containing this edit.
@@ -98,15 +103,22 @@ function applyTextEdits(
  * inside a replaced span is clamped to the replacement's new start column —
  * the token it named no longer exists, and the closest still-meaningful
  * position is where its replacement begins.
+ *
+ * An unparseable map is dropped (`undefined`) rather than passed through
+ * unshifted: a stale map describing pre-rewrite positions is worse than no
+ * map at all, since it silently mispoints instead of visibly disappearing.
  */
-function shiftMapColumns(mapJson: string, lineEditsByLine: Map<number, LineColumnEdit[]>): string {
+function shiftMapColumns(
+  mapJson: string,
+  lineEditsByLine: Map<number, LineColumnEdit[]>,
+): string | undefined {
   let parsed: { mappings?: unknown; [key: string]: unknown };
   try {
     parsed = JSON.parse(mapJson);
   } catch {
-    return mapJson;
+    return undefined;
   }
-  if (typeof parsed.mappings !== "string") return mapJson;
+  if (typeof parsed.mappings !== "string") return undefined;
 
   const decoded = decode(parsed.mappings);
   for (const [lineIndex, rawEdits] of lineEditsByLine) {
@@ -194,7 +206,7 @@ export function stripComponents(
   if (componentNames.length === 0) return { code, map };
 
   const edits: TextEdit[] = [];
-  for (const name of componentNames) {
+  for (const name of new Set(componentNames)) {
     const pattern = `_resolveComponent("${name}")`;
     const replacement = `(() => ({ __name: "${name}", render: () => null }))()`;
     for (const [start, end] of findAllOccurrences(code, pattern)) {

--- a/packages/unplugin/src/core/ssr-transforms.ts
+++ b/packages/unplugin/src/core/ssr-transforms.ts
@@ -49,6 +49,10 @@ export function applyTextEdits(
   edits: TextEdit[],
 ): SsrRewriteResult {
   if (edits.length === 0) {
+    // The zero-edit path admits a map on exactly the terms the edited path
+    // does (`shiftMapColumns` → `parseSourceMap`): an unusable map is
+    // dropped here too, never preserved because no rewrite happened to
+    // reject it.
     return { code, map: map === undefined || parseSourceMap(map) ? map : undefined };
   }
 
@@ -115,7 +119,7 @@ function shiftMapColumns(
   lineEditsByLine: Map<number, LineColumnEdit[]>,
 ): string | undefined {
   const parsed = parseSourceMap(mapJson);
-  if (!parsed || typeof parsed.mappings !== "string") return undefined;
+  if (!parsed) return undefined;
 
   const decoded = decode(parsed.mappings);
   for (const [lineIndex, rawEdits] of lineEditsByLine) {
@@ -145,14 +149,25 @@ function shiftMapColumns(
   return JSON.stringify(parsed);
 }
 
-/** Parse a source map JSON value only when it is safe to access object properties. */
-function parseSourceMap(
-  mapJson: string,
-): { mappings?: unknown; [key: string]: unknown } | undefined {
+/** A parsed source map this module can shift: an object carrying string `mappings`. */
+interface ParsedSourceMap {
+  mappings: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Parse a source map JSON value only when it is a map this module can use:
+ * a non-null object whose `mappings` is a string. Anything else — invalid
+ * JSON, `null`, a primitive, an array, or an object without string
+ * `mappings` — is `undefined`, so both the edited and the zero-edit path
+ * drop the same shapes.
+ */
+function parseSourceMap(mapJson: string): ParsedSourceMap | undefined {
   try {
     const parsed: unknown = JSON.parse(mapJson);
-    return parsed !== null && typeof parsed === "object"
-      ? (parsed as { mappings?: unknown; [key: string]: unknown })
+    if (parsed === null || typeof parsed !== "object") return undefined;
+    return typeof (parsed as { mappings?: unknown }).mappings === "string"
+      ? (parsed as ParsedSourceMap)
       : undefined;
   } catch {
     return undefined;

--- a/packages/unplugin/src/index.spec.ts
+++ b/packages/unplugin/src/index.spec.ts
@@ -2836,27 +2836,13 @@ const msg = 'hello'
     }
   });
 
-  // CHARACTERIZED, NOT FIXED — a defect in a different owner.
-  //
   // `replaceImportMetaSsr` / `stripComponents` (`src/core/ssr-transforms.ts`,
   // applied in the carrier transform of `src/index.ts`) rewrite the compiled
-  // module with plain string replacement AFTER the host produced it. The
-  // replacements change byte offsets — `import.meta.server` → `false` is 13
-  // bytes shorter — while the map the host published for that module is
-  // handed on unchanged, so the published pair describes two different texts.
-  //
-  // Measured on the fixture below: the host places `later` at generated line 7
-  // column 39 and the map names that position; `import.meta.server` → `false`
-  // shortens the line from 48 bytes to 35 and moves `later` to column 26, so
-  // the published map points past the end of the line it describes.
-  //
-  // This is NOT introduced by publishing the map on the inline product: the
-  // Vite branch has always cached the SAME rewritten code beside the SAME host
-  // map for the script sub-request. The fix belongs to the SSR
-  // dead-code-elimination pass, which must apply its rewrites through a
-  // map-aware mechanism instead of `String.replaceAll`, and is out of scope
-  // here.
-  it.skip("maps a token that the SSR rewrite moved to its new generated column", async () => {
+  // module's text. Each rewrite changes byte offsets — `import.meta.server` →
+  // `false` is 13 bytes shorter — so the rewrite carries the in-flight map
+  // through the same call and shifts its generated columns to match, instead
+  // of handing the pre-rewrite map on unchanged beside the rewritten text.
+  it("maps a token that the SSR rewrite moved to its new generated column", async () => {
     // `later` sits AFTER the rewritten expression on the same line, so the
     // rewrite moves it left. Every mapping at or beyond that point is then off
     // by the length the replacement removed.

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -1120,17 +1120,33 @@ function createFrameworkFactory(
         // Determine the effective language of the compiled output.
         const mainLang: string = main.lang ?? "ts";
 
-        // Apply SSR transforms (import.meta dead-code elimination, component stripping)
+        // Apply SSR transforms (import.meta dead-code elimination, component
+        // stripping). Each rewrite carries the in-flight map along with the
+        // code, so the map's generated columns stay aligned with whatever
+        // text it currently describes.
         let compiledCode = main.code;
+        let compiledMap = main.sourceMap;
         const ssrOpts = opts.ssr;
         if (ssrOpts?.deadCodeElimination !== false) {
-          compiledCode = replaceImportMetaSsr(compiledCode, ssr);
+          ({ code: compiledCode, map: compiledMap } = replaceImportMetaSsr(
+            compiledCode,
+            ssr,
+            compiledMap,
+          ));
         }
         if (ssr && ssrOpts?.clientOnlyComponents?.length) {
-          compiledCode = stripComponents(compiledCode, ssrOpts.clientOnlyComponents);
+          ({ code: compiledCode, map: compiledMap } = stripComponents(
+            compiledCode,
+            ssrOpts.clientOnlyComponents,
+            compiledMap,
+          ));
         }
         if (!ssr && ssrOpts?.serverOnlyComponents?.length) {
-          compiledCode = stripComponents(compiledCode, ssrOpts.serverOnlyComponents);
+          ({ code: compiledCode, map: compiledMap } = stripComponents(
+            compiledCode,
+            ssrOpts.serverOnlyComponents,
+            compiledMap,
+          ));
         }
 
         if (viteConfig) {
@@ -1145,7 +1161,7 @@ function createFrameworkFactory(
           // properly processed JavaScript, not raw TS/JSX.
           scriptCache.set(filename, {
             code: compiledCode,
-            map: main.sourceMap ?? null,
+            map: compiledMap ?? null,
           });
 
           const scriptRequest = `${filename}?vue&type=script&lang.${mainLang}`;
@@ -1218,7 +1234,7 @@ function createFrameworkFactory(
         // host published and leave a non-Vite consumer with no way back to the
         // authored SFC. Absent a requested map the host publishes none and this
         // is `null`, which is what "no map" means to a bundler.
-        return { code: compiledCode, map: main.sourceMap ?? null };
+        return { code: compiledCode, map: compiledMap ?? null };
       },
 
       async closeBundle() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,7 +273,7 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.6.2
-        version: 3.6.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(node-addon-api@7.1.1)
+        version: 3.6.2(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@25.9.1)(node-addon-api@7.1.1)
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -333,7 +333,7 @@ importers:
         version: link:../unplugin
       nuxt:
         specifier: ^3.0.0 || ^4.0.0
-        version: 4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2)
+        version: 4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.6.0-rc.5)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2)
     devDependencies:
       tsdown:
         specifier: ^0.22.0
@@ -525,6 +525,9 @@ importers:
 
   packages/unplugin:
     dependencies:
+      '@jridgewell/sourcemap-codec':
+        specifier: ^1.5.5
+        version: 1.5.5
       '@verter/native':
         specifier: workspace:*
         version: link:../native
@@ -5433,11 +5436,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.18.0:
-    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -6865,14 +6863,6 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-
-  esrap@2.2.11:
-    resolution: {integrity: sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==}
-    peerDependencies:
-      '@typescript-eslint/types': ^8.2.0
-    peerDependenciesMeta:
-      '@typescript-eslint/types':
-        optional: true
 
   esrap@2.3.5:
     resolution: {integrity: sha512-KciPkeZZX8srrh6xELzLR2cBaWOzgBQ4CwggO6Dh/KMlrfOcIcfyXCVy/Vvc3/OlS5gvFOd5tcxUYuaGM8o45A==}
@@ -13178,11 +13168,11 @@ snapshots:
       '@module-federation/sdk': 0.22.0
     optional: true
 
-  '@napi-rs/cli@3.6.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(node-addon-api@7.1.1)':
+  '@napi-rs/cli@3.6.2(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@types/node@25.9.1)(node-addon-api@7.1.1)':
     dependencies:
       '@inquirer/prompts': 8.5.0(@types/node@25.9.1)
-      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+      '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       '@octokit/rest': 22.0.1
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       colorette: 2.0.20
@@ -13193,7 +13183,7 @@ snapshots:
       semver: 7.8.1
       typanion: 3.14.0
     optionalDependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.3
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
@@ -13210,10 +13200,10 @@ snapshots:
       - node-addon-api
       - supports-color
 
-  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@napi-rs/lzma': 1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@napi-rs/tar': 1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/lzma': 1.4.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+      '@napi-rs/tar': 1.1.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -13259,9 +13249,9 @@ snapshots:
   '@napi-rs/lzma-linux-x64-musl@1.4.5':
     optional: true
 
-  '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -13276,7 +13266,7 @@ snapshots:
   '@napi-rs/lzma-win32-x64-msvc@1.4.5':
     optional: true
 
-  '@napi-rs/lzma@1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/lzma@1.4.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     optionalDependencies:
       '@napi-rs/lzma-android-arm-eabi': 1.4.5
       '@napi-rs/lzma-android-arm64': 1.4.5
@@ -13291,7 +13281,7 @@ snapshots:
       '@napi-rs/lzma-linux-s390x-gnu': 1.4.5
       '@napi-rs/lzma-linux-x64-gnu': 1.4.5
       '@napi-rs/lzma-linux-x64-musl': 1.4.5
-      '@napi-rs/lzma-wasm32-wasi': 1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/lzma-wasm32-wasi': 1.4.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       '@napi-rs/lzma-win32-arm64-msvc': 1.4.5
       '@napi-rs/lzma-win32-ia32-msvc': 1.4.5
       '@napi-rs/lzma-win32-x64-msvc': 1.4.5
@@ -13335,9 +13325,9 @@ snapshots:
   '@napi-rs/tar-linux-x64-musl@1.1.0':
     optional: true
 
-  '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -13352,7 +13342,7 @@ snapshots:
   '@napi-rs/tar-win32-x64-msvc@1.1.0':
     optional: true
 
-  '@napi-rs/tar@1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/tar@1.1.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     optionalDependencies:
       '@napi-rs/tar-android-arm-eabi': 1.1.0
       '@napi-rs/tar-android-arm64': 1.1.0
@@ -13366,7 +13356,7 @@ snapshots:
       '@napi-rs/tar-linux-s390x-gnu': 1.1.0
       '@napi-rs/tar-linux-x64-gnu': 1.1.0
       '@napi-rs/tar-linux-x64-musl': 1.1.0
-      '@napi-rs/tar-wasm32-wasi': 1.1.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/tar-wasm32-wasi': 1.1.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       '@napi-rs/tar-win32-arm64-msvc': 1.1.0
       '@napi-rs/tar-win32-ia32-msvc': 1.1.0
       '@napi-rs/tar-win32-x64-msvc': 1.1.0
@@ -13392,6 +13382,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.2
     optional: true
 
@@ -13429,9 +13426,9 @@ snapshots:
   '@napi-rs/wasm-tools-linux-x64-musl@1.0.1':
     optional: true
 
-  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -13446,7 +13443,7 @@ snapshots:
   '@napi-rs/wasm-tools-win32-x64-msvc@1.0.1':
     optional: true
 
-  '@napi-rs/wasm-tools@1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-tools@1.0.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     optionalDependencies:
       '@napi-rs/wasm-tools-android-arm-eabi': 1.0.1
       '@napi-rs/wasm-tools-android-arm64': 1.0.1
@@ -13457,7 +13454,7 @@ snapshots:
       '@napi-rs/wasm-tools-linux-arm64-musl': 1.0.1
       '@napi-rs/wasm-tools-linux-x64-gnu': 1.0.1
       '@napi-rs/wasm-tools-linux-x64-musl': 1.0.1
-      '@napi-rs/wasm-tools-wasm32-wasi': 1.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-tools-wasm32-wasi': 1.0.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       '@napi-rs/wasm-tools-win32-arm64-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-ia32-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-x64-msvc': 1.0.1
@@ -13629,7 +13626,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.3.1(@azure/identity@4.13.1)(db0@0.3.4)(ioredis@5.9.3)(magicast@0.5.2)(nuxt@4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2))(rolldown@1.0.2)(typescript@6.0.3)':
+  '@nuxt/nitro-server@4.3.1(@azure/identity@4.13.1)(db0@0.3.4)(ioredis@5.9.3)(magicast@0.5.2)(nuxt@4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.6.0-rc.5)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2))(rolldown@1.0.2)(typescript@6.0.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
@@ -13647,7 +13644,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.1(@azure/identity@4.13.1)(rolldown@1.0.2)
-      nuxt: 4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2)
+      nuxt: 4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.6.0-rc.5)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2)
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -13711,7 +13708,7 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/vite-builder@4.3.1(@types/node@25.9.1)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2))(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.3.1(@types/node@25.9.1)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.6.0-rc.5)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2))(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.57.1)
@@ -13730,7 +13727,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.0
       mocked-exports: 0.1.1
-      nuxt: 4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2)
+      nuxt: 4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.6.0-rc.5)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2)
       pathe: 2.0.3
       pkg-types: 2.3.0
       postcss: 8.5.20
@@ -16190,9 +16187,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  acorn@8.18.0:
-    optional: true
-
   agent-base@7.1.4: {}
 
   ajv-draft-04@1.0.0(ajv@8.18.0):
@@ -17692,10 +17686,6 @@ snapshots:
   esm-env@1.2.2: {}
 
   esprima@4.0.1: {}
-
-  esrap@2.2.11:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
 
   esrap@2.3.5:
     dependencies:
@@ -19646,16 +19636,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2):
+  nuxt@4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.6.0-rc.5)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2):
     dependencies:
       '@dxup/nuxt': 0.3.2(magicast@0.5.2)
       '@nuxt/cli': 3.33.1(@nuxt/schema@4.3.1)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(vue@3.5.34(typescript@6.0.3))
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.3.1(@azure/identity@4.13.1)(db0@0.3.4)(ioredis@5.9.3)(magicast@0.5.2)(nuxt@4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2))(rolldown@1.0.2)(typescript@6.0.3)
+      '@nuxt/nitro-server': 4.3.1(@azure/identity@4.13.1)(db0@0.3.4)(ioredis@5.9.3)(magicast@0.5.2)(nuxt@4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.6.0-rc.5)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2))(rolldown@1.0.2)(typescript@6.0.3)
       '@nuxt/schema': 4.3.1
       '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.3.1(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.3.1(@types/node@25.9.1)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2))(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))(yaml@2.8.2)
+      '@nuxt/vite-builder': 4.3.1(@types/node@25.9.1)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.3.1(@azure/identity@4.13.1)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.6.0-rc.5)(cac@6.7.14)(db0@0.3.4)(ioredis@5.9.3)(less@4.6.4)(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))(yaml@2.8.2))(rolldown@1.0.2)(rollup@4.57.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))(yaml@2.8.2)
       '@unhead/vue': 2.1.9(vue@3.5.34(typescript@6.0.3))
       '@vue/shared': 3.5.34
       c12: 3.3.3(magicast@0.5.2)
@@ -19701,7 +19691,7 @@ snapshots:
       unctx: 2.5.0
       unimport: 5.7.0
       unplugin: 3.0.0
-      unplugin-vue-router: 0.19.2(@vue/compiler-sfc@3.5.34)(vue-router@4.6.4(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
+      unplugin-vue-router: 0.19.2(@vue/compiler-sfc@3.6.0-rc.5)(vue-router@4.6.4(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
       untyped: 2.0.0
       vue: 3.5.34(typescript@6.0.3)
       vue-router: 4.6.4(vue@3.6.0-rc.5(typescript@6.0.3))
@@ -22151,11 +22141,11 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.3
 
-  unplugin-vue-router@0.19.2(@vue/compiler-sfc@3.5.34)(vue-router@4.6.4(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3)):
+  unplugin-vue-router@0.19.2(@vue/compiler-sfc@3.6.0-rc.5)(vue-router@4.6.4(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 7.29.1
       '@vue-macros/common': 3.1.2(vue@3.5.34(typescript@6.0.3))
-      '@vue/compiler-sfc': 3.5.34
+      '@vue/compiler-sfc': 3.6.0-rc.5
       '@vue/language-core': 3.2.5
       ast-walker-scope: 0.8.3
       chokidar: 5.0.0
@@ -22732,7 +22722,7 @@ snapshots:
   webpack-bundle-analyzer@4.10.2:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      acorn: 8.18.0
+      acorn: 8.16.0
       acorn-walk: 8.3.5
       commander: 7.2.0
       debounce: 1.2.1


### PR DESCRIPTION
## Summary

Replaced the plain String.replaceAll rewrites in packages/unplugin/src/core/ssr-transforms.ts (import.meta.env.SSR/server/client and the _resolveComponent stub pattern) with a map-aware text-edit mechanism: each rewrite now tracks its literal-text edits as offset ranges, applies them in one pass, and — when an in-flight source map is supplied — shifts the map's decoded generated columns (via @jridgewell/sourcemap-codec) past each edit by that edit's length delta, clamping any mapping that fell inside a replaced span to the replacement's new start. packages/unplugin/src/index.ts now threads main.sourceMap through replaceImportMetaSsr/stripComponents instead of handing the pre-rewrite map on unchanged. The previously-skipped test 'maps a token that the SSR rewrite moved to its new generated column' (packages/unplugin/src/index.spec.ts) is un-skipped and passes with zero overshooting positions, all other mapping assertions in that file remain green (120/120), the full unplugin package suite passes (241 passed, 4 pre-existing skips), and the Vite script sub-request caching path and SSR boolean-literal branch behavior are unchanged. Added @jridgewell/sourcemap-codec as a direct dependency (already present transitively in the workspace lockfile). Could not locate a predeclared ledger line for this node's id in roadmap/0.1.0-fleet/authority/state/implemented.toml (searched by both the branch-embedded id and the packet's internal node id) — see finding below; the file was left untouched rather than fabricating a new row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-map handling for server-side rendering transformations, preserving accurate links between generated and original source code.
  * Corrected source maps after import metadata replacements and component-call removal, improving debugging and stack-trace accuracy.
  * Prevented invalid source maps from being propagated.
  * Ensured duplicate component references are processed consistently without overlapping transformations.
  * Improved source-map accuracy for both cached and inline server-rendered output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->