### PR TITLE
feat(roadmap): add a cancelled ledger status for retired nodes

### DIFF
--- a/roadmap/0.1.0-tama/APPLICATION.md
+++ b/roadmap/0.1.0-tama/APPLICATION.md
@@ -40,9 +40,10 @@ This row identifies the native GitHub parent for all active mapped blocks in tha
 A node is READY when:
 
 - it is dispatchable;
-- every transitive DAG ancestor is implemented.
+- it is not cancelled;
+- every transitive DAG ancestor is settled: implemented, or cancelled (retired work is not waited for).
 
-No other lifecycle state is consulted. A recorded direct predecessor cannot hide a missing earlier ancestor. Conflict/resource/external-requirement fields are planning instructions for agents and maintainers, not locks or machine-validated authorizations.
+Only the ledger's `status` rows are consulted; no other lifecycle state is. A recorded direct predecessor cannot hide a missing earlier ancestor. Conflict/resource/external-requirement fields are planning instructions for agents and maintainers, not locks or machine-validated authorizations.
 
 The frontier command is read-only and stateless. It is just a convenient rendering of this rule; there is no start record or start commit. A node with no unimplemented ancestor can start immediately.
 

--- a/roadmap/0.1.0-tama/APPLICATION.md
+++ b/roadmap/0.1.0-tama/APPLICATION.md
@@ -45,7 +45,7 @@ A node is READY when:
 
 Only the ledger's `status` rows are consulted; no other lifecycle state is. A recorded direct predecessor cannot hide a missing earlier ancestor. Conflict/resource/external-requirement fields are planning instructions for agents and maintainers, not locks or machine-validated authorizations.
 
-The frontier command is read-only and stateless. It is just a convenient rendering of this rule; there is no start record or start commit. A node with no unimplemented ancestor can start immediately.
+The frontier command is read-only and stateless. It is just a convenient rendering of this rule; there is no start record or start commit. A node whose every ancestor is settled (implemented or cancelled) can start immediately.
 
 Inspect the frontier with:
 

--- a/roadmap/0.1.0-tama/APPLICATION.md
+++ b/roadmap/0.1.0-tama/APPLICATION.md
@@ -98,6 +98,16 @@ If the user or maintainer explicitly selects a non-PR landing instead, keep the 
 
 To represent an existing GitHub issue in the DAG, follow `ManualDagAuthoring`: manually author the node, charter, and `[[github_issue]]` row with `sync_to_github = false` in the same reviewed patch. No sync command imports or generates those local authority changes, and the existing issue remains protected from rewrite.
 
+## Retiring a node
+
+A node whose work will never land under its identity is retired, not left pending forever:
+
+```toml
+"BCSS0" = { status = "cancelled", reason = "superseded: the charter is a v2 identity wrapper for history already landed" }
+```
+
+`reason` is optional free text for the reader. A cancelled node is never READY and never emits a work packet; its descendants treat it as settled and wait only for their other ancestors. It is not implemented: `programctl implemented` omits it and product reports count it separately. Flipping the row back to `status = "pending"` reopens the node; an implemented node must be flipped to pending before it can be cancelled.
+
 ## Corrections
 
 The ledger is trusted documentation. If a locator hint is unhelpful, correct it with an ordinary patch. The correction does not reopen, invalidate, or re-prove the node. Flipping the row back to `status = "pending"` is the deliberate operation that marks a node unimplemented and may block descendants.

--- a/roadmap/0.1.0-tama/README.md
+++ b/roadmap/0.1.0-tama/README.md
@@ -14,7 +14,7 @@ Production LOC and file budgets are planning references rather than hard accepta
 
 There are no commit-SHA, tree, parent, ancestry, receipt, lease, activation-journal, authority-digest, or prompt/report-digest checks in the lifecycle. Agents are trusted to transition accurate rows to implemented and to obey charters, review profiles, and gates.
 
-`programctl frontier` is only a stateless convenience report. It derives the currently dispatchable nodes from DAG ancestors and implemented-line presence; it does not start, reserve, activate, or write anything. A node with no unimplemented ancestor can start immediately.
+`programctl frontier` is only a stateless convenience report. It derives the currently dispatchable nodes from DAG ancestors and the ledger's settled rows (implemented or cancelled); it does not start, reserve, activate, or write anything. A node whose every ancestor is settled can start immediately.
 
 Core commands from the repository root:
 

--- a/roadmap/0.1.0-tama/README.md
+++ b/roadmap/0.1.0-tama/README.md
@@ -4,7 +4,7 @@ The [codebase simplification train](decisions/2026-09-08-codebase-simplification
 
 This directory is the live Tama roadmap for Verter 0.1.0. It carries the ratified Revision 11 architecture forward as an execution program rather than documentation. Static work definition lives in `authority/dag/` and `charters/`. Implemented state lives in one intentionally simple file: `authority/state/implemented.toml`.
 
-A node is implemented when its predeclared `[implementation]` line has `status = "implemented"`. Its `commit_message`, `commit_date`, and optional `pull_request` are loose locator hints for a person or agent who later wants to find the work. They are not identity, proof, or validator inputs. Flipping the row back to `status = "pending"` is the deliberate operation that marks a node unimplemented.
+A node is implemented when its predeclared `[implementation]` line has `status = "implemented"`. Its `commit_message`, `commit_date`, and optional `pull_request` are loose locator hints for a person or agent who later wants to find the work. They are not identity, proof, or validator inputs. Flipping the row back to `status = "pending"` is the deliberate operation that marks a node unimplemented. A node whose work will never land under its identity (a superseded charter, work folded into another node) is retired with `status = "cancelled"` and an optional `reason`: it is never READY, its descendants do not wait for it, and flipping it back to pending reopens it.
 
 The same file may contain separate `[[github_issue]]` rows with `node_id`, `gh_issue`, and required `sync_to_github`. Those rows are a local lookup table and mutation policy only; they never mark a node implemented. `true` opts an issue into deterministic managed-label synchronization and explicit one-way content refresh. `false` protects a pre-existing issue manually mapped into the DAG. After GH6, `githubctl sync-issues` creates missing opt-in issues and reconciles the versioned catalogs without rewriting existing issue prose. Before creation or `--refresh-content`, author the selected node's reviewed `catalogs/github-issue-content.toml` entry; missing or invalid content fails before GitHub mutation. Opt-in descriptions follow the human issue standard in `contracts/github-control-plane.md`; they explain the problem, expected outcome, and observable acceptance in standalone prose rather than copying charter sections. GitHub edits never flow back, and protected issues are never read or rewritten.
 
@@ -23,6 +23,7 @@ node roadmap/0.1.0-tama/tools/programctl.mjs frontier
 node roadmap/0.1.0-tama/tools/programctl.mjs explain ID
 node roadmap/0.1.0-tama/tools/programctl.mjs packet ID
 node roadmap/0.1.0-tama/tools/programctl.mjs implemented
+node roadmap/0.1.0-tama/tools/programctl.mjs cancelled
 node roadmap/0.1.0-tama/tools/programctl.mjs products
 node roadmap/0.1.0-tama/tools/programctl.mjs github-issues
 node roadmap/0.1.0-tama/tools/programctl.mjs github-issue NUMBER

--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -6,6 +6,9 @@ schema = 2
 # commit_message, commit_date, and optionally pull_request) is the complete
 # implementation fact. Evidence fields are loose human locators; tooling never
 # resolves or validates them against Git, content, ancestry, or GitHub.
+# status = "cancelled" (with an optional reason) retires a node whose work
+# will never land under this identity: it is never READY, and descendants
+# treat it as settled; flipping it back to "pending" reopens it.
 # Serialization is canonical: nodes sorted by id, one line per node, so
 # independent transitions merge mechanically. [[github_issue]] rows map
 # node_id to gh_issue; sync_to_github is one-way-refresh policy only and never
@@ -16,7 +19,7 @@ schema = 2
 "A0" = { status = "implemented", commit_message = "chore(*): add the architecture-lock program documents, state validator, and gate wiring", commit_date = "2026-08-10T01:40:28+01:00" }
 "A1" = { status = "implemented", commit_message = "docs(*): reference command-truth evidence in the capability matrix", commit_date = "2026-08-10T08:17:25+01:00" }
 "A2" = { status = "implemented", commit_message = "test(session): strengthen the U6 flow-return corpus with recursive expectations, a fully modelled two-call boundary, checker-syntax semantic cross-validation, and per-clause comparator controls", commit_date = "2026-08-10T17:18:39+01:00" }
-"A2C" = { status = "pending" }
+"A2C" = { status = "cancelled", reason = "superseded: retired completion predecessor, deferred to D6" }
 "A3" = { status = "implemented", commit_message = "fix(session): retract unsupported flow-return results from warm admission", commit_date = "2026-08-11T15:42:17+01:00" }
 "A4" = { status = "implemented", commit_message = "feat(audit): install measurement-only work-attribution substrate and capture baseline", commit_date = "2026-08-12T00:12:56+01:00" }
 "A5" = { status = "implemented", commit_message = "docs(arch): accept the current-owner inventories and the implementation lock record into the program ledger", commit_date = "2026-08-12T08:32:50+01:00" }
@@ -32,7 +35,7 @@ schema = 2
 "B5" = { status = "implemented", commit_message = "feat(core): expose the accepted framework algorithms through one direct core", commit_date = "2026-08-22T16:48:49+01:00" }
 "B6" = { status = "implemented", commit_message = "perf(core): group batch items by map probe instead of a linear scan", commit_date = "2026-08-24T18:43:38+01:00" }
 "BA0" = { status = "implemented", commit_message = "fix(core): make a compile request atomic over the products it asks for", commit_date = "2026-08-17T23:47:24+01:00" }
-"BCSS0" = { status = "pending" }
+"BCSS0" = { status = "cancelled", reason = "superseded: the charter is a v2 identity wrapper for history already landed under the Rev11 compiler foundation" }
 "BF1" = { status = "implemented", commit_message = "chore(arch): freeze the oracle-manifest enumeration performance cells", commit_date = "2026-08-12T17:05:21+01:00" }
 "BF2" = { status = "implemented", commit_message = "fix(meta): correct three official-invocation option-propagation defects and rebuild the mapping axis on authored-source truthfulness", commit_date = "2026-08-14T19:02:10+01:00" }
 "BF3" = { status = "implemented", commit_message = "docs(arch): record the maintainer act closing the two held-open review items", commit_date = "2026-08-17T12:53:47+01:00" }

--- a/roadmap/0.1.0-tama/schemas/implementation-ledger.schema.json
+++ b/roadmap/0.1.0-tama/schemas/implementation-ledger.schema.json
@@ -12,18 +12,38 @@
       "patternProperties": {
         "^[A-Z][A-Z0-9-]*$": {
           "type": "object",
-          "additionalProperties": false,
           "required": ["status"],
-          "properties": {
-            "status": { "enum": ["pending", "implemented", "cancelled"] },
-            "reason": { "type": "string", "minLength": 1 },
-            "commit_message": { "type": "string", "minLength": 1 },
-            "commit_date": {
-              "type": "string",
-              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$"
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["status"],
+              "properties": { "status": { "const": "pending" } }
             },
-            "pull_request": { "type": "integer", "minimum": 1 }
-          }
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["status"],
+              "properties": {
+                "status": { "const": "cancelled" },
+                "reason": { "type": "string", "minLength": 1 }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["status", "commit_message", "commit_date"],
+              "properties": {
+                "status": { "const": "implemented" },
+                "commit_message": { "type": "string", "minLength": 1 },
+                "commit_date": {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$"
+                },
+                "pull_request": { "type": "integer", "minimum": 1 }
+              }
+            }
+          ]
         }
       }
     },

--- a/roadmap/0.1.0-tama/schemas/implementation-ledger.schema.json
+++ b/roadmap/0.1.0-tama/schemas/implementation-ledger.schema.json
@@ -15,7 +15,8 @@
           "additionalProperties": false,
           "required": ["status"],
           "properties": {
-            "status": { "enum": ["pending", "implemented"] },
+            "status": { "enum": ["pending", "implemented", "cancelled"] },
+            "reason": { "type": "string", "minLength": 1 },
             "commit_message": { "type": "string", "minLength": 1 },
             "commit_date": {
               "type": "string",

--- a/roadmap/0.1.0-tama/tools/implementation-ledger.test.mjs
+++ b/roadmap/0.1.0-tama/tools/implementation-ledger.test.mjs
@@ -18,7 +18,7 @@ import {
   validateSchemaObject,
 } from "./lib.mjs";
 
-function smallAuthority(implemented = []) {
+function smallAuthority(implemented = [], cancelled = []) {
   const node = (id, predecessors = []) => ({
     id,
     name: id,
@@ -27,7 +27,7 @@ function smallAuthority(implemented = []) {
   });
   return {
     nodes: [node("ORC0"), node("GH0", ["ORC0"]), node("GH1", ["GH0"])],
-    ledger: { implemented },
+    ledger: { implemented, cancelled },
   };
 }
 
@@ -92,6 +92,7 @@ test("product reporting distinguishes implemented foundations from pending accep
   };
   const [product] = productReport(authority, deriveState(authority));
   assert.equal(product.implemented, 1);
+  assert.equal(product.cancelled, 0);
   assert.deepEqual(product.acceptance_gates, [
     { id: "FINAL", status: "READY", missing_ancestors: [] },
   ]);
@@ -155,6 +156,40 @@ test("frontier is derived only from implemented ancestors", () => {
   assert.equal(afterOrc0.states.get("ORC0").status, "COMPLETE");
   assert.equal(afterOrc0.states.get("GH0").status, "READY");
   assert.equal(afterOrc0.states.get("GH1").status, "BLOCKED");
+});
+
+test("a cancelled node is settled without evidence: never READY, descendants proceed, no packet", () => {
+  const cancelled = deriveState(smallAuthority([], [{ node_id: "GH0", reason: "superseded" }]));
+  assert.equal(cancelled.states.get("ORC0").status, "READY");
+  assert.equal(cancelled.states.get("GH0").status, "CANCELLED");
+  assert.deepEqual(cancelled.states.get("GH0").cancellation, { reason: "superseded" });
+  // GH1 still waits for ORC0, but not for the retired GH0.
+  assert.equal(cancelled.states.get("GH1").status, "BLOCKED");
+  assert.deepEqual(cancelled.states.get("GH1").missing_ancestors, ["ORC0"]);
+  assert.deepEqual(cancelled.states.get("GH1").cancelled_ancestors, ["GH0"]);
+  const afterOrc0 = deriveState(smallAuthority([{ node_id: "ORC0" }], [{ node_id: "GH0" }]));
+  assert.equal(afterOrc0.states.get("GH1").status, "READY");
+  assert.deepEqual(afterOrc0.states.get("GH1").missing_ancestors, []);
+  // An implemented row wins over a cancelled one for the same node (the validator rejects the pair anyway).
+  const both = deriveState(smallAuthority([{ node_id: "GH0" }], [{ node_id: "GH0" }]));
+  assert.equal(both.states.get("GH0").status, "COMPLETE");
+
+  const authority = loadAuthority();
+  const live = deriveState(authority);
+  for (const row of authority.ledger.cancelled) {
+    assert.equal(live.states.get(row.node_id).status, "CANCELLED", `${row.node_id} is retired in the live ledger`);
+    assert.throws(() => packetFor(authority, live, row.node_id), /cannot create work packet for CANCELLED node/u);
+  }
+  assert.ok(
+    authority.ledger.cancelled.some((row) => row.node_id === "BCSS0"),
+    "the superseded BCSS0 charter is retired in the ledger rather than parked as BLOCKED forever",
+  );
+  const errors = validateAuthority({
+    ...authority,
+    ledger: { ...authority.ledger, cancelled: [...authority.ledger.cancelled, { node_id: "A0" }, { node_id: "ZZ9" }] },
+  });
+  assert.ok(errors.includes("implementation ledger: duplicate node A0"));
+  assert.ok(errors.includes("implementation ledger: unknown node ZZ9"));
 });
 
 test("successor promotion directly follows the final Rev11 gate", () => {

--- a/roadmap/0.1.0-tama/tools/ledger.mjs
+++ b/roadmap/0.1.0-tama/tools/ledger.mjs
@@ -19,11 +19,18 @@ import { parseToml, serializeInlineTable } from "./toml.mjs";
 export const LEDGER_SCHEMA_VERSION = 2;
 export const STATUS_PENDING = "pending";
 export const STATUS_IMPLEMENTED = "implemented";
+/**
+ * The node's work will never be done under this identity (superseded,
+ * withdrawn, folded into another node). A cancelled row is neither pending
+ * nor implemented: readiness never offers the node, and descendants treat it
+ * as settled. Flipping it back to pending reopens it.
+ */
+export const STATUS_CANCELLED = "cancelled";
 
 export const NODE_ID_PATTERN = /^[A-Z][A-Z0-9-]*$/u;
 export const COMMIT_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$/u;
 
-const RECORD_FIELDS = ["status", "commit_message", "commit_date", "pull_request"];
+const RECORD_FIELDS = ["status", "commit_message", "commit_date", "pull_request", "reason"];
 
 function isPlainObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -45,7 +52,13 @@ export function recordErrors(nodeId, record, location = "implementation ledger")
   if (record.status === STATUS_PENDING) {
     for (const key of Object.keys(record))
       if (key !== "status") errors.push(`${at}: pending rows carry no ${key}`);
+  } else if (record.status === STATUS_CANCELLED) {
+    for (const key of Object.keys(record))
+      if (key !== "status" && key !== "reason") errors.push(`${at}: cancelled rows carry no ${key}`);
+    if (record.reason !== undefined && (typeof record.reason !== "string" || record.reason.length === 0))
+      errors.push(`${at}: reason must be a non-empty string`);
   } else if (record.status === STATUS_IMPLEMENTED) {
+    if (record.reason !== undefined) errors.push(`${at}: implemented rows carry no reason`);
     if (typeof record.commit_message !== "string" || record.commit_message.length === 0)
       errors.push(`${at}: implemented rows require commit_message`);
     if (typeof record.commit_date !== "string" || !COMMIT_DATE_PATTERN.test(record.commit_date))
@@ -56,7 +69,7 @@ export function recordErrors(nodeId, record, location = "implementation ledger")
     )
       errors.push(`${at}: pull_request must be a positive integer`);
   } else {
-    errors.push(`${at}: status must be "pending" or "implemented"`);
+    errors.push(`${at}: status must be "pending", "implemented" or "cancelled"`);
   }
   return errors;
 }
@@ -124,8 +137,27 @@ export function implementedRows(parsed) {
   return rows.sort((left, right) => (left.node_id < right.node_id ? -1 : left.node_id > right.node_id ? 1 : 0));
 }
 
+/**
+ * Cancelled rows: [{ node_id, reason? }], sorted by node_id. deriveState
+ * treats them as settled without evidence; they never become READY.
+ */
+export function cancelledRows(parsed) {
+  const rows = [];
+  for (const [nodeId, record] of Object.entries(parsed.implementation || {})) {
+    if (!isPlainObject(record) || record.status !== STATUS_CANCELLED) continue;
+    const row = { node_id: nodeId };
+    if (record.reason !== undefined) row.reason = record.reason;
+    rows.push(row);
+  }
+  return rows.sort((left, right) => (left.node_id < right.node_id ? -1 : left.node_id > right.node_id ? 1 : 0));
+}
+
 function canonicalRecord(record) {
   const out = { status: record.status };
+  if (record.status === STATUS_CANCELLED) {
+    if (record.reason !== undefined) out.reason = record.reason;
+    return out;
+  }
   if (record.status === STATUS_IMPLEMENTED) {
     out.commit_message = record.commit_message;
     out.commit_date = record.commit_date;
@@ -140,6 +172,9 @@ const HEADER = `# Trusted implementation ledger (schema 2). Every DAG node is pr
 # commit_message, commit_date, and optionally pull_request) is the complete
 # implementation fact. Evidence fields are loose human locators; tooling never
 # resolves or validates them against Git, content, ancestry, or GitHub.
+# status = "cancelled" (with an optional reason) retires a node whose work
+# will never land under this identity: it is never READY, and descendants
+# treat it as settled; flipping it back to "pending" reopens it.
 # Serialization is canonical: nodes sorted by id, one line per node, so
 # independent transitions merge mechanically. [[github_issue]] rows map
 # node_id to gh_issue; sync_to_github is one-way-refresh policy only and never
@@ -195,6 +230,10 @@ export function transitionToImplemented(parsed, nodeId, { commitMessage, commitD
   };
   const problems = recordErrors(nodeId, replacement);
   if (problems.length) throw new Error(problems.join("; "));
+  if (record.status === STATUS_CANCELLED)
+    throw new Error(
+      `implementation ledger: ${nodeId} is cancelled; mark it pending before recording an implementation`,
+    );
   if (record.status === STATUS_IMPLEMENTED) {
     const same =
       record.commit_message === replacement.commit_message &&
@@ -235,6 +274,23 @@ export function markPending(parsed, nodeId) {
   if (!next.implementation?.[nodeId])
     throw new Error(`implementation ledger: unknown node ${nodeId}`);
   next.implementation[nodeId] = { status: STATUS_PENDING };
+  return next;
+}
+
+/**
+ * Retire a node: its work will never land under this identity. Idempotent;
+ * refuses an implemented node (flip it to pending first, deliberately).
+ */
+export function markCancelled(parsed, nodeId, { reason } = {}) {
+  const next = cloneParsed(parsed);
+  const record = next.implementation?.[nodeId];
+  if (!record) throw new Error(`implementation ledger: unknown node ${nodeId}`);
+  if (record.status === STATUS_IMPLEMENTED)
+    throw new Error(`implementation ledger: ${nodeId} is implemented; mark it pending before cancelling`);
+  const replacement = { status: STATUS_CANCELLED, ...(reason === undefined ? {} : { reason }) };
+  const problems = recordErrors(nodeId, replacement);
+  if (problems.length) throw new Error(problems.join("; "));
+  next.implementation[nodeId] = replacement;
   return next;
 }
 

--- a/roadmap/0.1.0-tama/tools/ledger.test.mjs
+++ b/roadmap/0.1.0-tama/tools/ledger.test.mjs
@@ -20,7 +20,7 @@ import {
   transitionToImplemented,
 } from "./ledger.mjs";
 import { parseToml } from "./toml.mjs";
-import { deriveState, loadAuthority, validateAuthority } from "./lib.mjs";
+import { deriveState, loadAuthority, validateAuthority, validateSchemaObject } from "./lib.mjs";
 
 const TOOLS_DIR = path.dirname(fileURLToPath(import.meta.url));
 
@@ -336,4 +336,15 @@ test("inline-table parser rejects duplicates and prototype-bearing keys", () => 
   assert.throws(() => parseToml('[implementation]\n"__proto__" = { status = "pending" }'), /unsafe/u);
   const nested = parseToml('a = { b = { c = 1 }, d = "x, y = }" }');
   assert.deepEqual(nested, { a: { b: { c: 1 }, d: "x, y = }" } });
+});
+
+test("the ledger schema keeps the per-status shapes mutually exclusive, like recordErrors", () => {
+  const schema = JSON.parse(fs.readFileSync(path.join(TOOLS_DIR, "..", "schemas", "implementation-ledger.schema.json"), "utf8"));
+  const check = (implementation) => validateSchemaObject({ schema: 2, implementation }, schema, "ledger");
+  assert.deepEqual(check({ A0: EVIDENCE, D4: { status: "pending" }, D5: { status: "cancelled", reason: "superseded" }, D6: { status: "cancelled" } }), []);
+  assert.ok(check({ A0: { ...EVIDENCE, reason: "why" } }).length, "implemented rows reject reason");
+  assert.ok(check({ D4: { status: "cancelled", commit_message: "sneaky" } }).length, "cancelled rows reject evidence");
+  assert.ok(check({ D4: { status: "pending", reason: "why" } }).length, "pending rows reject reason");
+  assert.ok(check({ D4: { status: "implemented" } }).length, "implemented rows require evidence");
+  assert.ok(check({ D4: { status: "CLAIMED" } }).length, "unknown statuses match no branch");
 });

--- a/roadmap/0.1.0-tama/tools/ledger.test.mjs
+++ b/roadmap/0.1.0-tama/tools/ledger.test.mjs
@@ -7,8 +7,10 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  cancelledRows,
   implementedRows,
   ledgerErrors,
+  markCancelled,
   mergeLedgerTexts,
   markPending,
   parseLedgerText,
@@ -69,8 +71,34 @@ test("pending rows carry no evidence; implemented rows require evidence", () => 
 
   const badStatus = doc({ D4: { status: "CLAIMED" } });
   assert.ok(
-    ledgerErrors(badStatus).some((error) => error.includes('status must be "pending" or "implemented"')),
+    ledgerErrors(badStatus).some((error) => error.includes('status must be "pending", "implemented" or "cancelled"')),
     "transient orchestration states are structurally invalid in the ledger",
+  );
+});
+
+test("cancelled rows carry only an optional reason and are neither implemented nor pending", () => {
+  const cancelled = doc({ A0: EVIDENCE, D4: { status: "cancelled", reason: "superseded by D5" }, D5: { status: "cancelled" } });
+  assert.deepEqual(ledgerErrors(cancelled), []);
+  assert.deepEqual(implementedRows(cancelled).map((row) => row.node_id), ["A0"]);
+  assert.deepEqual(cancelledRows(cancelled), [{ node_id: "D4", reason: "superseded by D5" }, { node_id: "D5" }]);
+
+  const withEvidence = doc({ D4: { status: "cancelled", commit_message: "sneaky" } });
+  assert.ok(ledgerErrors(withEvidence).some((error) => error.includes("cancelled rows carry no commit_message")));
+  const emptyReason = doc({ D4: { status: "cancelled", reason: "" } });
+  assert.ok(ledgerErrors(emptyReason).some((error) => error.includes("reason must be a non-empty string")));
+  const implementedWithReason = doc({ A0: { ...EVIDENCE, reason: "why" } });
+  assert.ok(ledgerErrors(implementedWithReason).some((error) => error.includes("implemented rows carry no reason")));
+
+  // The transition is a one-line diff like every other, round-trips through the canonical text, and is reversible.
+  const before = textOf({ A0: EVIDENCE, D4: { status: "pending" } });
+  const after = serializeLedger(markCancelled(parseLedgerText(before), "D4", { reason: "superseded by D5" }));
+  assert.match(after, /^"D4" = \{ status = "cancelled", reason = "superseded by D5" \}$/mu);
+  assert.equal(after.split("\n").filter((line) => !before.split("\n").includes(line)).length, 1);
+  assert.deepEqual(markPending(parseLedgerText(after), "D4").implementation.D4, { status: "pending" });
+  assert.throws(() => markCancelled(parseLedgerText(before), "A0"), /is implemented; mark it pending before cancelling/u);
+  assert.throws(
+    () => transitionToImplemented(parseLedgerText(after), "D4", { commitMessage: "m", commitDate: "2026-09-01T10:00:00+01:00" }),
+    /is cancelled; mark it pending before recording an implementation/u,
   );
 });
 
@@ -294,9 +322,10 @@ test("live authority loads the schema-2 ledger, derives state, and validates cle
 
 test("transient orchestration states never appear in the live ledger", () => {
   const authority = loadAuthority();
+  // pending, implemented and cancelled are durable ledger facts; anything else is runtime state.
   for (const [nodeId, record] of Object.entries(authority.ledger.implementation)) {
     assert.ok(
-      record.status === "pending" || record.status === "implemented",
+      ["pending", "implemented", "cancelled"].includes(record.status),
       `${nodeId} carries runtime state ${record.status}`,
     );
   }

--- a/roadmap/0.1.0-tama/tools/lib.mjs
+++ b/roadmap/0.1.0-tama/tools/lib.mjs
@@ -831,7 +831,11 @@ export function validateAuthority(authority, options = {}) {
   // validation error, not an exception (absent or null still means "none").
   if (authority.ledger.cancelled != null && !Array.isArray(authority.ledger.cancelled))
     errors.push("implementation ledger: cancelled rows must be an array");
-  for (const row of Array.isArray(authority.ledger.cancelled) ? authority.ledger.cancelled : []) {
+  for (const [index, row] of (Array.isArray(authority.ledger.cancelled) ? authority.ledger.cancelled : []).entries()) {
+    if (row === null || typeof row !== "object" || Array.isArray(row)) {
+      errors.push(`implementation ledger: cancelled row ${index} must be an object`);
+      continue;
+    }
     if (!knownNodes.has(row.node_id))
       errors.push(`implementation ledger: unknown node ${row.node_id}`);
     if (implemented.has(row.node_id) || cancelled.has(row.node_id))

--- a/roadmap/0.1.0-tama/tools/lib.mjs
+++ b/roadmap/0.1.0-tama/tools/lib.mjs
@@ -123,6 +123,12 @@ function schemaTypeMatches(value, type) {
 
 function schemaErrors(value, schema, location) {
   const errors = [];
+  if (Array.isArray(schema.oneOf)) {
+    // Mutually exclusive shapes (the ledger's per-status rows): exactly one branch may accept the value.
+    const matched = schema.oneOf.filter((branch) => schemaErrors(value, branch, location).length === 0).length;
+    if (matched !== 1)
+      errors.push(`${location}: must match exactly one of ${schema.oneOf.length} alternatives (matched ${matched})`);
+  }
   if (schema.const !== undefined && JSON.stringify(value) !== JSON.stringify(schema.const))
     errors.push(`${location}: expected constant ${JSON.stringify(schema.const)}`);
   if (Array.isArray(schema.enum) && !schema.enum.includes(value))
@@ -821,7 +827,11 @@ export function validateAuthority(authority, options = {}) {
       errors.push(`implementation ledger: invalid node id ${row.node_id}`);
   }
   const cancelled = new Set();
-  for (const row of authority.ledger.cancelled || []) {
+  // Programmatic mutations may hand in anything; a malformed container is a
+  // validation error, not an exception (absent or null still means "none").
+  if (authority.ledger.cancelled != null && !Array.isArray(authority.ledger.cancelled))
+    errors.push("implementation ledger: cancelled rows must be an array");
+  for (const row of Array.isArray(authority.ledger.cancelled) ? authority.ledger.cancelled : []) {
     if (!knownNodes.has(row.node_id))
       errors.push(`implementation ledger: unknown node ${row.node_id}`);
     if (implemented.has(row.node_id) || cancelled.has(row.node_id))

--- a/roadmap/0.1.0-tama/tools/lib.mjs
+++ b/roadmap/0.1.0-tama/tools/lib.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { parseToml, readToml } from "./toml.mjs";
-import { implementedRows, ledgerErrors, COMMIT_DATE_PATTERN, NODE_ID_PATTERN } from "./ledger.mjs";
+import { cancelledRows, implementedRows, ledgerErrors, COMMIT_DATE_PATTERN, NODE_ID_PATTERN } from "./ledger.mjs";
 
 export { parseToml, readToml };
 
@@ -280,6 +280,7 @@ export function loadAuthority(packageRoot = PACKAGE_ROOT) {
     schema: 2,
     implementation: raw.implementation,
     implemented: implementedRows(raw),
+    cancelled: cancelledRows(raw),
     github_issue: raw.github_issue || [],
     github_train_issue: raw.github_train_issue || [],
   };
@@ -638,12 +639,15 @@ export function productReport(authority, state) {
   const products = [...new Set(authority.nodes.map((node) => node.product))].sort();
   return products.map((product) => {
     const nodes = authority.nodes.filter((node) => node.product === product);
-    const pending = nodes.filter((node) => state.states.get(node.id).status !== "COMPLETE");
+    const statusOf = (node) => state.states.get(node.id).status;
+    // Cancelled nodes are settled, not pending: nothing is owed for them.
+    const pending = nodes.filter((node) => !["COMPLETE", "CANCELLED"].includes(statusOf(node)));
     return {
       product,
       total: nodes.length,
-      implemented: nodes.length - pending.length,
-      ready: pending.filter((node) => state.states.get(node.id).status === "READY").length,
+      implemented: nodes.filter((node) => statusOf(node) === "COMPLETE").length,
+      cancelled: nodes.filter((node) => statusOf(node) === "CANCELLED").length,
+      ready: pending.filter((node) => statusOf(node) === "READY").length,
       acceptance_gates: nodes
         .filter(
           (node) =>
@@ -816,6 +820,18 @@ export function validateAuthority(authority, options = {}) {
     if (!NODE_ID_PATTERN.test(row.node_id))
       errors.push(`implementation ledger: invalid node id ${row.node_id}`);
   }
+  const cancelled = new Set();
+  for (const row of authority.ledger.cancelled || []) {
+    if (!knownNodes.has(row.node_id))
+      errors.push(`implementation ledger: unknown node ${row.node_id}`);
+    if (implemented.has(row.node_id) || cancelled.has(row.node_id))
+      errors.push(`implementation ledger: duplicate node ${row.node_id}`);
+    cancelled.add(row.node_id);
+    if (row.reason !== undefined && (typeof row.reason !== "string" || row.reason.length === 0))
+      errors.push(`implementation ledger: ${row.node_id} reason must be a non-empty string`);
+    if (!NODE_ID_PATTERN.test(row.node_id))
+      errors.push(`implementation ledger: invalid node id ${row.node_id}`);
+  }
   const mappedNodes = new Set();
   const mappedIssues = new Set();
   // Identity is {node_id, gh_issue} unique both ways; sync_to_github is not a key.
@@ -879,6 +895,11 @@ export function deriveState(authority, options = {}) {
       },
     ]),
   );
+  // A cancelled node is settled without evidence: it is never offered as
+  // work and its descendants do not wait for it (the reason lives in the row).
+  const cancelled = new Map(
+    (options.cancelled || authority.ledger.cancelled || []).map((row) => [row.node_id, { reason: row.reason ?? null }]),
+  );
   const states = new Map();
   const byId = new Map(authority.nodes.map((node) => [node.id, node]));
   const ancestorCache = new Map();
@@ -896,20 +917,26 @@ export function deriveState(authority, options = {}) {
   for (const node of order) {
     const commit = commits.get(node.id) || null;
     const complete = Boolean(commit);
-    const missingAncestors = [...ancestorsOf(node.id)].filter((id) => !commits.has(id)).sort();
+    const ancestors = [...ancestorsOf(node.id)];
+    const missingAncestors = ancestors.filter((id) => !commits.has(id) && !cancelled.has(id)).sort();
+    const cancelledAncestors = ancestors.filter((id) => !commits.has(id) && cancelled.has(id)).sort();
     let status;
     if (complete) status = "COMPLETE";
+    else if (cancelled.has(node.id)) status = "CANCELLED";
     else if (node.dispatchable && missingAncestors.length === 0) status = "READY";
     else status = "BLOCKED";
     states.set(node.id, {
       status,
       commit,
+      cancellation: status === "CANCELLED" ? cancelled.get(node.id) : null,
       missing_ancestors: missingAncestors,
+      cancelled_ancestors: cancelledAncestors,
     });
   }
   return {
     states,
     commits,
+    cancelled,
     errors: [],
   };
 }
@@ -930,7 +957,9 @@ export function explainNode(authority, state, id) {
           locator: row.commit.locator,
         }
       : null,
+    cancellation: row.cancellation ?? null,
     missing_ancestors: row.missing_ancestors,
+    cancelled_ancestors: row.cancelled_ancestors ?? [],
     external_requirements: node.external_requirements,
     charter: node.charter,
   };
@@ -940,6 +969,10 @@ export function packetFor(authority, state, id) {
   const node = authority.nodes.find((candidate) => candidate.id === id);
   if (!node) throw new Error(`unknown node ${id}`);
   const row = state.states.get(id);
+  if (row.status === "CANCELLED")
+    throw new Error(
+      `cannot create work packet for CANCELLED node ${id}; ${row.cancellation?.reason || "the ledger retired it"}`,
+    );
   if (row.status === "BLOCKED") {
     const reason = row.missing_ancestors.length
       ? `missing ancestors: ${row.missing_ancestors.join(", ")}`
@@ -950,7 +983,7 @@ export function packetFor(authority, state, id) {
     confinedFile(authority.packageRoot, node.charter, `${id} charter`),
     "utf8",
   );
-  return `# Tama work packet: ${id}\n\nStatus: ${row.status}\nName: ${node.name}\nTrain: ${node.train}\nPredecessors: ${node.predecessors.join(", ") || "none"}\nMissing ancestors: ${row.missing_ancestors.join(", ") || "none"}\nExternal requirements (agent-checked): ${node.external_requirements.join(", ") || "none"}\n\n## Completion ledger\n\nBefore squashing or starting review, transition this node's predeclared line in \`authority/${authority.metadata.implemented_ledger}\` as part of the implementation patch. The node already has exactly one line under \`[implementation]\`; change only that line:\n\n    "${id}" = { status = "implemented", commit_message = "<planned squash commit message or useful search phrase>", commit_date = "<approximate squash date with timezone>" }\n\nAdd \`, pull_request = 1234\` inside the braces when the PR number is already known. Never append a second entry, never touch another node's line, and never edit \`[[github_issue]]\` rows for completion.\n\nThen squash once using the planned message and review that candidate. No after-commit ledger update or amend is required. The transitioned status is authoritative by presence. The commit fields are loose locator hints only. Tooling does not resolve or validate them, require an exact message/date match, compare content, inspect ancestry, or contact GitHub. If a message search returns several commits, use the date to choose the closest result; use the PR number when available.\n\n## Active sizing and train review policy\n\nProduction LOC and file budgets are planning references, not hard acceptance lines. Investigate material drift in either direction; if one expected production file becomes ten, require a scope-coherence explanation rather than mechanically rejecting or splitting the candidate.\n\nAfter every 3 to 6 implemented blocks in this train, the train manager spawns a fresh Codex Architect conformance review over the cumulative implementation before a seventh unchecked block proceeds. On the train's final intended block, also spawn a fresh train review covering every implemented block, the final candidate, and all current amendments. These train reviews are additional to the node's own review profile and create no new ledger or readiness state.\n\n## Charter\n\n${charter}`;
+  return `# Tama work packet: ${id}\n\nStatus: ${row.status}\nName: ${node.name}\nTrain: ${node.train}\nPredecessors: ${node.predecessors.join(", ") || "none"}\nMissing ancestors: ${row.missing_ancestors.join(", ") || "none"}\n${row.cancelled_ancestors?.length ? `Cancelled ancestors (settled without evidence): ${row.cancelled_ancestors.join(", ")}\n` : ""}External requirements (agent-checked): ${node.external_requirements.join(", ") || "none"}\n\n## Completion ledger\n\nBefore squashing or starting review, transition this node's predeclared line in \`authority/${authority.metadata.implemented_ledger}\` as part of the implementation patch. The node already has exactly one line under \`[implementation]\`; change only that line:\n\n    "${id}" = { status = "implemented", commit_message = "<planned squash commit message or useful search phrase>", commit_date = "<approximate squash date with timezone>" }\n\nAdd \`, pull_request = 1234\` inside the braces when the PR number is already known. Never append a second entry, never touch another node's line, and never edit \`[[github_issue]]\` rows for completion.\n\nThen squash once using the planned message and review that candidate. No after-commit ledger update or amend is required. The transitioned status is authoritative by presence. The commit fields are loose locator hints only. Tooling does not resolve or validate them, require an exact message/date match, compare content, inspect ancestry, or contact GitHub. If a message search returns several commits, use the date to choose the closest result; use the PR number when available.\n\n## Active sizing and train review policy\n\nProduction LOC and file budgets are planning references, not hard acceptance lines. Investigate material drift in either direction; if one expected production file becomes ten, require a scope-coherence explanation rather than mechanically rejecting or splitting the candidate.\n\nAfter every 3 to 6 implemented blocks in this train, the train manager spawns a fresh Codex Architect conformance review over the cumulative implementation before a seventh unchecked block proceeds. On the train's final intended block, also spawn a fresh train review covering every implemented block, the final candidate, and all current amendments. These train reviews are additional to the node's own review profile and create no new ledger or readiness state.\n\n## Charter\n\n${charter}`;
 }
 
 export function exactRegularFileInventory(root, label = "inventory") {

--- a/roadmap/0.1.0-tama/tools/programctl.mjs
+++ b/roadmap/0.1.0-tama/tools/programctl.mjs
@@ -52,6 +52,8 @@ try {
       }))
       .sort((left, right) => left.node_id.localeCompare(right.node_id));
     console.log(JSON.stringify(rows, null, 2));
+  } else if (command === "cancelled") {
+    console.log(JSON.stringify(authority.ledger.cancelled, null, 2));
   } else if (command === "github-issues") {
     console.log(JSON.stringify(listGitHubIssues(authority.ledger), null, 2));
   } else if (command === "github-issue") {
@@ -61,7 +63,7 @@ try {
     console.log(JSON.stringify(githubIssueByNumber(authority.ledger, issue), null, 2));
   } else {
     throw new Error(
-      `unknown command ${command}; supported commands: frontier, explain, packet, products, implemented, github-issues, github-issue`,
+      `unknown command ${command}; supported commands: frontier, explain, packet, products, implemented, cancelled, github-issues, github-issue`,
     );
   }
 } catch (error) {


### PR DESCRIPTION
Two nodes (`BCSS0`, `A2C`) carry `SUPERSEDED` charters: they are v2 identity wrappers whose work already landed elsewhere, yet the ledger only knew `pending` and `implemented`, so they sat `BLOCKED` forever with a "not dispatchable" explanation and counted as pending work.

This adds a third durable ledger status, `cancelled`, and retires both nodes with it.

### Ledger

- `status = "cancelled"` with an optional `reason` (free text for the reader). Like the other rows it is one canonical line, merges mechanically, and `markCancelled` / `markPending` flip it. An implemented node must be flipped to pending before it can be cancelled; a cancelled node must be reopened before an implementation can be recorded.
- `implemented.toml` header and the ledger JSON schema describe the new status.

### Derivation and reporting

- `deriveState` reports `CANCELLED`; the node is never `READY` and `packetFor` refuses it.
- Descendants treat a cancelled ancestor as settled without evidence: `missing_ancestors` excludes it and the row lists it under `cancelled_ancestors` (also in `explain` and, when present, in the work packet).
- `productReport` counts `cancelled` separately; `implemented` counts only `COMPLETE`, and pending work excludes retired nodes.
- `programctl cancelled` lists the retired rows; `validateAuthority` rejects unknown, duplicate, or implemented-and-cancelled nodes and empty reasons.

### Rows

- `BCSS0` and `A2C` → `cancelled` with their superseding reason. Neither has successors, so no readiness changes elsewhere.

### Verification

- `validate-program-dag.mjs --strict` passes (426 nodes).
- `ledger.test.mjs` (15) and `implementation-ledger.test.mjs` (31) pass, including new cases for the row rules, the derivation, packet refusal, and the live ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016q4mNeHJ6m35VXwWYW1jkJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retiring work items with a `cancelled` status and optional reason.
  * Cancelled items are never ready, are treated as settled, do not block descendants, and cannot generate work packets.
  * Added a command to view cancelled entries as JSON.
  * Cancelled items can be reopened by returning them to pending.
  * Reports and item details now distinguish cancelled work.

* **Documentation**
  * Updated roadmap and implementation guidance with cancellation behavior and prerequisites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->