### PR TITLE
perf(lsp): reuse one source index per provider response batch

### DIFF
--- a/.claude/skills/position-encoding/SKILL.md
+++ b/.claude/skills/position-encoding/SKILL.md
@@ -105,8 +105,9 @@ Spans computed as `content_offset + local_offset` during CSS scanning, where `co
 index in `documents/mod.rs`) and a borrowing `SourceIndex<'a>` (owns only the line-start table). Both
 delegate to the same private conversion core, so they cannot disagree about an encoding, a bound
 check, or a clamp. A caller converting more than one position against one immutable source — a
-diagnostic pull, a rename/code-fix batch, a span's two endpoints — builds ONE `SourceIndex` and
-converts every endpoint through it; the per-call convenience functions rescan the source each time.
+diagnostic pull, a semantic-token stream, an inlay-hint or highlight batch, a rename/code-fix
+batch, a span's two endpoints — builds ONE `SourceIndex` and converts every endpoint through it;
+the per-call convenience functions rescan the source each time.
 
 Each index offers both conventions explicitly: `clamped_position_to_offset` fails OPEN (out-of-range
 clamps to EOF — the navigation-sentinel default) and `checked_position_to_offset` fails CLOSED

--- a/.claude/skills/position-encoding/SKILL.md
+++ b/.claude/skills/position-encoding/SKILL.md
@@ -107,7 +107,10 @@ delegate to the same private conversion core, so they cannot disagree about an e
 check, or a clamp. A caller converting more than one position against one immutable source — a
 diagnostic pull, a semantic-token stream, an inlay-hint or highlight batch, a rename/code-fix
 batch, a span's two endpoints — builds ONE `SourceIndex` and converts every endpoint through it;
-the per-call convenience functions rescan the source each time.
+the per-call convenience functions rescan the source each time. A response whose endpoints span
+several target files (definition/references locations, rename and code-action edits) resolves each
+distinct target's content (snapshot, then disk) and indexes it once, through
+`contents_snapshot::{with_target_index, convert_per_target}`; results keep the response order.
 
 Each index offers both conventions explicitly: `clamped_position_to_offset` fails OPEN (out-of-range
 clamps to EOF — the navigation-sentinel default) and `checked_position_to_offset` fails CLOSED
@@ -124,8 +127,9 @@ corrupts a file or forges a bogus "see declaration" link at EOF.
 | LSP Position → byte offset | `LineIndex::position_to_offset()` | `crates/verter_lsp/src/documents/line_index.rs` |
 | Byte offset → LSP Position | `LineIndex::offset_to_position()` | `crates/verter_lsp/src/documents/line_index.rs` |
 | Provider response batch → byte offsets | One `SourceIndex` per source snapshot, reused for every endpoint | `crates/verter_type_runtime/src/codec.rs` |
-| TSGO response → byte offset | `position_to_offset_with_encoding()` | `crates/verter_type_runtime/src/tsgo/ipc.rs` |
-| tsserver response → byte offset | `tsserver_pos_to_byte_offset()` (1-based wire positions) | `crates/verter_type_runtime/src/tsserver/ipc.rs` |
+| Multi-file provider response → byte offsets | One content resolution + index per distinct target | `crates/verter_type_runtime/src/contents_snapshot.rs` |
+| TSGO response range → byte offsets | `parse_range_to_offsets()` (navigation, clamped) / `parse_range_to_offsets_strict()` (edits, checked) over the batch index | `crates/verter_type_runtime/src/tsgo/ipc.rs` |
+| tsserver response → byte offset | `tsserver_pos_to_byte_offset_indexed()` (clamped) / `tsserver_pos_to_byte_offset_checked()` (edits) over the batch index; 1-based wire positions | `crates/verter_type_runtime/src/tsserver/ipc.rs` |
 
 ## VS Code Extension
 

--- a/.claude/skills/position-encoding/SKILL.md
+++ b/.claude/skills/position-encoding/SKILL.md
@@ -100,6 +100,20 @@ Spans computed as `content_offset + local_offset` during CSS scanning, where `co
 **Standard LSP positions** (`line:character`): handled by `LineIndex` in `documents/line_index.rs`.
 **Custom protocol data** (analysis spans): converted at LSP boundary before serialization.
 
+**Two index shapes, one conversion implementation.** `verter_type_runtime::codec` exposes an owning
+`LineIndex` (copies the source; for an index stored beyond the buffer's life, e.g. the per-document
+index in `documents/mod.rs`) and a borrowing `SourceIndex<'a>` (owns only the line-start table). Both
+delegate to the same private conversion core, so they cannot disagree about an encoding, a bound
+check, or a clamp. A caller converting more than one position against one immutable source — a
+diagnostic pull, a rename/code-fix batch, a span's two endpoints — builds ONE `SourceIndex` and
+converts every endpoint through it; the per-call convenience functions rescan the source each time.
+
+Each index offers both conventions explicitly: `clamped_position_to_offset` fails OPEN (out-of-range
+clamps to EOF — the navigation-sentinel default) and `checked_position_to_offset` fails CLOSED
+(rejects a past-EOF line, a column past the line's end, and a column inside a surrogate pair).
+Edit-applying and secondary-link paths must use the checked converter; a clamped wrong offset
+corrupts a file or forges a bogus "see declaration" link at EOF.
+
 ## Encoding Conversion Reference
 
 | Boundary | Pattern | Reference Implementation |
@@ -108,7 +122,9 @@ Spans computed as `content_offset + local_offset` during CSS scanning, where `co
 | Rust internal → LSP client | Negotiated encoding conversion | `crates/verter_lsp/src/documents/mod.rs` |
 | LSP Position → byte offset | `LineIndex::position_to_offset()` | `crates/verter_lsp/src/documents/line_index.rs` |
 | Byte offset → LSP Position | `LineIndex::offset_to_position()` | `crates/verter_lsp/src/documents/line_index.rs` |
-| TSGO response → byte offset | `position_to_offset()` | `crates/verter_lsp/src/tsgo/ipc.rs` (ASCII TSX only) |
+| Provider response batch → byte offsets | One `SourceIndex` per source snapshot, reused for every endpoint | `crates/verter_type_runtime/src/codec.rs` |
+| TSGO response → byte offset | `position_to_offset_with_encoding()` | `crates/verter_type_runtime/src/tsgo/ipc.rs` |
+| tsserver response → byte offset | `tsserver_pos_to_byte_offset()` (1-based wire positions) | `crates/verter_type_runtime/src/tsserver/ipc.rs` |
 
 ## VS Code Extension
 

--- a/crates/verter_lsp/src/extension_provider.rs
+++ b/crates/verter_lsp/src/extension_provider.rs
@@ -22,8 +22,8 @@ use crate::tsserver::ipc::{
     completion_entry_details_to_resolve_result, concat_display_parts, dedup_error_codes,
     enrich_completion_with_entry_details, format_quickinfo_hover, merge_diagnostic_sets,
     parse_tsserver_code_action, parse_tsserver_combined_code_fix, parse_tsserver_completion,
-    parse_tsserver_diagnostic, parse_tsserver_inlay_hint, parse_tsserver_location,
-    parse_tsserver_rename_span, quickinfo_wire_pos_to_byte_offset,
+    parse_tsserver_diagnostic, parse_tsserver_inlay_hint, parse_tsserver_locations,
+    parse_tsserver_rename_spans, quickinfo_wire_pos_to_byte_offset,
     stamp_tsserver_completion_offset,
 };
 use crate::type_provider::protocol::*;
@@ -439,10 +439,13 @@ impl<T: TsQueryTransport> TypeProvider for ExtensionTypeProvider<T> {
                     let (range_start, range_end) = {
                         let cache = contents_cache.lock().await;
                         match cache.get(&file) {
-                            Some(content) => (
-                                quickinfo_wire_pos_to_byte_offset(content, body.get("start")),
-                                quickinfo_wire_pos_to_byte_offset(content, body.get("end")),
-                            ),
+                            Some(content) => {
+                                let index = SourceIndex::new_utf16(content);
+                                (
+                                    quickinfo_wire_pos_to_byte_offset(&index, body.get("start")),
+                                    quickinfo_wire_pos_to_byte_offset(&index, body.get("end")),
+                                )
+                            }
                             None => (None, None),
                         }
                     };
@@ -563,7 +566,7 @@ impl<T: TsQueryTransport> TypeProvider for ExtensionTypeProvider<T> {
                 )
                 .await?;
 
-            // Snapshot then release before parsing: `parse_tsserver_location` can fall back to a
+            // Snapshot then release before parsing: `parse_tsserver_locations` can fall back to a
             // blocking disk read on a cache miss for a cross-file target. The snapshot is a cheap
             // pointer-map clone (`Arc<str>` values).
             let cache_snapshot = {
@@ -572,11 +575,7 @@ impl<T: TsQueryTransport> TypeProvider for ExtensionTypeProvider<T> {
             };
             let locs = result
                 .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|loc| parse_tsserver_location(loc, &cache_snapshot))
-                        .collect()
-                })
+                .map(|arr| parse_tsserver_locations(arr, &cache_snapshot))
                 .unwrap_or_default();
 
             Ok(locs)
@@ -610,7 +609,7 @@ impl<T: TsQueryTransport> TypeProvider for ExtensionTypeProvider<T> {
                 )
                 .await?;
 
-            // Snapshot then release before parsing: `parse_tsserver_location` can fall back to a
+            // Snapshot then release before parsing: `parse_tsserver_locations` can fall back to a
             // blocking disk read on a cache miss for a cross-file target. The snapshot is a cheap
             // pointer-map clone (`Arc<str>` values).
             let cache_snapshot = {
@@ -619,11 +618,7 @@ impl<T: TsQueryTransport> TypeProvider for ExtensionTypeProvider<T> {
             };
             let locs = result
                 .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|loc| parse_tsserver_location(loc, &cache_snapshot))
-                        .collect()
-                })
+                .map(|arr| parse_tsserver_locations(arr, &cache_snapshot))
                 .unwrap_or_default();
 
             Ok(locs)
@@ -653,7 +648,7 @@ impl<T: TsQueryTransport> TypeProvider for ExtensionTypeProvider<T> {
                 )
                 .await?;
 
-            // Snapshot then release before parsing: `parse_tsserver_location` can fall back to a
+            // Snapshot then release before parsing: `parse_tsserver_locations` can fall back to a
             // blocking disk read on a cache miss for a cross-file target. The snapshot is a cheap
             // pointer-map clone (`Arc<str>` values).
             let cache_snapshot = {
@@ -663,11 +658,7 @@ impl<T: TsQueryTransport> TypeProvider for ExtensionTypeProvider<T> {
             let locs = result
                 .get("refs")
                 .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|loc| parse_tsserver_location(loc, &cache_snapshot))
-                        .collect()
-                })
+                .map(|arr| parse_tsserver_locations(arr, &cache_snapshot))
                 .unwrap_or_default();
 
             Ok(locs)
@@ -704,7 +695,7 @@ impl<T: TsQueryTransport> TypeProvider for ExtensionTypeProvider<T> {
                 .await?;
 
             // Snapshot ONLY this response's target files and release the lock BEFORE parsing: a
-            // rename span resolves its target through `parse_tsserver_rename_span`, which can fall
+            // rename group resolves its target through `parse_tsserver_rename_spans`, which can fall
             // back to a blocking disk read on a cache miss. Holding the async mutex across that read
             // would block every other task contending for the cache. Scanning the response bounds
             // the snapshot to the files it touches.
@@ -734,16 +725,11 @@ impl<T: TsQueryTransport> TypeProvider for ExtensionTypeProvider<T> {
                                         .and_then(|v| v.as_str())
                                         .unwrap_or_default(),
                                 );
-                                group
+                                let spans = group
                                     .get("locs")
                                     .and_then(|v| v.as_array())
-                                    .into_iter()
-                                    .flat_map(move |spans| {
-                                        let fp = file_path.clone();
-                                        spans.iter().filter_map(move |span| {
-                                            parse_tsserver_rename_span(span, &fp, cache)
-                                        })
-                                    })
+                                    .map_or(&[][..], Vec::as_slice);
+                                parse_tsserver_rename_spans(spans, &file_path, cache)
                             })
                             .collect()
                     })

--- a/crates/verter_lsp/src/extension_provider.rs
+++ b/crates/verter_lsp/src/extension_provider.rs
@@ -1202,15 +1202,15 @@ impl<T: TsQueryTransport> TypeProvider for ExtensionTypeProvider<T> {
                 )
                 .await;
 
+            // One index for the whole hint batch.
+            let index = content_snapshot.as_deref().map(SourceIndex::new_utf16);
             match result {
                 Ok(body) => {
                     let hints = body
                         .as_array()
                         .map(|arr| {
                             arr.iter()
-                                .filter_map(|hint| {
-                                    parse_tsserver_inlay_hint(hint, content_snapshot.as_deref())
-                                })
+                                .filter_map(|hint| parse_tsserver_inlay_hint(hint, index.as_ref()))
                                 .collect()
                         })
                         .unwrap_or_default();

--- a/crates/verter_lsp/src/extension_provider.rs
+++ b/crates/verter_lsp/src/extension_provider.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 
 use tokio::sync::{Mutex, OnceCell};
 
+use verter_type_runtime::codec::SourceIndex;
+
 use crate::server::TsQueryParams;
 use crate::tsserver::ipc::{
     assemble_signature_label, build_completion_entry_details_request, build_entry_names_entry,
@@ -483,16 +485,16 @@ impl<T: TsQueryTransport> TypeProvider for ExtensionTypeProvider<T> {
             // failures degrade that category to empty rather than failing the
             // whole pull. The union/dedup is the shared `merge_diagnostic_sets`
             // owner (one merge point, not a per-provider fork).
+            // One index for all three passes: they resolve against the same
+            // content snapshot, so the document is scanned once for the whole
+            // pull rather than twice per diagnostic per pass.
+            let index = content.as_deref().map(SourceIndex::new_utf16);
             let parse_body = |body: serde_json::Value| -> Vec<TypeDiagnostic> {
                 body.as_array()
                     .map(|arr| {
                         arr.iter()
                             .filter_map(|d| {
-                                parse_tsserver_diagnostic(
-                                    d,
-                                    content.as_deref(),
-                                    Some(file.as_str()),
-                                )
+                                parse_tsserver_diagnostic(d, index.as_ref(), Some(file.as_str()))
                             })
                             .collect()
                     })

--- a/crates/verter_lsp/src/tsserver/ipc.rs
+++ b/crates/verter_lsp/src/tsserver/ipc.rs
@@ -9,8 +9,8 @@ pub use verter_type_runtime::tsserver::{
     completion_entry_details_to_resolve_result, concat_display_parts, dedup_error_codes,
     enrich_completion_with_entry_details, format_quickinfo_hover, merge_diagnostic_sets,
     parse_tsserver_code_action, parse_tsserver_combined_code_fix, parse_tsserver_completion,
-    parse_tsserver_diagnostic, parse_tsserver_inlay_hint, parse_tsserver_location,
-    parse_tsserver_rename_span, quickinfo_wire_pos_to_byte_offset,
+    parse_tsserver_diagnostic, parse_tsserver_inlay_hint, parse_tsserver_locations,
+    parse_tsserver_rename_spans, quickinfo_wire_pos_to_byte_offset,
     stamp_tsserver_completion_offset, tsserver_pos_to_byte_offset, AssembledSignatureLabel,
     TsserverTypeProvider, CHILD_PROCESS_ENV_DENYLIST,
 };

--- a/crates/verter_lsp/tests/cases/repro_external_defn_line.rs
+++ b/crates/verter_lsp/tests/cases/repro_external_defn_line.rs
@@ -8,7 +8,7 @@
 //! (and its wrapper `merge_definitions`) substituted `Range::default()` (line 0, char 0) for
 //! every non-`.vue` target instead of resolving the type provider's byte offsets to line:col.
 //! The type provider returns a `TypeLocation { path, start, end }` whose `start`/`end` are REAL
-//! byte offsets into the external file (`parse_lsp_location` in
+//! byte offsets into the external file (`parse_lsp_locations_per_target` in
 //! `verter_type_runtime/src/tsgo/ipc.rs` disk-reads the target to compute them); the merge
 //! layer threw those offsets away for any non-`.vue` file and collapsed the range to line 0.
 //!

--- a/crates/verter_type_runtime/src/codec.rs
+++ b/crates/verter_type_runtime/src/codec.rs
@@ -29,47 +29,35 @@ pub struct LineColumn {
 }
 
 // ---------------------------------------------------------------------------
-// LineIndex
+// Shared conversion core
 // ---------------------------------------------------------------------------
 
-/// Precomputed line start offsets for fast byte-offset ↔ line/column conversion.
+/// Borrowed line-start table plus source — the single implementation of every
+/// offset ↔ position conversion in this module.
 ///
-/// Supports UTF-8, UTF-16 (default), and UTF-32 position encodings.
-/// Build once per document version, then use for all position conversions.
-#[derive(Debug, Clone)]
-pub struct LineIndex {
-    /// Byte offset of the start of each line. `line_starts[0]` is always 0.
-    line_starts: Vec<u32>,
-    /// The full source text (needed for column calculation).
-    source: Vec<u8>,
-    /// Position encoding.
+/// Both index types below hold exactly these three pieces and delegate here, so
+/// the owning and the borrowing index can never disagree about an encoding,
+/// a bound check, or a clamp.
+#[derive(Debug, Clone, Copy)]
+struct IndexRef<'a> {
+    line_starts: &'a [u32],
+    source: &'a str,
     encoding: PositionEncoding,
 }
 
-impl LineIndex {
-    /// Build a `LineIndex` from the full source text, using the specified encoding.
-    pub fn new(source: &str, encoding: PositionEncoding) -> Self {
-        let bytes = source.as_bytes();
-        let mut line_starts = vec![0u32];
-        for (i, &b) in bytes.iter().enumerate() {
-            if b == b'\n' {
-                line_starts.push((i + 1) as u32);
-            }
-        }
-        Self {
-            line_starts,
-            source: bytes.to_vec(),
-            encoding,
+/// Scan `source` once for its line-start byte offsets. Index 0 is always present.
+fn scan_line_starts(source: &str) -> Vec<u32> {
+    let mut line_starts = vec![0u32];
+    for (i, &b) in source.as_bytes().iter().enumerate() {
+        if b == b'\n' {
+            line_starts.push((i + 1) as u32);
         }
     }
+    line_starts
+}
 
-    /// Build a `LineIndex` with the default UTF-16 encoding.
-    pub fn new_utf16(source: &str) -> Self {
-        Self::new(source, PositionEncoding::Utf16)
-    }
-
-    /// Convert a byte offset to a line/column position (0-indexed, encoding-dependent column).
-    pub fn offset_to_position(&self, offset: u32) -> Option<LineColumn> {
+impl IndexRef<'_> {
+    fn offset_to_position(&self, offset: u32) -> Option<LineColumn> {
         let offset = offset as usize;
         if offset > self.source.len() {
             return None;
@@ -81,21 +69,26 @@ impl LineIndex {
         };
 
         let line_start = self.line_starts[line] as usize;
-        let col_bytes = &self.source[line_start..offset];
-        let character = match self.encoding {
-            PositionEncoding::Utf8 => col_bytes.len() as u32,
-            PositionEncoding::Utf32 => utf8_byte_len_to_utf32_len(col_bytes) as u32,
-            PositionEncoding::Utf16 => utf8_byte_len_to_utf16_len(col_bytes) as u32,
-        };
-
+        // Byte slicing (not `str` slicing) is deliberate: a caller may hand us an
+        // offset that falls inside a multi-byte character, and the width helpers
+        // fall back to the byte length for a non-UTF-8 slice rather than panicking.
+        let col_bytes = &self.source.as_bytes()[line_start..offset];
         Some(LineColumn {
             line: line as u32,
-            character,
+            character: self.column_width(col_bytes),
         })
     }
 
-    /// Convert a line/column position (0-indexed, encoding-dependent column) to a byte offset.
-    pub fn position_to_offset(&self, pos: LineColumn) -> Option<u32> {
+    /// Width of `bytes` in this index's position-encoding units.
+    fn column_width(&self, bytes: &[u8]) -> u32 {
+        match self.encoding {
+            PositionEncoding::Utf8 => bytes.len() as u32,
+            PositionEncoding::Utf32 => utf8_byte_len_to_utf32_len(bytes) as u32,
+            PositionEncoding::Utf16 => utf8_byte_len_to_utf16_len(bytes) as u32,
+        }
+    }
+
+    fn position_to_offset(&self, pos: LineColumn) -> Option<u32> {
         let line = pos.line as usize;
         if line >= self.line_starts.len() {
             return None;
@@ -108,7 +101,7 @@ impl LineIndex {
             self.source.len()
         };
 
-        let line_bytes = &self.source[line_start..line_end];
+        let line_bytes = &self.source.as_bytes()[line_start..line_end];
         let byte_col = match self.encoding {
             PositionEncoding::Utf8 => (pos.character as usize).min(line_bytes.len()),
             PositionEncoding::Utf32 => utf32_col_to_byte_col(line_bytes, pos.character as usize),
@@ -122,6 +115,130 @@ impl LineIndex {
         Some(offset as u32)
     }
 
+    fn line_start(&self, line: usize) -> Option<u32> {
+        self.line_starts.get(line).copied()
+    }
+
+    fn line_end(&self, line: usize) -> Option<u32> {
+        let _start = self.line_start(line)?;
+        let bytes = self.source.as_bytes();
+        let end = if line + 1 < self.line_starts.len() {
+            let next_start = self.line_starts[line + 1] as usize;
+            if next_start > 0 && bytes.get(next_start - 1) == Some(&b'\n') {
+                if next_start > 1 && bytes.get(next_start - 2) == Some(&b'\r') {
+                    next_start - 2
+                } else {
+                    next_start - 1
+                }
+            } else {
+                next_start
+            }
+        } else {
+            bytes.len()
+        };
+        Some(end as u32)
+    }
+
+    fn line_length(&self, line: usize) -> Option<u32> {
+        let start = self.line_start(line)? as usize;
+        let end = self.line_end(line)? as usize;
+        Some(self.column_width(&self.source.as_bytes()[start..end]))
+    }
+
+    fn checked_position_to_offset(&self, pos: LineColumn) -> Option<u32> {
+        if pos.line as usize >= self.line_starts.len() {
+            return None; // past-EOF line
+        }
+        if pos.character > self.line_length(pos.line as usize)? {
+            return None; // column past the line end
+        }
+        let offset = self.position_to_offset(pos)?;
+        // A column landing between the two halves of an astral (surrogate-pair)
+        // character is not a scalar boundary; `position_to_offset` rounds it to an
+        // adjacent character, yielding an offset that does NOT map back to the
+        // requested column. Require the round-trip to be exact.
+        if self.offset_to_position(offset)? != pos {
+            return None;
+        }
+        Some(offset)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SourceIndex — reusable, borrowing index
+// ---------------------------------------------------------------------------
+
+/// Line index over a BORROWED immutable source snapshot.
+///
+/// Owns only the line-start table (4 bytes per line) and borrows the source
+/// text, so building one never copies the document. Build it ONCE per immutable
+/// source snapshot or response batch and convert every endpoint through it: a
+/// per-conversion index rebuild makes a D-diagnostic batch scan the same source
+/// 2D times.
+#[derive(Debug, Clone)]
+pub struct SourceIndex<'a> {
+    line_starts: Vec<u32>,
+    source: &'a str,
+    encoding: PositionEncoding,
+}
+
+impl<'a> SourceIndex<'a> {
+    /// Scan `source` once and retain a reusable index over it.
+    pub fn new(source: &'a str, encoding: PositionEncoding) -> Self {
+        Self {
+            line_starts: scan_line_starts(source),
+            source,
+            encoding,
+        }
+    }
+
+    /// Reusable index with the default UTF-16 encoding (LSP / tsserver default).
+    pub fn new_utf16(source: &'a str) -> Self {
+        Self::new(source, PositionEncoding::Utf16)
+    }
+
+    fn as_index_ref(&self) -> IndexRef<'_> {
+        IndexRef {
+            line_starts: &self.line_starts,
+            source: self.source,
+            encoding: self.encoding,
+        }
+    }
+
+    /// The borrowed source this index was built over.
+    pub fn source(&self) -> &'a str {
+        self.source
+    }
+
+    /// Convert a byte offset to a line/column position (0-indexed, encoding-dependent column).
+    pub fn offset_to_position(&self, offset: u32) -> Option<LineColumn> {
+        self.as_index_ref().offset_to_position(offset)
+    }
+
+    /// Convert a line/column position (0-indexed, encoding-dependent column) to a byte offset.
+    pub fn position_to_offset(&self, pos: LineColumn) -> Option<u32> {
+        self.as_index_ref().position_to_offset(pos)
+    }
+
+    /// Convert a line/column to a byte offset, clamping an out-of-range position to EOF.
+    ///
+    /// Fails OPEN — the navigation-sentinel convention. An EDIT or a secondary
+    /// link must use [`Self::checked_position_to_offset`] instead.
+    pub fn clamped_position_to_offset(&self, pos: LineColumn) -> u32 {
+        self.position_to_offset(pos)
+            .unwrap_or(self.source.len() as u32)
+    }
+
+    /// Convert a line/column to a byte offset, returning `None` when the position is OUT OF RANGE
+    /// instead of clamping it to EOF.
+    ///
+    /// Fails CLOSED: a past-EOF line, a column past the line's end, or a column landing inside a
+    /// surrogate pair is rejected. Edit and secondary-link paths use this, because a clamped wrong
+    /// offset corrupts a file or forges a bogus "see declaration" link at EOF.
+    pub fn checked_position_to_offset(&self, pos: LineColumn) -> Option<u32> {
+        self.as_index_ref().checked_position_to_offset(pos)
+    }
+
     /// Return the number of lines in the source.
     pub fn line_count(&self) -> usize {
         self.line_starts.len()
@@ -129,7 +246,93 @@ impl LineIndex {
 
     /// Return the byte offset of the start of a line.
     pub fn line_start(&self, line: usize) -> Option<u32> {
-        self.line_starts.get(line).copied()
+        self.as_index_ref().line_start(line)
+    }
+
+    /// Return the byte offset of the end of a line (before the newline, or EOF).
+    pub fn line_end(&self, line: usize) -> Option<u32> {
+        self.as_index_ref().line_end(line)
+    }
+
+    /// Width of a line in this index's position-encoding units, excluding the line terminator.
+    pub fn line_length(&self, line: usize) -> Option<u32> {
+        self.as_index_ref().line_length(line)
+    }
+
+    /// Return the total byte length of the source text.
+    pub fn source_len(&self) -> u32 {
+        self.source.len() as u32
+    }
+
+    /// The position encoding this index was built with.
+    pub fn encoding(&self) -> PositionEncoding {
+        self.encoding
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LineIndex — owning index
+// ---------------------------------------------------------------------------
+
+/// Precomputed line start offsets for fast byte-offset ↔ line/column conversion.
+///
+/// Supports UTF-8, UTF-16 (default), and UTF-32 position encodings.
+/// Build once per document version, then use for all position conversions.
+///
+/// This index OWNS a copy of the source, for a caller that outlives the buffer it
+/// was built from (a stored per-document index). A caller converting positions
+/// against a live buffer should use [`SourceIndex`], which borrows instead.
+#[derive(Debug, Clone)]
+pub struct LineIndex {
+    /// Byte offset of the start of each line. `line_starts[0]` is always 0.
+    line_starts: Vec<u32>,
+    /// The full source text (needed for column calculation).
+    source: String,
+    /// Position encoding.
+    encoding: PositionEncoding,
+}
+
+impl LineIndex {
+    /// Build a `LineIndex` from the full source text, using the specified encoding.
+    pub fn new(source: &str, encoding: PositionEncoding) -> Self {
+        Self {
+            line_starts: scan_line_starts(source),
+            source: source.to_owned(),
+            encoding,
+        }
+    }
+
+    /// Build a `LineIndex` with the default UTF-16 encoding.
+    pub fn new_utf16(source: &str) -> Self {
+        Self::new(source, PositionEncoding::Utf16)
+    }
+
+    fn as_index_ref(&self) -> IndexRef<'_> {
+        IndexRef {
+            line_starts: &self.line_starts,
+            source: &self.source,
+            encoding: self.encoding,
+        }
+    }
+
+    /// Convert a byte offset to a line/column position (0-indexed, encoding-dependent column).
+    pub fn offset_to_position(&self, offset: u32) -> Option<LineColumn> {
+        self.as_index_ref().offset_to_position(offset)
+    }
+
+    /// Convert a line/column position (0-indexed, encoding-dependent column) to a byte offset.
+    pub fn position_to_offset(&self, pos: LineColumn) -> Option<u32> {
+        self.as_index_ref().position_to_offset(pos)
+    }
+
+    /// Return the number of lines in the source.
+    pub fn line_count(&self) -> usize {
+        self.line_starts.len()
+    }
+
+    /// Return the byte offset of the start of a line.
+    pub fn line_start(&self, line: usize) -> Option<u32> {
+        self.as_index_ref().line_start(line)
     }
 
     /// Return the total byte length of the source text.
@@ -144,22 +347,7 @@ impl LineIndex {
 
     /// Return the byte offset of the end of a line (before the newline, or EOF).
     pub fn line_end(&self, line: usize) -> Option<u32> {
-        let _start = self.line_start(line)?;
-        let end = if line + 1 < self.line_starts.len() {
-            let next_start = self.line_starts[line + 1] as usize;
-            if next_start > 0 && self.source.get(next_start - 1) == Some(&b'\n') {
-                if next_start > 1 && self.source.get(next_start - 2) == Some(&b'\r') {
-                    next_start - 2
-                } else {
-                    next_start - 1
-                }
-            } else {
-                next_start
-            }
-        } else {
-            self.source.len()
-        };
-        Some(end as u32)
+        self.as_index_ref().line_end(line)
     }
 }
 
@@ -169,10 +357,11 @@ impl LineIndex {
 
 /// Convert a byte offset to a line/column using the given encoding.
 ///
-/// Creates a `LineIndex` on each call (cheap — no allocation beyond Vec).
+/// Scans `content` on each call. A caller converting more than one position
+/// against the same source should build a [`SourceIndex`] once instead.
 /// Falls back to end-of-file position if offset is out of bounds.
 pub fn offset_to_line_column(content: &str, offset: u32, encoding: PositionEncoding) -> LineColumn {
-    let idx = LineIndex::new(content, encoding);
+    let idx = SourceIndex::new(content, encoding);
     idx.offset_to_position(offset).unwrap_or_else(|| {
         // Fallback: position at end of file
         let last_line = idx.line_count().saturating_sub(1);
@@ -185,7 +374,8 @@ pub fn offset_to_line_column(content: &str, offset: u32, encoding: PositionEncod
 
 /// Convert a line/column to a byte offset using the given encoding.
 ///
-/// Creates a `LineIndex` on each call (cheap — no allocation beyond Vec).
+/// Scans `content` on each call. A caller converting more than one position
+/// against the same source should build a [`SourceIndex`] once instead.
 /// Falls back to end of content if position is out of bounds.
 pub fn line_column_to_offset(
     content: &str,
@@ -193,9 +383,7 @@ pub fn line_column_to_offset(
     character: u32,
     encoding: PositionEncoding,
 ) -> u32 {
-    let idx = LineIndex::new(content, encoding);
-    idx.position_to_offset(LineColumn { line, character })
-        .unwrap_or(content.len() as u32)
+    SourceIndex::new(content, encoding).clamped_position_to_offset(LineColumn { line, character })
 }
 
 /// Convert a byte offset to a line/column using UTF-16 encoding (default for tsserver/TSGO).
@@ -494,5 +682,129 @@ mod tests {
     fn test_convenience_fallback_on_oob() {
         let lc = offset_to_line_column_utf16("abc", 999);
         assert_eq!(lc.line, 0); // fallback to last line
+    }
+
+    /// A reusable index must SHARE the caller's bytes. An index that copied the
+    /// source would make a D-diagnostic batch copy the document once per
+    /// endpoint, which is the cost this type exists to remove.
+    #[test]
+    fn source_index_borrows_the_caller_buffer_instead_of_copying_it() {
+        let source = String::from("const a = 1;\nconst b = 2;\n");
+        let idx = SourceIndex::new_utf16(&source);
+        assert_eq!(idx.source().as_ptr(), source.as_ptr());
+        assert_eq!(idx.source_len(), source.len() as u32);
+    }
+
+    /// The borrowing and the owning index share one conversion implementation,
+    /// so they must agree at every offset under every encoding.
+    #[test]
+    fn source_index_agrees_with_owning_line_index_across_encodings() {
+        let source = "a😀b\ncafé\r\nxy";
+        for encoding in [
+            PositionEncoding::Utf8,
+            PositionEncoding::Utf16,
+            PositionEncoding::Utf32,
+        ] {
+            let owned = LineIndex::new(source, encoding);
+            let borrowed = SourceIndex::new(source, encoding);
+            assert_eq!(owned.line_count(), borrowed.line_count());
+            for offset in 0..=source.len() as u32 {
+                assert_eq!(
+                    owned.offset_to_position(offset),
+                    borrowed.offset_to_position(offset),
+                    "offset {offset} under {encoding:?}"
+                );
+            }
+            for line in 0..owned.line_count() {
+                assert_eq!(owned.line_start(line), borrowed.line_start(line));
+                assert_eq!(owned.line_end(line), borrowed.line_end(line));
+                for character in 0..8 {
+                    let pos = LineColumn {
+                        line: line as u32,
+                        character,
+                    };
+                    assert_eq!(
+                        owned.position_to_offset(pos),
+                        borrowed.position_to_offset(pos),
+                        "{pos:?} under {encoding:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// One index reused across many endpoints must produce exactly what a fresh
+    /// per-endpoint index would — reuse is a work reduction, never a semantic
+    /// change.
+    #[test]
+    fn one_reused_index_matches_per_endpoint_conversion() {
+        let source = "let x = 1;\nlet ø = 'a😀b';\nlet z = 3;";
+        let shared = SourceIndex::new_utf16(source);
+        for offset in 0..=source.len() as u32 {
+            assert_eq!(
+                shared.offset_to_position(offset),
+                SourceIndex::new_utf16(source).offset_to_position(offset),
+            );
+        }
+        for line in 0..shared.line_count() as u32 {
+            for character in 0..12 {
+                let pos = LineColumn { line, character };
+                assert_eq!(
+                    shared.clamped_position_to_offset(pos),
+                    line_column_to_offset_utf16(source, line, character),
+                );
+                assert_eq!(
+                    shared.checked_position_to_offset(pos),
+                    SourceIndex::new_utf16(source).checked_position_to_offset(pos),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn line_length_counts_in_the_index_encoding_and_excludes_the_terminator() {
+        let source = "a😀b\ncd";
+        assert_eq!(SourceIndex::new_utf16(source).line_length(0), Some(4));
+        assert_eq!(
+            SourceIndex::new(source, PositionEncoding::Utf8).line_length(0),
+            Some(6)
+        );
+        assert_eq!(
+            SourceIndex::new(source, PositionEncoding::Utf32).line_length(0),
+            Some(3)
+        );
+        assert_eq!(SourceIndex::new_utf16(source).line_length(1), Some(2));
+        assert_eq!(SourceIndex::new_utf16(source).line_length(2), None);
+        // CRLF is a terminator, not content.
+        assert_eq!(SourceIndex::new_utf16("ab\r\ncd").line_length(0), Some(2));
+    }
+
+    /// The strict converter is what edit and secondary-link paths rely on: it
+    /// must reject a past-EOF line, a column past the line's end, and a column
+    /// landing between the halves of a surrogate pair — never clamp them onto a
+    /// valid-looking offset.
+    #[test]
+    fn checked_position_to_offset_rejects_out_of_range_and_surrogate_interiors() {
+        let source = "a😀b";
+        let idx = SourceIndex::new_utf16(source);
+        let at = |line, character| idx.checked_position_to_offset(LineColumn { line, character });
+
+        assert_eq!(at(0, 0), Some(0));
+        assert_eq!(at(0, 1), Some(1));
+        assert_eq!(at(0, 2), None); // inside the surrogate pair
+        assert_eq!(at(0, 3), Some(5));
+        assert_eq!(at(0, 4), Some(6)); // AT the line end is in range
+        assert_eq!(at(0, 5), None); // past the line end
+        assert_eq!(at(1, 0), None); // past-EOF line
+
+        // The clamping converter is the fail-open counterpart: it never returns
+        // `None`, which is exactly why an edit may not use it.
+        assert_eq!(
+            idx.clamped_position_to_offset(LineColumn {
+                line: 9,
+                character: 9
+            }),
+            source.len() as u32
+        );
     }
 }

--- a/crates/verter_type_runtime/src/contents_snapshot.rs
+++ b/crates/verter_type_runtime/src/contents_snapshot.rs
@@ -13,11 +13,71 @@
 //! The scanners walk the typed response JSON (no string heuristics) and
 //! canonicalize each path exactly as the corresponding parser does for its
 //! content lookup, so a scanned key matches the parser's lookup key byte-for-byte.
+//!
+//! [`with_target_index`] and [`convert_per_target`] are that per-target content
+//! resolution: each distinct target a response touches is resolved once through
+//! the provider's resolver (snapshot, then disk) and indexed once, however many
+//! endpoints land in it.
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use crate::codec::SourceIndex;
 use crate::uri::file_uri_to_path;
+
+/// Resolve one response target's content through the provider's `resolve` (its
+/// contents snapshot, then its disk fallback) and hand `convert` ONE UTF-16 index
+/// over it, shared by every endpoint the response places in that target.
+/// `convert` sees `None` when the target has no content. The content and its
+/// index live only for this call.
+pub fn with_target_index<'c, R>(
+    target: &str,
+    resolve: impl FnOnce(&str) -> Option<Cow<'c, str>>,
+    convert: impl FnOnce(Option<&SourceIndex<'_>>) -> R,
+) -> R {
+    let content = resolve(target);
+    let index = content.as_deref().map(SourceIndex::new_utf16);
+    convert(index.as_ref())
+}
+
+/// Convert a flat response batch whose elements each name their own target file
+/// (definition / references locations), resolving and indexing each DISTINCT
+/// target once through [`with_target_index`].
+///
+/// An element whose `target_of` is `None` is skipped. Only one target's content
+/// is held at a time, and the results keep the batch's element order.
+pub fn convert_per_target<'c, T, R>(
+    items: &[T],
+    target_of: impl Fn(&T) -> Option<String>,
+    resolve: impl Fn(&str) -> Option<Cow<'c, str>>,
+    convert: impl Fn(&T, &str, Option<&SourceIndex<'_>>) -> Option<R>,
+) -> Vec<R> {
+    let mut group_of: HashMap<String, usize> = HashMap::new();
+    let mut groups: Vec<(String, Vec<usize>)> = Vec::new();
+    for (position, item) in items.iter().enumerate() {
+        let Some(target) = target_of(item) else {
+            continue;
+        };
+        match group_of.get(&target) {
+            Some(&group) => groups[group].1.push(position),
+            None => {
+                group_of.insert(target.clone(), groups.len());
+                groups.push((target, vec![position]));
+            }
+        }
+    }
+
+    let mut converted: Vec<Option<R>> = std::iter::repeat_with(|| None).take(items.len()).collect();
+    for (target, members) in &groups {
+        with_target_index(target, &resolve, |index| {
+            for &position in members {
+                converted[position] = convert(&items[position], target, index);
+            }
+        });
+    }
+    converted.into_iter().flatten().collect()
+}
 
 /// Clone only the `paths` entries out of the locked contents cache into a small
 /// snapshot. The values are `Arc<str>`, so each clone is a pointer bump; the map
@@ -108,7 +168,7 @@ pub fn tsserver_rename_target_paths(response: &serde_json::Value) -> HashSet<Str
 /// Canonical target paths referenced by an LSP `WorkspaceEdit` value (the
 /// `changes: { [uri]: … }` map keys plus each `documentChanges[].textDocument.uri`).
 /// Each URI is converted to a canonical filesystem path exactly as
-/// `parse_rename_edit` / `parse_text_edit_to_code_edit` key their content lookup.
+/// `parse_rename_edits` / `parse_text_edits_to_code_edits` key their content lookup.
 ///
 /// Used for the LSP-shape responses (tsgo rename's top-level workspace edit and
 /// the workspace edit nested under a tsgo code action's `edit`).
@@ -159,6 +219,57 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), Arc::from(*v)))
             .collect()
+    }
+
+    /// A batch converts through one content resolution per DISTINCT target: interleaved
+    /// elements of the same target share it, a target-less element is skipped, a target with
+    /// no content converts with no index, and results keep the batch's element order.
+    #[test]
+    fn convert_per_target_resolves_each_distinct_target_once_in_batch_order() {
+        let items = [
+            (Some("a"), 0usize),
+            (Some("b"), 1),
+            (None, 0),
+            (Some("a"), 2),
+            (Some("missing"), 0),
+            (Some("b"), 0),
+        ];
+
+        let lookups = std::cell::RefCell::new(Vec::new());
+        let converted = convert_per_target(
+            &items,
+            |(target, _)| target.map(str::to_string),
+            |target| {
+                lookups.borrow_mut().push(target.to_string());
+                match target {
+                    "a" => Some(Cow::Borrowed("x\ny\nz")),
+                    "b" => Some(Cow::Borrowed("bb\ncc")),
+                    _ => None,
+                }
+            },
+            |&(_, line), target, index| {
+                Some((
+                    target.to_string(),
+                    index.and_then(|index| index.line_start(line)),
+                ))
+            },
+        );
+
+        assert_eq!(
+            converted,
+            vec![
+                ("a".to_string(), Some(0)),
+                ("b".to_string(), Some(3)),
+                ("a".to_string(), Some(4)),
+                ("missing".to_string(), None),
+                ("b".to_string(), Some(0)),
+            ]
+        );
+        assert_eq!(
+            *lookups.borrow(),
+            vec!["a".to_string(), "b".to_string(), "missing".to_string()],
+            "each distinct target resolves once, in first-seen order"
+        );
     }
 
     #[test]

--- a/crates/verter_type_runtime/src/lib.rs
+++ b/crates/verter_type_runtime/src/lib.rs
@@ -58,7 +58,7 @@ pub use backend::{
 };
 pub use codec::{
     line_column_to_offset, line_column_to_offset_utf16, offset_to_line_column,
-    offset_to_line_column_utf16, LineColumn, LineIndex, PositionEncoding,
+    offset_to_line_column_utf16, LineColumn, LineIndex, PositionEncoding, SourceIndex,
 };
 pub use discovery::{
     detect_ts_major_version, find_node, find_tsserver, ts_major_is_native_family,

--- a/crates/verter_type_runtime/src/traits.rs
+++ b/crates/verter_type_runtime/src/traits.rs
@@ -359,7 +359,7 @@ pub trait TypeProvider: Send + Sync {
     /// `{name}.svelte`); `companion_path` is its generated companion path
     /// (`{name}.vue.tsx` / `{name}.vue.verter.ts`); `content` is the exact bytes the publish store
     /// holds for it (used ONLY for the provider's local position conversion —
-    /// `byte_offset_to_tsserver_pos` / `parse_tsserver_location` — never forwarded
+    /// `byte_offset_to_tsserver_pos` / `parse_tsserver_locations` — never forwarded
     /// to the engine); `project_file_name` is the owning project's tsconfig path
     /// (resolved by the publish path's `ProjectBinding`), threaded into the
     /// `projectFileName` of carrier diagnostics/definition/hover/completion requests

--- a/crates/verter_type_runtime/src/tsgo/ipc.rs
+++ b/crates/verter_type_runtime/src/tsgo/ipc.rs
@@ -3874,9 +3874,12 @@ impl TypeProvider for TsgoTypeProvider {
                 .await?;
 
             let items = result.as_array().cloned().unwrap_or_default();
+            // One index for the whole highlight batch — every highlight converts
+            // two endpoints against this same content snapshot.
+            let index = content_snapshot.as_deref().map(SourceIndex::new_utf16);
             Ok(items
                 .iter()
-                .filter_map(|item| parse_document_highlight(item, content_snapshot.as_deref()))
+                .filter_map(|item| parse_document_highlight(item, index.as_ref()))
                 .collect())
         })
     }
@@ -3917,9 +3920,11 @@ impl TypeProvider for TsgoTypeProvider {
                 .await?;
 
             let items = result.as_array().cloned().unwrap_or_default();
+            // One index for the whole hint batch.
+            let index = content_snapshot.as_deref().map(SourceIndex::new_utf16);
             Ok(items
                 .iter()
-                .filter_map(|item| parse_inlay_hint(item, content_snapshot.as_deref()))
+                .filter_map(|item| parse_inlay_hint(item, index.as_ref()))
                 .collect())
         })
     }
@@ -3970,9 +3975,11 @@ impl TypeProvider for TsgoTypeProvider {
                 cache.get(&contents_key(&path_owned)).cloned()
             };
 
+            // One index for every edit this resolve carries.
+            let index = content_snapshot.as_deref().map(SourceIndex::new_utf16);
             let additional_text_edits: Vec<ResolvedTextEdit> = edits
                 .iter()
-                .filter_map(|edit| parse_additional_text_edit(edit, content_snapshot.as_deref()))
+                .filter_map(|edit| parse_additional_text_edit(edit, index.as_ref()))
                 .collect();
 
             // The resolve response may also carry the lazy detail/documentation
@@ -4466,7 +4473,7 @@ fn parse_code_action<'a>(
 /// itself.
 fn parse_additional_text_edit(
     edit: &serde_json::Value,
-    content: Option<&str>,
+    index: Option<&SourceIndex<'_>>,
 ) -> Option<ResolvedTextEdit> {
     let range = edit.get("range")?;
     let start = range.get("start")?;
@@ -4477,9 +4484,15 @@ fn parse_additional_text_edit(
     let ec = u32::try_from(end.get("character")?.as_u64()?).ok()?;
     let new_text = edit.get("newText")?.as_str()?.to_string();
 
-    let c = content?;
-    let start_offset = position_to_offset_checked(c, sl, sc)?;
-    let end_offset = position_to_offset_checked(c, el, ec)?;
+    let idx = index?;
+    let start_offset = idx.checked_position_to_offset(LineColumn {
+        line: sl,
+        character: sc,
+    })?;
+    let end_offset = idx.checked_position_to_offset(LineColumn {
+        line: el,
+        character: ec,
+    })?;
     if start_offset > end_offset {
         return None;
     }
@@ -4533,6 +4546,10 @@ fn decode_semantic_tokens(
     if data.len() < 5 {
         return vec![];
     }
+    // One index for the whole token stream. Every token converts two endpoints,
+    // so a per-endpoint rebuild would rescan the document 2N times for N tokens —
+    // the largest response batch this provider decodes.
+    let idx = SourceIndex::new_utf16(content);
     let mut tokens = Vec::new();
     let mut current_line = 0u32;
     let mut current_start = 0u32;
@@ -4590,10 +4607,16 @@ fn decode_semantic_tokens(
         let Some(end_character) = current_start.checked_add(length) else {
             break;
         };
-        let Some(start) = position_to_offset_checked(content, current_line, current_start) else {
+        let Some(start) = idx.checked_position_to_offset(LineColumn {
+            line: current_line,
+            character: current_start,
+        }) else {
             continue;
         };
-        let Some(end) = position_to_offset_checked(content, current_line, end_character) else {
+        let Some(end) = idx.checked_position_to_offset(LineColumn {
+            line: current_line,
+            character: end_character,
+        }) else {
             continue;
         };
         let Some(length) = end.checked_sub(start) else {
@@ -4614,10 +4637,10 @@ fn decode_semantic_tokens(
 /// Parse a DocumentHighlight from a JSON value.
 fn parse_document_highlight(
     item: &serde_json::Value,
-    content: Option<&str>,
+    index: Option<&SourceIndex<'_>>,
 ) -> Option<TypeDocumentHighlight> {
     let range = item.get("range")?;
-    let (start, end) = parse_range_to_offsets(range, content)?;
+    let (start, end) = parse_range_to_offsets(range, index)?;
     let kind = match item.get("kind").and_then(|v| v.as_u64()) {
         Some(2) => TypeDocumentHighlightKind::Read,
         Some(3) => TypeDocumentHighlightKind::Write,
@@ -4627,11 +4650,18 @@ fn parse_document_highlight(
 }
 
 /// Parse an LSP InlayHint JSON value into an `InlayHint`.
-fn parse_inlay_hint(item: &serde_json::Value, content: Option<&str>) -> Option<InlayHint> {
+///
+/// `index` is the caller's index over this file's content, built once for the
+/// hint batch; without it the hint is dropped rather than positioned by a packed
+/// sentinel.
+fn parse_inlay_hint(
+    item: &serde_json::Value,
+    index: Option<&SourceIndex<'_>>,
+) -> Option<InlayHint> {
     let pos = item.get("position")?;
     let line = u32::try_from(pos.get("line")?.as_u64()?).ok()?;
     let character = u32::try_from(pos.get("character")?.as_u64()?).ok()?;
-    let offset = position_to_offset_checked(content?, line, character)?;
+    let offset = index?.checked_position_to_offset(LineColumn { line, character })?;
 
     // label can be a string or an array of InlayHintLabelPart
     let label = if let Some(s) = item.get("label").and_then(|v| v.as_str()) {
@@ -4664,7 +4694,10 @@ fn parse_inlay_hint(item: &serde_json::Value, content: Option<&str>) -> Option<I
 }
 
 /// Parse a JSON range `{ start: { line, character }, end: { line, character } }` to byte offsets.
-fn parse_range_to_offsets(range: &serde_json::Value, content: Option<&str>) -> Option<(u32, u32)> {
+fn parse_range_to_offsets(
+    range: &serde_json::Value,
+    index: Option<&SourceIndex<'_>>,
+) -> Option<(u32, u32)> {
     let start = range.get("start")?;
     let end = range.get("end")?;
     let sl = start.get("line")?.as_u64()? as u32;
@@ -4672,8 +4705,19 @@ fn parse_range_to_offsets(range: &serde_json::Value, content: Option<&str>) -> O
     let el = end.get("line")?.as_u64()? as u32;
     let ec = end.get("character")?.as_u64()? as u32;
 
-    if let Some(c) = content {
-        Some((position_to_offset(c, sl, sc), position_to_offset(c, el, ec)))
+    if let Some(idx) = index {
+        // Navigation range: keeps the fail-open clamp (an EDIT path must use
+        // `parse_range_to_offsets_strict_with_disk_fallback` instead).
+        Some((
+            idx.clamped_position_to_offset(LineColumn {
+                line: sl,
+                character: sc,
+            }),
+            idx.clamped_position_to_offset(LineColumn {
+                line: el,
+                character: ec,
+            }),
+        ))
     } else {
         Some((pack_position(sl, sc), pack_position(el, ec)))
     }

--- a/crates/verter_type_runtime/src/tsgo/ipc.rs
+++ b/crates/verter_type_runtime/src/tsgo/ipc.rs
@@ -16,6 +16,7 @@ use tokio::process::Child;
 use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 
 use crate::codec::{LineColumn, PositionEncoding, SourceIndex};
+use crate::contents_snapshot::{convert_per_target, with_target_index};
 use crate::protocol::*;
 use crate::traits::{ProviderFuture, TypeProvider};
 #[cfg(test)]
@@ -1658,26 +1659,6 @@ pub fn position_to_offset_with_encoding(
     SourceIndex::new(content, encoding).clamped_position_to_offset(LineColumn { line, character })
 }
 
-/// Convert an LSP `(line, character)` position to a byte offset in content.
-///
-/// `character` is interpreted as UTF-16 code units (used by TSGO and tsserver).
-/// Single-position entry point — scans `content` once per call.
-fn position_to_offset(content: &str, line: u32, character: u32) -> u32 {
-    position_to_offset_with_encoding(content, line, character, PositionEncoding::Utf16)
-}
-
-/// Convert an LSP 0-based `(line, character)` to a byte offset, returning `None` when the position
-/// is OUT OF RANGE for `content` instead of clamping it to EOF.
-///
-/// [`position_to_offset_with_encoding`] fails OPEN — a past-EOF line or a column past the line end
-/// clamps to `content.len()` / the line end and returns a valid-looking WRONG offset. That is
-/// acceptable for a navigation sentinel, but for an EDIT a clamped wrong offset corrupts the file,
-/// so the edit path validates the position is real and DROPS it otherwise. `character` is UTF-16
-/// code units. Single-position entry point — scans `content` once per call.
-fn position_to_offset_checked(content: &str, line: u32, character: u32) -> Option<u32> {
-    SourceIndex::new_utf16(content).checked_position_to_offset(LineColumn { line, character })
-}
-
 /// Split TSGO's PLAINTEXT hover block into (display, documentation).
 ///
 /// SHAPE DEPENDENCY: `build_client_capabilities()` (this file, sent on the
@@ -1712,63 +1693,31 @@ fn split_plaintext_hover_display(contents: &str) -> (Option<&str>, Option<String
 }
 
 /// Parse an LSP wire position object (`{"line": L, "character": C}`, 0-based
-/// UTF-16) into a byte offset against `content`, failing CLOSED on a malformed
+/// UTF-16) into a byte offset through `index`, failing CLOSED on a malformed
 /// or out-of-range position (a hover range is display metadata — a clamped
 /// wrong offset would highlight the wrong span, so it is dropped).
-fn lsp_wire_pos_to_byte_offset(content: &str, pos: Option<&serde_json::Value>) -> Option<u32> {
+fn lsp_wire_pos_to_byte_offset(
+    index: &SourceIndex<'_>,
+    pos: Option<&serde_json::Value>,
+) -> Option<u32> {
     let pos = pos?;
     let line = u32::try_from(pos.get("line")?.as_u64()?).ok()?;
     let character = u32::try_from(pos.get("character")?.as_u64()?).ok()?;
-    position_to_offset_checked(content, line, character)
+    index.checked_position_to_offset(LineColumn { line, character })
 }
 
-/// Parse an LSP Location JSON value into a `TypeLocation`, using content for offset resolution.
-///
-/// Converts TSGO's `file://` URI to a filesystem path so downstream code
-/// (e.g., `path_to_uri()` in merge.rs) can construct correct URIs without
-/// double-wrapping.
-fn parse_lsp_location(loc: &serde_json::Value, content: Option<&str>) -> Option<TypeLocation> {
-    let uri = loc.get("uri")?.as_str()?;
-
-    // Convert file:// URI to filesystem path for consistent downstream handling.
-    // TSGO returns URIs like "file:///d:/dev/.../file.ts", but TypeLocation.path
-    // is treated as a filesystem path everywhere it's consumed.
-    let path = uri_to_file_path(uri);
-
-    let range = loc.get("range")?;
-    let start = range.get("start")?;
-    let end = range.get("end")?;
-    let start_line = start.get("line")?.as_u64()? as u32;
-    let start_char = start.get("character")?.as_u64()? as u32;
-    let end_line = end.get("line")?.as_u64()? as u32;
-    let end_char = end.get("character")?.as_u64()? as u32;
-
-    let disk_content;
-    let content = if let Some(content) = content {
-        Some(content)
-    } else {
-        disk_content = std::fs::read_to_string(&path).ok();
-        disk_content.as_deref()
-    };
-
-    let (start_offset, end_offset) = if let Some(c) = content {
-        (
-            position_to_offset(c, start_line, start_char),
-            position_to_offset(c, end_line, end_char),
-        )
-    } else {
-        // Fallback: store packed positions
-        (
-            pack_position(start_line, start_char),
-            pack_position(end_line, end_char),
-        )
-    };
-
-    Some(TypeLocation {
-        path,
-        start: start_offset,
-        end: end_offset,
-    })
+/// A response target's content: the contents cache (`content_for`) first, then a disk read on a
+/// miss (a cross-file target the session never opened).
+fn cached_or_disk<'a>(
+    target: &str,
+    content_for: impl FnOnce(&str) -> Option<&'a str>,
+) -> Option<std::borrow::Cow<'a, str>> {
+    match content_for(target) {
+        Some(content) => Some(std::borrow::Cow::Borrowed(content)),
+        None => std::fs::read_to_string(target)
+            .ok()
+            .map(std::borrow::Cow::Owned),
+    }
 }
 
 /// Parse a batch of LSP `Location` JSON values into `TypeLocation`s, resolving EACH location's
@@ -1780,22 +1729,32 @@ fn parse_lsp_location(loc: &serde_json::Value, content: Option<&str>) -> Option<
 /// location converts cross-file ranges against the wrong file, packing garbage byte offsets that
 /// surface downstream as line-0 / wrong-position results.
 ///
-/// `content_for(target_path)` hands back the target file's content (from the contents cache);
-/// `parse_lsp_location` falls back to a disk read when it returns `None`.
+/// Each TSGO `file://` URI converts to the canonical filesystem path, so downstream code (e.g.
+/// `path_to_uri()` in merge.rs) never double-wraps it. `content_for(target_path)` hands back the
+/// target file's content (from the contents cache), with a disk read on a miss; each distinct
+/// target resolves and indexes once for the whole batch. A navigation location keeps the
+/// fail-open clamp, and a target with no content falls back to packed positions.
 fn parse_lsp_locations_per_target<'a>(
     locations: &[serde_json::Value],
     content_for: impl Fn(&str) -> Option<&'a str>,
 ) -> Vec<TypeLocation> {
-    locations
-        .iter()
-        .filter_map(|loc| {
-            let target_path = loc
-                .get("uri")
+    convert_per_target(
+        locations,
+        |loc| {
+            loc.get("uri")
                 .and_then(|value| value.as_str())
-                .map(uri_to_file_path)?;
-            parse_lsp_location(loc, content_for(&target_path))
-        })
-        .collect()
+                .map(uri_to_file_path)
+        },
+        |target| cached_or_disk(target, &content_for),
+        |loc, path, index| {
+            let (start, end) = parse_range_to_offsets(loc.get("range")?, index)?;
+            Some(TypeLocation {
+                path: path.to_string(),
+                start,
+                end,
+            })
+        },
+    )
 }
 
 /// Convert a `file://` URI from TSGO into the shared CANONICAL filesystem-path
@@ -1850,7 +1809,13 @@ fn contents_key(path: &str) -> String {
 }
 
 /// Parse an LSP CompletionItem JSON value into a `Completion`.
-fn parse_completion_item(item: &serde_json::Value, content: Option<&str>) -> Option<Completion> {
+///
+/// `index` is the caller's index over the completion document, built once for
+/// the whole completion list.
+fn parse_completion_item(
+    item: &serde_json::Value,
+    index: Option<&SourceIndex<'_>>,
+) -> Option<Completion> {
     let label = item.get("label")?.as_str()?.to_string();
     let kind = item.get("kind").and_then(|v| v.as_u64()).map(|k| match k {
         1 => CompletionKind::Text,
@@ -1935,23 +1900,8 @@ fn parse_completion_item(item: &serde_json::Value, content: Option<&str>) -> Opt
     // rather than emitting a packed or clamped offset that would corrupt the file.
     let (edit_range_start, edit_range_end) = item
         .get("textEdit")
-        .and_then(|te| {
-            let range = te.get("range")?;
-            let start = range.get("start")?;
-            let end = range.get("end")?;
-            let sl = u32::try_from(start.get("line")?.as_u64()?).ok()?;
-            let sc = u32::try_from(start.get("character")?.as_u64()?).ok()?;
-            let el = u32::try_from(end.get("line")?.as_u64()?).ok()?;
-            let ec = u32::try_from(end.get("character")?.as_u64()?).ok()?;
-            let c = content?;
-            let s = position_to_offset_checked(c, sl, sc)?;
-            let e = position_to_offset_checked(c, el, ec)?;
-            if s > e {
-                return None;
-            }
-            Some((Some(s), Some(e)))
-        })
-        .unwrap_or((None, None));
+        .and_then(|te| parse_range_to_offsets_strict(te.get("range")?, index?))
+        .map_or((None, None), |(start, end)| (Some(start), Some(end)));
 
     // Preserve the upstream-LSP resolve handle as the provider-pure
     // `CompletionResolveData::Lsp` variant: the item's own `label` plus its
@@ -2091,16 +2041,18 @@ pub fn offset_to_position_with_encoding(
     offset: u32,
     encoding: PositionEncoding,
 ) -> (u32, u32) {
-    let idx = SourceIndex::new(content, encoding);
-    match idx.offset_to_position(offset) {
+    clamped_offset_to_position(&SourceIndex::new(content, encoding), offset)
+}
+
+/// [`offset_to_position_with_encoding`] through an already-built index: an offset
+/// past EOF clamps to the EOF position.
+fn clamped_offset_to_position(idx: &SourceIndex<'_>, offset: u32) -> (u32, u32) {
+    match idx
+        .offset_to_position(offset)
+        .or_else(|| idx.offset_to_position(idx.source_len()))
+    {
         Some(pos) => (pos.line, pos.character),
-        None => {
-            // Fallback: clamp to end of content
-            match idx.offset_to_position(content.len() as u32) {
-                Some(pos) => (pos.line, pos.character),
-                None => (0, 0),
-            }
-        }
+        None => (0, 0),
     }
 }
 
@@ -3054,9 +3006,12 @@ impl TypeProvider for TsgoTypeProvider {
                 });
             };
 
+            // One index for the whole list: every item's replace-range converts
+            // through it instead of rescanning the document per endpoint.
+            let index = content_snapshot.as_deref().map(SourceIndex::new_utf16);
             let items = items_slice
                 .iter()
-                .filter_map(|item| parse_completion_item(item, content_snapshot.as_deref()))
+                .filter_map(|item| parse_completion_item(item, index.as_ref()))
                 .collect();
 
             Ok(CompletionResult {
@@ -3348,13 +3303,19 @@ impl TypeProvider for TsgoTypeProvider {
                     let (range_start, range_end) = {
                         let cache = contents_cache.lock().await;
                         match cache.get(&contents_key(&path_owned)) {
-                            Some(content) => (
-                                lsp_wire_pos_to_byte_offset(
-                                    content,
-                                    result.pointer("/range/start"),
-                                ),
-                                lsp_wire_pos_to_byte_offset(content, result.pointer("/range/end")),
-                            ),
+                            Some(content) => {
+                                let index = SourceIndex::new_utf16(content);
+                                (
+                                    lsp_wire_pos_to_byte_offset(
+                                        &index,
+                                        result.pointer("/range/start"),
+                                    ),
+                                    lsp_wire_pos_to_byte_offset(
+                                        &index,
+                                        result.pointer("/range/end"),
+                                    ),
+                                )
+                            }
                             None => (None, None),
                         }
                     };
@@ -3448,25 +3409,11 @@ impl TypeProvider for TsgoTypeProvider {
             };
 
             let cache = contents_cache.lock().await;
-            Ok(locations
-                .iter()
-                .filter_map(|loc| {
-                    let target_path = loc
-                        .get("uri")
-                        .and_then(|value| value.as_str())
-                        .map(uri_to_file_path)?;
-                    let target_content = if target_path == path_owned {
-                        cache
-                            .get(&contents_key(&path_owned))
-                            .map(|text| text.as_ref())
-                    } else {
-                        cache
-                            .get(&contents_key(&target_path))
-                            .map(|text| text.as_ref())
-                    };
-                    parse_lsp_location(loc, target_content)
-                })
-                .collect())
+            Ok(parse_lsp_locations_per_target(&locations, |target_path| {
+                cache
+                    .get(&contents_key(target_path))
+                    .map(|text| text.as_ref())
+            }))
         })
     }
 
@@ -3518,25 +3465,11 @@ impl TypeProvider for TsgoTypeProvider {
             };
 
             let cache = contents_cache.lock().await;
-            Ok(locations
-                .iter()
-                .filter_map(|loc| {
-                    let target_path = loc
-                        .get("uri")
-                        .and_then(|value| value.as_str())
-                        .map(uri_to_file_path)?;
-                    let target_content = if target_path == path_owned {
-                        cache
-                            .get(&contents_key(&path_owned))
-                            .map(|text| text.as_ref())
-                    } else {
-                        cache
-                            .get(&contents_key(&target_path))
-                            .map(|text| text.as_ref())
-                    };
-                    parse_lsp_location(loc, target_content)
-                })
-                .collect())
+            Ok(parse_lsp_locations_per_target(&locations, |target_path| {
+                cache
+                    .get(&contents_key(target_path))
+                    .map(|text| text.as_ref())
+            }))
         })
     }
 
@@ -3576,7 +3509,7 @@ impl TypeProvider for TsgoTypeProvider {
             let locations = result.as_array().cloned().unwrap_or_default();
             // References are cross-file: each location's byte offsets must be computed against
             // THAT location's own file, not the queried file. Look up each target's content (disk
-            // fallback inside `parse_lsp_location`), exactly as `get_definition` does — reusing the
+            // fallback inside `parse_lsp_locations_per_target`), exactly as `get_definition` does — reusing the
             // queried file's single snapshot for every location packs cross-file offsets against
             // the WRONG file.
             let cache = contents_cache.lock().await;
@@ -3899,8 +3832,9 @@ impl TypeProvider for TsgoTypeProvider {
                 let cache = contents_cache.lock().await;
                 match cache.get(&contents_key(&path_owned)) {
                     Some(c) => {
-                        let (sl, sc) = offset_to_position(c, start_offset);
-                        let (el, ec) = offset_to_position(c, end_offset);
+                        let index = SourceIndex::new_utf16(c);
+                        let (sl, sc) = clamped_offset_to_position(&index, start_offset);
+                        let (el, ec) = clamped_offset_to_position(&index, end_offset);
                         (sl, sc, el, ec, Some(c.clone()))
                     }
                     None => (0, start_offset, 0, end_offset, None),
@@ -4246,11 +4180,7 @@ fn parse_workspace_edit_locations<'a>(
     if let Some(changes) = result.get("changes").and_then(|v| v.as_object()) {
         for (change_uri, edits) in changes {
             if let Some(arr) = edits.as_array() {
-                for edit in arr {
-                    if let Some(loc) = parse_rename_edit(change_uri, edit, content_for) {
-                        locations.push(loc);
-                    }
-                }
+                locations.extend(parse_rename_edits(change_uri, arr, content_for));
             }
         }
     }
@@ -4263,33 +4193,49 @@ fn parse_workspace_edit_locations<'a>(
                 .and_then(|v| v.as_str())
                 .unwrap_or_default();
             if let Some(edits) = dc.get("edits").and_then(|v| v.as_array()) {
-                for edit in edits {
-                    if let Some(loc) = parse_rename_edit(dc_uri, edit, content_for) {
-                        locations.push(loc);
-                    }
-                }
+                locations.extend(parse_rename_edits(dc_uri, edits, content_for));
             }
         }
     }
 }
 
-fn parse_rename_edit<'a>(
+/// Parse the rename edits a workspace edit places in ONE target file.
+fn parse_rename_edits<'a>(
     uri: &str,
-    edit: &serde_json::Value,
+    edits: &[serde_json::Value],
     content_for: &impl Fn(&str) -> Option<&'a str>,
-) -> Option<RenameLocation> {
-    let range = edit.get("range")?;
+) -> Vec<RenameLocation> {
+    if edits.is_empty() {
+        return Vec::new();
+    }
     // Canonical filesystem-path ID, matching `TypeLocation.path` and the tsserver provider — NOT
     // the raw `file://` URI (which would split file identity vs the documents/VFS layer on
     // Windows). The same canonical path keys the per-target content lookup.
     let path = uri_to_file_path(uri);
-    // Resolve each rename edit's range against ITS OWN file content, with a per-target disk fallback
-    // for a cache miss. FAIL CLOSED via the STRICT converter: a rename is a WRITE edit, so a total
-    // cache+disk miss or an out-of-range position DROPS the location (returns None) rather than
-    // packing a line-0 / clamped offset that CORRUPTS the file. The caller collects via push-if-Some,
-    // so a dropped location skips only that span.
-    let (start, end) = parse_range_to_offsets_strict_with_disk_fallback(range, &path, content_for)?;
-    Some(RenameLocation { path, start, end })
+    // Resolve the target's OWN content once (cache, then a per-target disk read) and convert every
+    // edit through one index. FAIL CLOSED via the STRICT converter: a rename is a WRITE edit, so a
+    // total cache+disk miss drops every edit of this target, and an out-of-range or inverted range
+    // drops its own edit, rather than packing a line-0 / clamped offset that CORRUPTS the file.
+    with_target_index(
+        &path,
+        |target| cached_or_disk(target, content_for),
+        |index| {
+            let Some(index) = index else {
+                return Vec::new();
+            };
+            edits
+                .iter()
+                .filter_map(|edit| {
+                    let (start, end) = parse_range_to_offsets_strict(edit.get("range")?, index)?;
+                    Some(RenameLocation {
+                        path: path.clone(),
+                        start,
+                        end,
+                    })
+                })
+                .collect()
+        },
+    )
 }
 
 /// Parse an LSP `ParameterInformation.label`, which is EITHER a JSON string OR a
@@ -4424,12 +4370,7 @@ fn parse_code_action<'a>(
         if let Some(changes) = edit.get("changes").and_then(|v| v.as_object()) {
             for (change_uri, text_edits) in changes {
                 if let Some(arr) = text_edits.as_array() {
-                    for te in arr {
-                        if let Some(ce) = parse_text_edit_to_code_edit(change_uri, te, content_for)
-                        {
-                            edits.push(ce);
-                        }
-                    }
+                    edits.extend(parse_text_edits_to_code_edits(change_uri, arr, content_for));
                 }
             }
         }
@@ -4441,11 +4382,7 @@ fn parse_code_action<'a>(
                     .and_then(|v| v.as_str())
                     .unwrap_or_default();
                 if let Some(arr) = dc.get("edits").and_then(|v| v.as_array()) {
-                    for te in arr {
-                        if let Some(ce) = parse_text_edit_to_code_edit(dc_uri, te, content_for) {
-                            edits.push(ce);
-                        }
-                    }
+                    edits.extend(parse_text_edits_to_code_edits(dc_uri, arr, content_for));
                 }
             }
         }
@@ -4475,55 +4412,52 @@ fn parse_additional_text_edit(
     edit: &serde_json::Value,
     index: Option<&SourceIndex<'_>>,
 ) -> Option<ResolvedTextEdit> {
-    let range = edit.get("range")?;
-    let start = range.get("start")?;
-    let end = range.get("end")?;
-    let sl = u32::try_from(start.get("line")?.as_u64()?).ok()?;
-    let sc = u32::try_from(start.get("character")?.as_u64()?).ok()?;
-    let el = u32::try_from(end.get("line")?.as_u64()?).ok()?;
-    let ec = u32::try_from(end.get("character")?.as_u64()?).ok()?;
     let new_text = edit.get("newText")?.as_str()?.to_string();
-
-    let idx = index?;
-    let start_offset = idx.checked_position_to_offset(LineColumn {
-        line: sl,
-        character: sc,
-    })?;
-    let end_offset = idx.checked_position_to_offset(LineColumn {
-        line: el,
-        character: ec,
-    })?;
-    if start_offset > end_offset {
-        return None;
-    }
-
+    let (start, end) = parse_range_to_offsets_strict(edit.get("range")?, index?)?;
     Some(ResolvedTextEdit {
-        start: start_offset,
-        end: end_offset,
-        new_text,
-    })
-}
-
-fn parse_text_edit_to_code_edit<'a>(
-    uri: &str,
-    te: &serde_json::Value,
-    content_for: &impl Fn(&str) -> Option<&'a str>,
-) -> Option<TypeCodeEdit> {
-    let range = te.get("range")?;
-    let new_text = te.get("newText")?.as_str()?.to_string();
-    // Canonical filesystem-path ID (see `parse_rename_edit`), not the raw URI; keys the content.
-    let path = uri_to_file_path(uri);
-    // Per-target content with a disk fallback for a cache miss. FAIL CLOSED via the STRICT converter:
-    // a total cache+disk miss or an out-of-range position DROPS the edit (returns None) rather than
-    // packing a line-0 / clamped offset that the merge layer would apply at the WRONG location and
-    // corrupt the file. The caller collects via push-if-Some, so a dropped edit skips only itself.
-    let (start, end) = parse_range_to_offsets_strict_with_disk_fallback(range, &path, content_for)?;
-    Some(TypeCodeEdit {
-        path,
         start,
         end,
         new_text,
     })
+}
+
+/// Parse the text edits a code action places in ONE target file.
+fn parse_text_edits_to_code_edits<'a>(
+    uri: &str,
+    text_edits: &[serde_json::Value],
+    content_for: &impl Fn(&str) -> Option<&'a str>,
+) -> Vec<TypeCodeEdit> {
+    if text_edits.is_empty() {
+        return Vec::new();
+    }
+    // Canonical filesystem-path ID (see `parse_rename_edits`), not the raw URI; keys the content.
+    let path = uri_to_file_path(uri);
+    // The target's content resolves once (cache, then a per-target disk read) behind one index.
+    // FAIL CLOSED via the STRICT converter: a total cache+disk miss drops every edit of this target,
+    // and an out-of-range or inverted range drops its own edit, rather than packing a line-0 /
+    // clamped offset that the merge layer would apply at the WRONG location and corrupt the file.
+    with_target_index(
+        &path,
+        |target| cached_or_disk(target, content_for),
+        |index| {
+            let Some(index) = index else {
+                return Vec::new();
+            };
+            text_edits
+                .iter()
+                .filter_map(|te| {
+                    let new_text = te.get("newText")?.as_str()?.to_string();
+                    let (start, end) = parse_range_to_offsets_strict(te.get("range")?, index)?;
+                    Some(TypeCodeEdit {
+                        path: path.clone(),
+                        start,
+                        end,
+                        new_text,
+                    })
+                })
+                .collect()
+        },
+    )
 }
 
 /// Decode delta-encoded semantic tokens into absolute-offset tokens, remapping
@@ -4707,7 +4641,7 @@ fn parse_range_to_offsets(
 
     if let Some(idx) = index {
         // Navigation range: keeps the fail-open clamp (an EDIT path must use
-        // `parse_range_to_offsets_strict_with_disk_fallback` instead).
+        // `parse_range_to_offsets_strict` instead).
         Some((
             idx.clamped_position_to_offset(LineColumn {
                 line: sl,
@@ -4723,44 +4657,32 @@ fn parse_range_to_offsets(
     }
 }
 
-/// Like [`parse_range_to_offsets`], but FAIL CLOSED for EDIT paths: resolves the target content
-/// (cache → disk) and, when content is unavailable, returns `None` (NO `pack_position` sentinel).
-/// With content present it converts through the CHECKED [`position_to_offset_checked`], so an
-/// out-of-range position DROPS instead of clamping to EOF, and an inverted `start > end` span drops
-/// too.
+/// Like [`parse_range_to_offsets`], but FAIL CLOSED for WRITE edits: a malformed position, a
+/// `line`/`character` exceeding `u32::MAX` (checked `u32::try_from`, never a wrapping `as u32`), a
+/// position out of range for `index`'s content (the CHECKED converter drops it instead of clamping
+/// to EOF), or an inverted `start > end` span yields `None`.
 ///
-/// Edit-producing parsers (`parse_text_edit_to_code_edit`, `parse_rename_edit`) route through this
-/// so a total cache+disk miss or an out-of-range position never packs a line-0 / clamped offset that
-/// the merge layer would apply as a corrupting WRITE. Navigation-only callers keep the lenient
-/// `parse_range_to_offsets` (a packed sentinel is a tolerable display miss).
-fn parse_range_to_offsets_strict_with_disk_fallback<'a>(
+/// Every edit-producing parser — rename, code-action and completion edits — converts through this
+/// with the caller's per-target index; a target whose content is unavailable has no index, so its
+/// edits drop before reaching here (NO `pack_position` sentinel). Navigation-only callers keep the
+/// lenient `parse_range_to_offsets` (a packed sentinel is a tolerable display miss).
+fn parse_range_to_offsets_strict(
     range: &serde_json::Value,
-    path: &str,
-    content_for: &impl Fn(&str) -> Option<&'a str>,
+    index: &SourceIndex<'_>,
 ) -> Option<(u32, u32)> {
     let start = range.get("start")?;
     let end = range.get("end")?;
-    let sl = u32::try_from(start.get("line")?.as_u64()?).ok()?;
-    let sc = u32::try_from(start.get("character")?.as_u64()?).ok()?;
-    let el = u32::try_from(end.get("line")?.as_u64()?).ok()?;
-    let ec = u32::try_from(end.get("character")?.as_u64()?).ok()?;
-
-    let disk_content;
-    let content = match content_for(path) {
-        Some(content) => Some(content),
-        None => {
-            disk_content = std::fs::read_to_string(path).ok();
-            disk_content.as_deref()
-        }
+    let start = LineColumn {
+        line: u32::try_from(start.get("line")?.as_u64()?).ok()?,
+        character: u32::try_from(start.get("character")?.as_u64()?).ok()?,
     };
-    // FAIL CLOSED on a total content miss — never pack a line-0 offset for a WRITE edit.
-    let c = content?;
-    let s = position_to_offset_checked(c, sl, sc)?;
-    let e = position_to_offset_checked(c, el, ec)?;
-    if s > e {
-        return None;
-    }
-    Some((s, e))
+    let end = LineColumn {
+        line: u32::try_from(end.get("line")?.as_u64()?).ok()?,
+        character: u32::try_from(end.get("character")?.as_u64()?).ok()?,
+    };
+    let start = index.checked_position_to_offset(start)?;
+    let end = index.checked_position_to_offset(end)?;
+    (start <= end).then_some((start, end))
 }
 
 /// Extract a string from a MarkupContent or plain string JSON value.
@@ -4798,8 +4720,29 @@ pub fn create_test_project(dir: &Path) -> std::io::Result<()> {
 // `file://` URI — is enforced.
 #[cfg(test)]
 mod dto_path_canonicalization_tests {
-    use super::{parse_rename_edit, parse_text_edit_to_code_edit, uri_to_file_path};
+    use super::{
+        parse_rename_edits, parse_text_edits_to_code_edits, uri_to_file_path, RenameLocation,
+        TypeCodeEdit,
+    };
     use verter_test_support::unique_temp_dir;
+
+    /// One rename edit through the per-target parser.
+    fn rename_edit<'a>(
+        uri: &str,
+        edit: &serde_json::Value,
+        content_for: &impl Fn(&str) -> Option<&'a str>,
+    ) -> Option<RenameLocation> {
+        parse_rename_edits(uri, std::slice::from_ref(edit), content_for).pop()
+    }
+
+    /// One code-action text edit through the per-target parser.
+    fn code_edit<'a>(
+        uri: &str,
+        te: &serde_json::Value,
+        content_for: &impl Fn(&str) -> Option<&'a str>,
+    ) -> Option<TypeCodeEdit> {
+        parse_text_edits_to_code_edits(uri, std::slice::from_ref(te), content_for).pop()
+    }
 
     fn edit_json() -> serde_json::Value {
         serde_json::json!({
@@ -4830,12 +4773,12 @@ mod dto_path_canonicalization_tests {
     #[test]
     fn parse_rename_edit_stores_canonical_path_not_raw_uri() {
         // The DTO path must be the canonical filesystem ID, NEVER the raw URI.
-        // Reverting `parse_rename_edit` to `path: uri.to_string()` fails this.
+        // Reverting `parse_rename_edits` to `path: uri.to_string()` fails this.
         // Seed resolvable content keyed by the CANONICAL path so the fail-closed rename
         // location survives; the assertion under test is the canonical path, not the raw URI.
         let content = "ab";
         let content_for = |p: &str| -> Option<&str> { (p == "d:/proj/App.vue").then_some(content) };
-        let loc = parse_rename_edit("file:///D:/proj/App.vue", &edit_json(), &content_for).unwrap();
+        let loc = rename_edit("file:///D:/proj/App.vue", &edit_json(), &content_for).unwrap();
         assert_eq!(loc.path, "d:/proj/App.vue");
         assert_ne!(loc.path, "file:///D:/proj/App.vue");
         assert!(!loc.path.starts_with("file://"));
@@ -4851,7 +4794,7 @@ mod dto_path_canonicalization_tests {
     /// computed from the target's own content.
     #[test]
     fn parse_rename_edit_resolves_each_target_against_its_own_file_disk_fallback() {
-        use super::{position_to_offset, uri_to_file_path};
+        use super::uri_to_file_path;
 
         // Target file content: the renamed symbol is on line 2 (0-based), not line 0.
         let target_src = "// header line 0\nconst pad = 1;\nexport const renamed = 2;\n";
@@ -4878,11 +4821,10 @@ mod dto_path_canonicalization_tests {
         });
 
         // `content_for` is a CACHE MISS for this path → forces the per-target disk fallback.
-        let loc = parse_rename_edit(&uri, &edit, &|_p: &str| None)
+        let loc = rename_edit(&uri, &edit, &|_p: &str| None)
             .expect("rename edit resolves through the per-target disk fallback");
 
-        let want_end =
-            position_to_offset(target_src, want_line, want_char + "renamed".len() as u32);
+        let want_end = want_off + "renamed".len() as u32;
         assert_eq!(
             (loc.start, loc.end),
             (want_off, want_end),
@@ -4906,7 +4848,7 @@ mod dto_path_canonicalization_tests {
     /// resolved against ITS OWN target file with the per-target disk fallback on a cache miss.
     #[test]
     fn parse_text_edit_resolves_each_target_against_its_own_file_disk_fallback() {
-        use super::{position_to_offset, uri_to_file_path};
+        use super::uri_to_file_path;
 
         let target_src = "import a from 'x';\nconst y = 1;\nexport const fixme = 3;\n";
         let want_off = target_src.find("fixme").expect("symbol present") as u32;
@@ -4931,10 +4873,10 @@ mod dto_path_canonicalization_tests {
             "newText": "fixed"
         });
 
-        let edit = parse_text_edit_to_code_edit(&uri, &te, &|_p: &str| None)
+        let edit = code_edit(&uri, &te, &|_p: &str| None)
             .expect("code-action edit resolves through the per-target disk fallback");
 
-        let want_end = position_to_offset(target_src, want_line, want_char + "fixme".len() as u32);
+        let want_end = want_off + "fixme".len() as u32;
         assert_eq!(
             (edit.start, edit.end),
             (want_off, want_end),
@@ -4963,8 +4905,7 @@ mod dto_path_canonicalization_tests {
         // the assertion under test is that the stored path is canonical, not the raw `file://` URI.
         let content = "ab";
         let content_for = |p: &str| -> Option<&str> { (p == "d:/proj/App.vue").then_some(content) };
-        let edit =
-            parse_text_edit_to_code_edit("file:///D:/proj/App.vue", &te, &content_for).unwrap();
+        let edit = code_edit("file:///D:/proj/App.vue", &te, &content_for).unwrap();
         assert_eq!(edit.path, "d:/proj/App.vue");
         assert_ne!(edit.path, "file:///D:/proj/App.vue");
         assert!(!edit.path.starts_with("file://"));
@@ -4999,7 +4940,7 @@ mod dto_path_canonicalization_tests {
             "newText": "x"
         });
         let uri = absent_target_uri("code_edit_gone");
-        let edit = parse_text_edit_to_code_edit(&uri, &te, &|_p| None);
+        let edit = code_edit(&uri, &te, &|_p| None);
         assert!(
             edit.is_none(),
             "a code-action edit whose content is unavailable must be DROPPED (fail-closed), never \
@@ -5012,7 +4953,7 @@ mod dto_path_canonicalization_tests {
     #[test]
     fn parse_rename_edit_drops_when_content_unavailable() {
         let uri = absent_target_uri("rename_gone");
-        let loc = parse_rename_edit(&uri, &edit_json(), &|_p| None);
+        let loc = rename_edit(&uri, &edit_json(), &|_p| None);
         assert!(
             loc.is_none(),
             "a rename edit whose content is unavailable must be DROPPED (fail-closed), never \
@@ -5034,7 +4975,7 @@ mod dto_path_canonicalization_tests {
         });
         let content = "short";
         let content_for = |p: &str| -> Option<&str> { (p == "d:/proj/oob.ts").then_some(content) };
-        let edit = parse_text_edit_to_code_edit("file:///D:/proj/oob.ts", &te, &content_for);
+        let edit = code_edit("file:///D:/proj/oob.ts", &te, &content_for);
         assert!(
             edit.is_none(),
             "an out-of-range code-action edit must be DROPPED, never clamped to EOF: {edit:?}"
@@ -5059,7 +5000,7 @@ mod dto_path_canonicalization_tests {
         });
         let content = "ab";
         let content_for = |p: &str| -> Option<&str> { (p == "d:/proj/ovf.ts").then_some(content) };
-        let edit = parse_text_edit_to_code_edit("file:///D:/proj/ovf.ts", &te, &content_for);
+        let edit = code_edit("file:///D:/proj/ovf.ts", &te, &content_for);
         assert!(
             edit.is_none(),
             "a u64>u32::MAX position must be DROPPED, never truncated into an in-range offset: \
@@ -5075,7 +5016,7 @@ mod dto_path_canonicalization_tests {
             },
             "newText": "x"
         });
-        let ok = parse_text_edit_to_code_edit("file:///D:/proj/ovf.ts", &te_ok, &content_for)
+        let ok = code_edit("file:///D:/proj/ovf.ts", &te_ok, &content_for)
             .expect("an in-range edit must still be produced");
         assert_eq!((ok.start, ok.end), (0, 1), "in-range offsets unchanged");
     }
@@ -5094,7 +5035,7 @@ mod dto_path_canonicalization_tests {
         });
         let content = "ab";
         let content_for = |p: &str| -> Option<&str> { (p == "d:/proj/ovf.ts").then_some(content) };
-        let loc = parse_rename_edit("file:///D:/proj/ovf.ts", &edit, &content_for);
+        let loc = rename_edit("file:///D:/proj/ovf.ts", &edit, &content_for);
         assert!(
             loc.is_none(),
             "a u64>u32::MAX rename position must be DROPPED, never truncated: {loc:?}"
@@ -5107,7 +5048,7 @@ mod dto_path_canonicalization_tests {
                 "end": { "line": 0, "character": 1 }
             }
         });
-        let ok = parse_rename_edit("file:///D:/proj/ovf.ts", &edit_ok, &content_for)
+        let ok = rename_edit("file:///D:/proj/ovf.ts", &edit_ok, &content_for)
             .expect("an in-range rename span must still resolve");
         assert_eq!((ok.start, ok.end), (0, 1), "in-range offsets unchanged");
     }

--- a/crates/verter_type_runtime/src/tsgo/ipc.rs
+++ b/crates/verter_type_runtime/src/tsgo/ipc.rs
@@ -15,7 +15,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Child;
 use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 
-use crate::codec::{LineIndex, PositionEncoding};
+use crate::codec::{LineColumn, PositionEncoding, SourceIndex};
 use crate::protocol::*;
 use crate::traits::{ProviderFuture, TypeProvider};
 #[cfg(test)]
@@ -1413,8 +1413,12 @@ async fn read_loop(
                                 }
                             })
                         };
-                        if content.is_some() {
+                        if let Some(content) = content.as_deref() {
                             let diag_file = uri_to_file_path(raw_uri);
+                            // One index for the whole publish batch: every
+                            // diagnostic's start, end and related spans convert
+                            // through the same single scan of this document.
+                            let index = SourceIndex::new_utf16(content);
                             let diags = params
                                 .get("diagnostics")
                                 .and_then(|v| v.as_array())
@@ -1423,7 +1427,7 @@ async fn read_loop(
                                         .filter_map(|d| {
                                             parse_lsp_diagnostic(
                                                 d,
-                                                content.as_deref(),
+                                                Some(&index),
                                                 Some(diag_file.as_str()),
                                             )
                                         })
@@ -1462,14 +1466,17 @@ async fn read_loop(
 
 /// Parse a single LSP Diagnostic JSON value into a `TypeDiagnostic`.
 ///
-/// When `content` is available, resolves LSP positions to byte offsets directly.
+/// When `index` is available, resolves LSP positions to byte offsets directly.
 /// Otherwise falls back to packed `(line<<16)|character` encoding, which only
 /// works for diagnostics on line 0.
 ///
-/// `position_to_offset` interprets `character` as UTF-16 code units (LSP default).
+/// The index is built ONCE per response batch by the caller and shared across
+/// every diagnostic and endpoint in it — a per-endpoint rebuild would rescan the
+/// same document twice per diagnostic. It must be a UTF-16 index: LSP counts
+/// `character` in UTF-16 code units.
 fn parse_lsp_diagnostic(
     d: &serde_json::Value,
-    content: Option<&str>,
+    index: Option<&SourceIndex<'_>>,
     file_path: Option<&str>,
 ) -> Option<TypeDiagnostic> {
     let range = d.get("range")?;
@@ -1514,10 +1521,16 @@ fn parse_lsp_diagnostic(
 
     // When content is available, resolve to actual byte offsets.
     // Without content, fall back to packed positions (only correct for line 0).
-    let (start_offset, end_offset) = if let Some(c) = content {
+    let (start_offset, end_offset) = if let Some(idx) = index {
         (
-            position_to_offset(c, start_line, start_char),
-            position_to_offset(c, end_line, end_char),
+            idx.clamped_position_to_offset(LineColumn {
+                line: start_line,
+                character: start_char,
+            }),
+            idx.clamped_position_to_offset(LineColumn {
+                line: end_line,
+                character: end_char,
+            }),
         )
     } else {
         (
@@ -1539,7 +1552,7 @@ fn parse_lsp_diagnostic(
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
-                .filter_map(|ri| parse_lsp_related_info(ri, content, primary_file.as_deref()))
+                .filter_map(|ri| parse_lsp_related_info(ri, index, primary_file.as_deref()))
                 .collect()
         })
         .unwrap_or_default();
@@ -1572,7 +1585,7 @@ fn parse_lsp_diagnostic(
 /// for the content — fail-closed: a dropped secondary link beats a bogus one.
 fn parse_lsp_related_info(
     ri: &serde_json::Value,
-    primary_content: Option<&str>,
+    primary_index: Option<&SourceIndex<'_>>,
     primary_file: Option<&str>,
 ) -> Option<DiagnosticRelatedInfo> {
     let message = ri.get("message")?.as_str()?.to_string();
@@ -1598,15 +1611,21 @@ fn parse_lsp_related_info(
     // real offset — DROP it rather than store a packed position the merge would
     // mis-read as a byte offset. Both paths are already canonicalized.
     let same_file = primary_file == Some(path.as_str());
-    let content = primary_content.filter(|_| same_file)?;
+    let idx = primary_index.filter(|_| same_file)?;
     // Even a same-file related span can be MALFORMED (a line/col past EOF). The
-    // fail-open `position_to_offset` would CLAMP that to `content.len()` and forge a
-    // bogus "see declaration" link at EOF, so the related-info path uses the CHECKED
-    // converter and DROPS the entry (returns `None`) when the position is out of
-    // range — never clamps. The primary-span path keeps its own clamp/recovery
-    // behavior (out of scope here).
-    let start_byte = position_to_offset_checked(content, start_line, start_char)?;
-    let end_byte = position_to_offset_checked(content, end_line, end_char)?;
+    // fail-open clamp would round that to `content.len()` and forge a bogus "see
+    // declaration" link at EOF, so the related-info path uses the CHECKED converter
+    // and DROPS the entry (returns `None`) when the position is out of range —
+    // never clamps. The primary-span path keeps its own clamp/recovery behavior
+    // (out of scope here).
+    let start_byte = idx.checked_position_to_offset(LineColumn {
+        line: start_line,
+        character: start_char,
+    })?;
+    let end_byte = idx.checked_position_to_offset(LineColumn {
+        line: end_line,
+        character: end_char,
+    })?;
 
     Some(DiagnosticRelatedInfo {
         path,
@@ -1634,17 +1653,15 @@ pub fn position_to_offset_with_encoding(
     character: u32,
     encoding: PositionEncoding,
 ) -> u32 {
-    let idx = LineIndex::new(content, encoding);
-    idx.position_to_offset(crate::codec::LineColumn { line, character })
-        .unwrap_or({
-            // Fallback: clamp to content length
-            content.len() as u32
-        })
+    // Single-position entry point: scans `content` once. A caller converting a
+    // whole response batch should build one `SourceIndex` and convert through it.
+    SourceIndex::new(content, encoding).clamped_position_to_offset(LineColumn { line, character })
 }
 
 /// Convert an LSP `(line, character)` position to a byte offset in content.
 ///
 /// `character` is interpreted as UTF-16 code units (used by TSGO and tsserver).
+/// Single-position entry point — scans `content` once per call.
 fn position_to_offset(content: &str, line: u32, character: u32) -> u32 {
     position_to_offset_with_encoding(content, line, character, PositionEncoding::Utf16)
 }
@@ -1655,31 +1672,10 @@ fn position_to_offset(content: &str, line: u32, character: u32) -> u32 {
 /// [`position_to_offset_with_encoding`] fails OPEN — a past-EOF line or a column past the line end
 /// clamps to `content.len()` / the line end and returns a valid-looking WRONG offset. That is
 /// acceptable for a navigation sentinel, but for an EDIT a clamped wrong offset corrupts the file,
-/// so the edit path validates the position is real and DROPS it otherwise. EDIT-PATH-LOCAL: does
-/// not change the shared codec. `character` is UTF-16 code units.
+/// so the edit path validates the position is real and DROPS it otherwise. `character` is UTF-16
+/// code units. Single-position entry point — scans `content` once per call.
 fn position_to_offset_checked(content: &str, line: u32, character: u32) -> Option<u32> {
-    let idx = LineIndex::new(content, PositionEncoding::Utf16);
-    if line as usize >= idx.line_count() {
-        return None; // past-EOF line
-    }
-    // The line's UTF-16 width; a column past it would clamp.
-    let line_start = idx.line_start(line as usize)?;
-    let line_end = idx.line_end(line as usize)?; // before the newline / EOF
-    let line_text = content.get(line_start as usize..line_end as usize)?;
-    let line_utf16_len: u32 = line_text.encode_utf16().count() as u32;
-    if character > line_utf16_len {
-        return None; // column past the line end
-    }
-    let target = crate::codec::LineColumn { line, character };
-    let offset = idx.position_to_offset(target)?;
-    // A column landing between the two halves of an astral (surrogate-pair) character is not a
-    // UTF-16 scalar boundary; the codec rounds it to an adjacent character, yielding an offset that
-    // does NOT map back to the requested column. Require the round-trip to be exact so an EDIT is
-    // only accepted at a real boundary; drop it otherwise.
-    if idx.offset_to_position(offset)? != target {
-        return None;
-    }
-    Some(offset)
+    SourceIndex::new_utf16(content).checked_position_to_offset(LineColumn { line, character })
 }
 
 /// Split TSGO's PLAINTEXT hover block into (display, documentation).
@@ -2095,7 +2091,7 @@ pub fn offset_to_position_with_encoding(
     offset: u32,
     encoding: PositionEncoding,
 ) -> (u32, u32) {
-    let idx = LineIndex::new(content, encoding);
+    let idx = SourceIndex::new(content, encoding);
     match idx.offset_to_position(offset) {
         Some(pos) => (pos.line, pos.character),
         None => {
@@ -2579,6 +2575,8 @@ impl TsgoTypeProvider {
             )
             .await?;
         let content = self.contents.lock().await.get(&contents_key(path)).cloned();
+        // One index for the whole pull response — see `parse_lsp_diagnostic`.
+        let index = content.as_deref().map(SourceIndex::new_utf16);
         let diagnostics = value
             .get("items")
             .and_then(serde_json::Value::as_array)
@@ -2586,7 +2584,7 @@ impl TsgoTypeProvider {
                 items
                     .iter()
                     .filter_map(|diagnostic| {
-                        parse_lsp_diagnostic(diagnostic, content.as_deref(), Some(path))
+                        parse_lsp_diagnostic(diagnostic, index.as_ref(), Some(path))
                     })
                     .collect::<Vec<_>>()
             })
@@ -4167,10 +4165,12 @@ impl TypeProvider for TsgoTypeProvider {
                         .await
                         .get(&contents_key(&path_owned))
                         .cloned();
+                    // One index for the whole pull response — see `parse_lsp_diagnostic`.
+                    let index = content.as_deref().map(SourceIndex::new_utf16);
                     Ok(items
                         .iter()
                         .filter_map(|d| {
-                            parse_lsp_diagnostic(d, content.as_deref(), Some(path_owned.as_str()))
+                            parse_lsp_diagnostic(d, index.as_ref(), Some(path_owned.as_str()))
                         })
                         .collect())
                 }

--- a/crates/verter_type_runtime/src/tsgo/ipc_tests.rs
+++ b/crates/verter_type_runtime/src/tsgo/ipc_tests.rs
@@ -2019,7 +2019,12 @@ fn parse_lsp_diagnostic_reads_same_file_related_information() {
     });
     // The primary file path (canonicalized inside the parser) matches the related
     // location URI's path, so the related span resolves to a real byte offset.
-    let diag = parse_lsp_diagnostic(&json, Some(content), Some("/proj/dup.ts")).unwrap();
+    let diag = parse_lsp_diagnostic(
+        &json,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/dup.ts"),
+    )
+    .unwrap();
     assert_eq!(
         diag.related_information.len(),
         1,
@@ -2055,7 +2060,12 @@ fn parse_lsp_diagnostic_without_related_information_is_empty() {
         "code": 1234,
         "message": "some error"
     });
-    let diag = parse_lsp_diagnostic(&json, Some(content), Some("/proj/x.ts")).unwrap();
+    let diag = parse_lsp_diagnostic(
+        &json,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/x.ts"),
+    )
+    .unwrap();
     assert!(
         diag.related_information.is_empty(),
         "absent relatedInformation ⇒ empty list, got: {:?}",
@@ -2094,7 +2104,12 @@ fn parse_lsp_diagnostic_drops_cross_file_related_without_content() {
             }
         ]
     });
-    let diag = parse_lsp_diagnostic(&json, Some(content), Some("/proj/a.ts")).unwrap();
+    let diag = parse_lsp_diagnostic(
+        &json,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/a.ts"),
+    )
+    .unwrap();
     assert!(
         diag.related_information.is_empty(),
         "a cross-file related span with no content for the related file must be \
@@ -2132,7 +2147,12 @@ fn parse_lsp_related_never_stores_packed_position_anti_bogus_link() {
             }
         ]
     });
-    let diag = parse_lsp_diagnostic(&json, Some(content), Some("/proj/a.ts")).unwrap();
+    let diag = parse_lsp_diagnostic(
+        &json,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/a.ts"),
+    )
+    .unwrap();
     let packed = (99u32 << 16) | (4u32 & 0xFFFF);
     assert_eq!(
         packed, 6_488_068,
@@ -2192,7 +2212,12 @@ fn parse_lsp_related_drops_same_file_out_of_range_offset() {
             }
         ]
     });
-    let diag = parse_lsp_diagnostic(&json, Some(content), Some("/proj/dup.ts")).unwrap();
+    let diag = parse_lsp_diagnostic(
+        &json,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/dup.ts"),
+    )
+    .unwrap();
     // The primary diagnostic survives with its real in-range offsets.
     assert_eq!(diag.start, 6, "primary start is a real in-range offset");
     assert_eq!(diag.end, 9, "primary end is a real in-range offset");
@@ -2253,7 +2278,12 @@ fn parse_lsp_related_drops_same_file_wrap_to_valid_coordinate() {
             }
         ]
     });
-    let diag = parse_lsp_diagnostic(&json, Some(content), Some("/proj/dup.ts")).unwrap();
+    let diag = parse_lsp_diagnostic(
+        &json,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/dup.ts"),
+    )
+    .unwrap();
     // The primary diagnostic survives with its real in-range offsets.
     assert_eq!(diag.start, 6, "primary start is a real in-range offset");
     assert_eq!(diag.end, 9, "primary end is a real in-range offset");

--- a/crates/verter_type_runtime/src/tsgo/ipc_tests.rs
+++ b/crates/verter_type_runtime/src/tsgo/ipc_tests.rs
@@ -47,22 +47,22 @@ fn empty_plaintext_hover_yields_no_display_signature() {
 
 #[test]
 fn lsp_wire_pos_maps_to_byte_offset() {
-    let content = "const x = 1;\nconst y = 2;\n";
+    let index = SourceIndex::new_utf16("const x = 1;\nconst y = 2;\n");
     let pos = serde_json::json!({ "line": 1, "character": 6 });
     assert_eq!(
-        lsp_wire_pos_to_byte_offset(content, Some(&pos)),
+        lsp_wire_pos_to_byte_offset(&index, Some(&pos)),
         Some(13 + 6)
     );
 }
 
 #[test]
 fn lsp_wire_pos_fails_closed_on_out_of_range_or_malformed() {
-    let content = "const x = 1;\n";
+    let index = SourceIndex::new_utf16("const x = 1;\n");
     let past_eof = serde_json::json!({ "line": 9, "character": 0 });
-    assert_eq!(lsp_wire_pos_to_byte_offset(content, Some(&past_eof)), None);
+    assert_eq!(lsp_wire_pos_to_byte_offset(&index, Some(&past_eof)), None);
     let malformed = serde_json::json!({ "line": "zero" });
-    assert_eq!(lsp_wire_pos_to_byte_offset(content, Some(&malformed)), None);
-    assert_eq!(lsp_wire_pos_to_byte_offset(content, None), None);
+    assert_eq!(lsp_wire_pos_to_byte_offset(&index, Some(&malformed)), None);
+    assert_eq!(lsp_wire_pos_to_byte_offset(&index, None), None);
 }
 
 #[test]
@@ -638,11 +638,21 @@ impl Drop for ForcedTraceEnv {
 // `'😀'` occupies 0-based UTF-16 cols 9 (start) and 10 (the trailing surrogate half) on this line:
 // `l e t   x   =   '` = cols 0..=8, `😀` = cols 9,10, closing `'` = col 11, `;` = col 12.
 // tsgo positions are 0-based.
+/// An empty (insertion) edit range at 0-based UTF-16 `character` on line 0, through the strict
+/// converter every tsgo edit path uses.
+fn tsgo_strict_insertion_offset(content: &str, character: u32) -> Option<u32> {
+    let range = serde_json::json!({
+        "start": { "line": 0, "character": character },
+        "end": { "line": 0, "character": character },
+    });
+    parse_range_to_offsets_strict(&range, &SourceIndex::new_utf16(content)).map(|(start, _)| start)
+}
+
 #[test]
 fn tsgo_checked_drops_mid_surrogate_column() {
     let content = "let x = '😀';";
     assert_eq!(
-        position_to_offset_checked(content, 0, 10),
+        tsgo_strict_insertion_offset(content, 10),
         None,
         "a UTF-16 column inside an astral character is not a scalar boundary and must be dropped"
     );
@@ -652,7 +662,7 @@ fn tsgo_checked_drops_mid_surrogate_column() {
 fn tsgo_checked_accepts_position_after_astral() {
     let content = "let x = '😀';";
     // Col 11 is the closing quote, immediately AFTER the emoji.
-    let off = position_to_offset_checked(content, 0, 11)
+    let off = tsgo_strict_insertion_offset(content, 11)
         .expect("the position immediately after an astral character is a valid scalar boundary");
     // `let x = '` is 9 bytes, `😀` is 4 UTF-8 bytes → byte offset 13 is the closing quote.
     assert_eq!(off, 13);
@@ -663,7 +673,7 @@ fn tsgo_checked_accepts_position_after_astral() {
 fn tsgo_checked_accepts_eol_insertion_on_astral_line() {
     let content = "let x = '😀';";
     // EOL insertion: 0-based col == line UTF-16 length (13).
-    let off = position_to_offset_checked(content, 0, 13)
+    let off = tsgo_strict_insertion_offset(content, 13)
         .expect("an end-of-line insertion position is a valid scalar boundary");
     assert_eq!(off as usize, content.len());
 }
@@ -1135,7 +1145,15 @@ fn test_normalize_file_uri_cache_key_match() {
     );
 }
 
-/// @ai-generated — parse_lsp_location stores a filesystem path, not a URI
+/// One LSP location through the per-target batch parser.
+fn parse_one_lsp_location<'a>(
+    loc: &serde_json::Value,
+    content_for: impl Fn(&str) -> Option<&'a str>,
+) -> Option<TypeLocation> {
+    parse_lsp_locations_per_target(std::slice::from_ref(loc), content_for).pop()
+}
+
+/// @ai-generated — parse_lsp_locations_per_target stores a filesystem path, not a URI
 #[test]
 fn test_parse_lsp_location_stores_filesystem_path() {
     let content = "const foo = 1;\nconst bar = 2;\n";
@@ -1147,7 +1165,7 @@ fn test_parse_lsp_location_stores_filesystem_path() {
         }
     });
 
-    let result = parse_lsp_location(&loc, Some(content)).unwrap();
+    let result = parse_one_lsp_location(&loc, |_| Some(content)).unwrap();
 
     // The path should be a filesystem path, NOT a file:// URI.
     // Before the fix, this was "file:///d:/dev/project/src/utils.ts".
@@ -1290,15 +1308,19 @@ async fn test_tsgo_survives_workspace_configuration() {
 
 // ── Parsing helper unit tests ─────────────────────────────────────
 
-/// @ai-generated — position_to_offset converts line/char to byte offset
+fn utf16_position_to_offset(content: &str, line: u32, character: u32) -> u32 {
+    position_to_offset_with_encoding(content, line, character, PositionEncoding::Utf16)
+}
+
+/// @ai-generated — position_to_offset_with_encoding converts line/char to byte offset
 #[test]
 fn test_position_to_offset_fn() {
     let content = "line1\nline2\nline3";
-    assert_eq!(position_to_offset(content, 0, 0), 0);
-    assert_eq!(position_to_offset(content, 0, 3), 3);
-    assert_eq!(position_to_offset(content, 1, 0), 6);
-    assert_eq!(position_to_offset(content, 1, 2), 8);
-    assert_eq!(position_to_offset(content, 2, 0), 12);
+    assert_eq!(utf16_position_to_offset(content, 0, 0), 0);
+    assert_eq!(utf16_position_to_offset(content, 0, 3), 3);
+    assert_eq!(utf16_position_to_offset(content, 1, 0), 6);
+    assert_eq!(utf16_position_to_offset(content, 1, 2), 8);
+    assert_eq!(utf16_position_to_offset(content, 2, 0), 12);
 }
 
 #[test]
@@ -1306,8 +1328,8 @@ fn test_position_to_offset_utf16_bmp() {
     // "café\nworld" — 'é' is 2 bytes UTF-8, 1 UTF-16 code unit
     let content = "café\nworld";
     // UTF-16 char 4 = end of "café" = byte 5
-    assert_eq!(position_to_offset(content, 0, 4), 5);
-    assert_eq!(position_to_offset(content, 1, 0), 6);
+    assert_eq!(utf16_position_to_offset(content, 0, 4), 5);
+    assert_eq!(utf16_position_to_offset(content, 1, 0), 6);
 }
 
 #[test]
@@ -1315,7 +1337,7 @@ fn test_position_to_offset_utf16_supplementary() {
     // "a😀b" — '😀' is 4 bytes UTF-8, 2 UTF-16 code units
     let content = "a😀b";
     // UTF-16: 'a'=1, '😀'=2 (surrogate pair), 'b' at char 3 = byte 5
-    assert_eq!(position_to_offset(content, 0, 3), 5);
+    assert_eq!(utf16_position_to_offset(content, 0, 3), 5);
 }
 
 #[test]
@@ -1395,7 +1417,7 @@ fn parse_completion_item_drops_text_edit_range_on_position_overflow() {
     // Content is valid and large enough for the WRAPPED (line 0 / char 0..5) position, so the only
     // reason the range can drop is the u64>u32 overflow itself.
     let content = "myVar = 1";
-    let item = parse_completion_item(&json, Some(content)).unwrap();
+    let item = parse_completion_item(&json, Some(&SourceIndex::new_utf16(content))).unwrap();
     assert_eq!(item.label, "myVar");
     assert_eq!(
         item.edit_range_start, None,
@@ -1416,7 +1438,7 @@ fn parse_completion_item_drops_text_edit_range_on_position_overflow() {
             "newText": "myVar"
         }
     });
-    let ok = parse_completion_item(&json_ok, Some(content)).unwrap();
+    let ok = parse_completion_item(&json_ok, Some(&SourceIndex::new_utf16(content))).unwrap();
     assert_eq!(
         (ok.edit_range_start, ok.edit_range_end),
         (Some(0), Some(5)),
@@ -1716,7 +1738,7 @@ fn parse_completion_item_drops_out_of_range_text_edit() {
             "newText": "myVar"
         }
     });
-    let item = parse_completion_item(&json, Some(content)).unwrap();
+    let item = parse_completion_item(&json, Some(&SourceIndex::new_utf16(content))).unwrap();
     assert_eq!(
         item.edit_range_start, None,
         "an out-of-range replace-range must be dropped, never clamped"
@@ -1748,7 +1770,7 @@ fn test_parse_completion_item_lsp_kind_16_is_not_property() {
     );
 }
 
-/// @ai-generated — parse_lsp_location parses an LSP Location with content
+/// @ai-generated — an LSP Location parses against its target's content
 #[test]
 fn test_parse_lsp_location() {
     let json = serde_json::json!({
@@ -1759,7 +1781,7 @@ fn test_parse_lsp_location() {
         }
     });
     let content = "line1\nline2\n";
-    let loc = parse_lsp_location(&json, Some(content)).unwrap();
+    let loc = parse_one_lsp_location(&json, |_| Some(content)).unwrap();
     // URI is converted to filesystem path (Unix: /test.ts)
     assert_eq!(loc.path, "/test.ts");
     assert_eq!(loc.start, 6);
@@ -1783,11 +1805,62 @@ fn test_parse_lsp_location_without_inline_content_reads_disk_content() {
         }
     });
 
-    let loc = parse_lsp_location(&json, None).unwrap();
+    let loc = parse_one_lsp_location(&json, |_| None).unwrap();
     assert_eq!(loc.start, 27);
     assert_eq!(loc.end, 32);
 
     let _ = std::fs::remove_dir_all(&temp_root);
+}
+
+/// A references batch converts every location in the same file through ONE resolution of that
+/// file's content: interleaved targets resolve once each, and the results keep response order.
+#[test]
+fn references_batch_resolves_each_distinct_target_once_in_response_order() {
+    let a_path = "/proj/a.ts";
+    let a_content = "let x = 1;\nlet y = x;\n";
+    let b_path = "/proj/b.ts";
+    let b_content = "import { x } from './a';\n";
+    let location = |path: &str, line: u32, start: u32, end: u32| {
+        serde_json::json!({
+            "uri": path_to_file_uri_string(path),
+            "range": {
+                "start": { "line": line, "character": start },
+                "end": { "line": line, "character": end }
+            }
+        })
+    };
+    let locations = vec![
+        location(a_path, 0, 4, 5),
+        location(b_path, 0, 9, 10),
+        location(a_path, 1, 8, 9),
+    ];
+
+    let lookups = std::cell::RefCell::new(Vec::new());
+    let result = parse_lsp_locations_per_target(&locations, |target| {
+        lookups.borrow_mut().push(target.to_string());
+        if target == a_path {
+            Some(a_content)
+        } else if target == b_path {
+            Some(b_content)
+        } else {
+            None
+        }
+    });
+
+    let got: Vec<_> = result
+        .iter()
+        .map(|l| (l.path.as_str(), l.start, l.end))
+        .collect();
+    assert_eq!(
+        got,
+        vec![(a_path, 4, 5), (b_path, 9, 10), (a_path, 19, 20)],
+        "every location converts against its own file and keeps its response position"
+    );
+    assert_eq!(
+        *lookups.borrow(),
+        vec![a_path.to_string(), b_path.to_string()],
+        "each distinct target's content resolves once per batch, not once per location"
+    );
 }
 
 /// Block H regression — cross-file references must convert each location's range against its OWN
@@ -2181,10 +2254,10 @@ fn parse_lsp_related_never_stores_packed_position_anti_bogus_link() {
 /// to `content.len()`. A clamped EOF offset would fabricate a bogus "see
 /// declaration" link landing at the end of the file.
 ///
-/// Pre-fix (fail-open `position_to_offset`): line 99 clamps to `content.len()` (15),
-/// so `related_information` is NON-empty with start == end == 15 — this assertion
-/// fires. Post-fix (`position_to_offset_checked`): the entry is dropped, the list is
-/// empty, and the PRIMARY diagnostic still survives.
+/// A fail-open clamped conversion would map line 99 to `content.len()` (15), leaving
+/// `related_information` NON-empty with start == end == 15 — this assertion fires.
+/// The checked conversion (`SourceIndex::checked_position_to_offset`) drops the
+/// entry: the list is empty, and the PRIMARY diagnostic still survives.
 #[test]
 fn parse_lsp_related_drops_same_file_out_of_range_offset() {
     let content = "const dup = 1;\n"; // 15 bytes, 2 lines (1 trailing empty)

--- a/crates/verter_type_runtime/src/tsgo/ipc_tests.rs
+++ b/crates/verter_type_runtime/src/tsgo/ipc_tests.rs
@@ -1440,7 +1440,7 @@ fn parse_additional_text_edit_drops_on_position_overflow() {
         "newText": "import { foo } from './foo';\n"
     });
     let content = "const a = 1;";
-    let resolved = parse_additional_text_edit(&edit, Some(content));
+    let resolved = parse_additional_text_edit(&edit, Some(&SourceIndex::new_utf16(content)));
     assert!(
         resolved.is_none(),
         "a u64>u32::MAX additionalTextEdit position must be DROPPED, never truncated into an \
@@ -1455,7 +1455,7 @@ fn parse_additional_text_edit_drops_on_position_overflow() {
         },
         "newText": "import { foo } from './foo';\n"
     });
-    let ok = parse_additional_text_edit(&edit_ok, Some(content))
+    let ok = parse_additional_text_edit(&edit_ok, Some(&SourceIndex::new_utf16(content)))
         .expect("an in-range additionalTextEdit must still be produced");
     assert_eq!((ok.start, ok.end), (0, 0), "in-range offsets unchanged");
     assert_eq!(ok.new_text, "import { foo } from './foo';\n");
@@ -2648,6 +2648,48 @@ fn test_decode_semantic_tokens_converts_utf16_lengths_to_bytes() {
     );
 }
 
+/// A token stream is decoded against ONE index built for the whole response. The
+/// tokens are delta-encoded across lines, so a shared index that went stale after
+/// the first line — or that measured a later line against the first line's start —
+/// would misplace every token after the first. Non-ASCII on more than one line is
+/// what makes a byte-offset slip visible.
+#[test]
+fn decode_semantic_tokens_places_every_token_in_a_multiline_non_ascii_stream() {
+    let content = "const π𝛛a = 1;\nconst é_b = 2;\nconst c𝛛 = 3;\n";
+    let legend =
+        crate::semantic_tokens::SemanticTokenLegendMap::from_names(&["variable"], &["declaration"]);
+    // Three tokens, one per line. `deltaLine` advances the line and resets the
+    // column, so token N's byte offset depends on the index knowing line N's start.
+    let data: Vec<serde_json::Value> = vec![
+        // line 0, UTF-16 col 6, "π𝛛a" = 1 + 2 + 1 = 4 units
+        0.into(),
+        6.into(),
+        4.into(),
+        0.into(),
+        1.into(),
+        // line 1, UTF-16 col 6, "é_b" = 3 units
+        1.into(),
+        6.into(),
+        3.into(),
+        0.into(),
+        1.into(),
+        // line 2, UTF-16 col 6, "c𝛛" = 1 + 2 = 3 units
+        1.into(),
+        6.into(),
+        3.into(),
+        0.into(),
+        1.into(),
+    ];
+
+    let tokens = decode_semantic_tokens(&data, Some(content), &legend);
+    assert_eq!(tokens.len(), 3, "{tokens:?}");
+    let sliced: Vec<&str> = tokens
+        .iter()
+        .map(|t| &content[t.start as usize..(t.start + t.length) as usize])
+        .collect();
+    assert_eq!(sliced, vec!["π𝛛a", "é_b", "c𝛛"]);
+}
+
 // @ai-generated - Guards checked conversion of tsgo semantic-token fields.
 #[test]
 fn test_decode_semantic_tokens_stops_on_numeric_field_overflow() {
@@ -2745,7 +2787,8 @@ fn test_parse_inlay_hint_requires_content_and_an_exact_position() {
         "kind": 1,
     });
 
-    let parsed = parse_inlay_hint(&hint, Some(content)).expect("valid inlay hint");
+    let parsed =
+        parse_inlay_hint(&hint, Some(&SourceIndex::new_utf16(content))).expect("valid inlay hint");
     assert_eq!(
         parsed.position, 9,
         "the UTF-16 line/column must resolve to a byte offset"
@@ -2761,7 +2804,7 @@ fn test_parse_inlay_hint_requires_content_and_an_exact_position() {
         "kind": 1,
     });
     assert!(
-        parse_inlay_hint(&out_of_range, Some(content)).is_none(),
+        parse_inlay_hint(&out_of_range, Some(&SourceIndex::new_utf16(content))).is_none(),
         "an out-of-range inlay position must be dropped, never clamped to EOF"
     );
 
@@ -2772,7 +2815,7 @@ fn test_parse_inlay_hint_requires_content_and_an_exact_position() {
         "kind": 1,
     });
     assert!(
-        parse_inlay_hint(&overflowing, Some(content)).is_none(),
+        parse_inlay_hint(&overflowing, Some(&SourceIndex::new_utf16(content))).is_none(),
         "an overflowing inlay position must be dropped, never truncated to line 0"
     );
 }
@@ -2788,7 +2831,7 @@ fn test_parse_document_highlight() {
         "kind": 2
     });
     let content = "const msg = 'hello';\n";
-    let hl = parse_document_highlight(&json, Some(content)).unwrap();
+    let hl = parse_document_highlight(&json, Some(&SourceIndex::new_utf16(content))).unwrap();
     assert_eq!(hl.start, 6);
     assert_eq!(hl.end, 9);
     assert!(matches!(hl.kind, TypeDocumentHighlightKind::Read));

--- a/crates/verter_type_runtime/src/tsserver/ipc.rs
+++ b/crates/verter_type_runtime/src/tsserver/ipc.rs
@@ -16,7 +16,9 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Child;
 use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 
-use crate::codec::{line_column_to_offset_utf16, offset_to_line_column_utf16};
+use crate::codec::{
+    line_column_to_offset_utf16, offset_to_line_column_utf16, LineColumn, SourceIndex,
+};
 use crate::protocol::*;
 use crate::traits::{ProviderFuture, TypeProvider};
 
@@ -1354,9 +1356,14 @@ fn handle_message(
 ///
 /// tsserver diagnostics use `{start: {line, offset}, end: {line, offset}}` format
 /// where line and offset are 1-based.
+///
+/// `index` is a UTF-16 index over the file's content, built ONCE per response
+/// batch by the caller and shared across every diagnostic and every diagnostic
+/// pass in it — a per-endpoint rebuild would rescan the same document twice per
+/// diagnostic. Without it, positions fall back to packed 0-based values.
 pub fn parse_tsserver_diagnostic(
     d: &serde_json::Value,
-    content: Option<&str>,
+    index: Option<&SourceIndex<'_>>,
     file_path: Option<&str>,
 ) -> Option<TypeDiagnostic> {
     let text = d.get("text")?.as_str()?.to_string();
@@ -1398,10 +1405,10 @@ pub fn parse_tsserver_diagnostic(
     }
 
     // Convert 1-based line/offset to byte offsets
-    let (so, eo) = if let Some(c) = content {
+    let (so, eo) = if let Some(idx) = index {
         (
-            tsserver_pos_to_byte_offset(c, start_line, start_offset),
-            tsserver_pos_to_byte_offset(c, end_line, end_offset),
+            tsserver_pos_to_byte_offset_indexed(idx, start_line, start_offset),
+            tsserver_pos_to_byte_offset_indexed(idx, end_line, end_offset),
         )
     } else {
         // Fallback: use 0-based packed positions
@@ -1426,7 +1433,7 @@ pub fn parse_tsserver_diagnostic(
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
-                .filter_map(|ri| parse_tsserver_related_info(ri, content, primary_file.as_deref()))
+                .filter_map(|ri| parse_tsserver_related_info(ri, index, primary_file.as_deref()))
                 .collect()
         })
         .unwrap_or_default();
@@ -1458,7 +1465,7 @@ pub fn parse_tsserver_diagnostic(
 /// the content — fail-closed: a dropped secondary link beats a bogus one.
 fn parse_tsserver_related_info(
     ri: &serde_json::Value,
-    primary_content: Option<&str>,
+    primary_index: Option<&SourceIndex<'_>>,
     primary_file: Option<&str>,
 ) -> Option<DiagnosticRelatedInfo> {
     let message = ri.get("message")?.as_str()?.to_string();
@@ -1483,15 +1490,15 @@ fn parse_tsserver_related_info(
     // real offset — DROP it rather than store a packed position the merge would
     // mis-read as a byte offset. Both paths are already canonicalized.
     let same_file = primary_file == Some(file.as_str());
-    let content = primary_content.filter(|_| same_file)?;
+    let idx = primary_index.filter(|_| same_file)?;
     // Even a same-file related span can be MALFORMED (a 1-based line/offset past
     // EOF). The fail-open `tsserver_pos_to_byte_offset` would CLAMP that to
     // `content.len()` and forge a bogus "see declaration" link at EOF, so the
     // related-info path uses the CHECKED converter and DROPS the entry (returns
     // `None`) when the position is out of range — never clamps. The primary-span
     // path keeps its own clamp/recovery behavior (out of scope here).
-    let start_byte = tsserver_pos_to_byte_offset_checked(content, start_line, start_offset)?;
-    let end_byte = tsserver_pos_to_byte_offset_checked(content, end_line, end_offset)?;
+    let start_byte = tsserver_pos_to_byte_offset_checked(idx, start_line, start_offset)?;
+    let end_byte = tsserver_pos_to_byte_offset_checked(idx, end_line, end_offset)?;
 
     Some(DiagnosticRelatedInfo {
         path: file,
@@ -1689,13 +1696,13 @@ async fn recover_companion_managed_root(
 /// the same diagnostic shape, so a single parser serves them all.
 fn parse_tsserver_diagnostics_body(
     body: &serde_json::Value,
-    content: Option<&str>,
+    index: Option<&SourceIndex<'_>>,
     file_path: Option<&str>,
 ) -> Vec<TypeDiagnostic> {
     body.as_array()
         .map(|arr| {
             arr.iter()
-                .filter_map(|d| parse_tsserver_diagnostic(d, content, file_path))
+                .filter_map(|d| parse_tsserver_diagnostic(d, index, file_path))
                 .collect()
         })
         .unwrap_or_default()
@@ -1730,6 +1737,18 @@ pub fn tsserver_pos_to_byte_offset(content: &str, line: u32, offset: u32) -> u32
     line_column_to_offset_utf16(content, line.saturating_sub(1), offset.saturating_sub(1))
 }
 
+/// [`tsserver_pos_to_byte_offset`] against an already-built index.
+///
+/// Same fail-open clamp and same 1-based → 0-based convention; the caller
+/// supplies the shared per-batch index instead of paying a fresh source scan for
+/// every endpoint.
+fn tsserver_pos_to_byte_offset_indexed(idx: &SourceIndex<'_>, line: u32, offset: u32) -> u32 {
+    idx.clamped_position_to_offset(LineColumn {
+        line: line.saturating_sub(1),
+        character: offset.saturating_sub(1),
+    })
+}
+
 /// Parse a tsserver wire position object (`{"line": L, "offset": C}`, 1-based)
 /// into a byte offset against `content`, failing CLOSED on a malformed or
 /// out-of-range position (the quickinfo hover range is display metadata — a
@@ -1741,7 +1760,7 @@ pub fn quickinfo_wire_pos_to_byte_offset(
     let pos = pos?;
     let line = u32::try_from(pos.get("line")?.as_u64()?).ok()?;
     let offset = u32::try_from(pos.get("offset")?.as_u64()?).ok()?;
-    tsserver_pos_to_byte_offset_checked(content, line, offset)
+    tsserver_pos_to_byte_offset_checked(&SourceIndex::new_utf16(content), line, offset)
 }
 
 /// Convert tsserver's 1-based (line, offset) to a byte offset, returning `None` when the position
@@ -1750,41 +1769,24 @@ pub fn quickinfo_wire_pos_to_byte_offset(
 /// The shared codec ([`line_column_to_offset_utf16`]) fails OPEN: a past-EOF line or a column past
 /// the line's end is silently clamped to a valid-looking offset (`content.len()` / the line end).
 /// That is acceptable for a navigation sentinel, but for an EDIT a clamped wrong offset corrupts
-/// the file — so the edit path validates the position is real and DROPS it otherwise. The check is
-/// EDIT-PATH-LOCAL: it does not change the shared codec.
+/// the file — so the edit path validates the position is real and DROPS it otherwise. The two
+/// conventions coexist deliberately: the clamping converter stays the navigation-sentinel default.
 ///
-/// Validates against the content's own UTF-16 [`LineIndex`]: the 1-based line must exist, and the
-/// 0-based UTF-16 column must not exceed that line's UTF-16 length (a column AT the line end is in
-/// range; past it is not).
-fn tsserver_pos_to_byte_offset_checked(content: &str, line: u32, offset: u32) -> Option<u32> {
+/// The 1-based → 0-based conversion is the tsserver-specific half and stays here (line or offset 0
+/// is malformed); the range validation itself is the shared strict converter
+/// ([`SourceIndex::checked_position_to_offset`]), which rejects a past-EOF line, a column past the
+/// line's end, and a column landing inside a surrogate pair.
+fn tsserver_pos_to_byte_offset_checked(
+    idx: &SourceIndex<'_>,
+    line: u32,
+    offset: u32,
+) -> Option<u32> {
     let line0 = line.checked_sub(1)?; // 1-based → 0-based; line 0 is malformed
     let col0 = offset.checked_sub(1)?; // 1-based → 0-based; offset 0 is malformed
-    let idx = crate::codec::LineIndex::new(content, crate::codec::PositionEncoding::Utf16);
-    if line0 as usize >= idx.line_count() {
-        return None; // past-EOF line
-    }
-    // The line's UTF-16 width: bytes from this line's start to the next line's start (or EOF),
-    // measured in the same UTF-16 space tsserver columns use. A column past it would clamp.
-    let line_start = idx.line_start(line0 as usize)?;
-    let line_end = idx.line_end(line0 as usize)?; // before the newline / EOF
-    let line_text = content.get(line_start as usize..line_end as usize)?;
-    let line_utf16_len: u32 = line_text.encode_utf16().count() as u32;
-    if col0 > line_utf16_len {
-        return None; // column past the line end
-    }
-    let target = crate::codec::LineColumn {
+    idx.checked_position_to_offset(LineColumn {
         line: line0,
         character: col0,
-    };
-    let offset = idx.position_to_offset(target)?;
-    // A column landing between the two halves of an astral (surrogate-pair) character is not a
-    // UTF-16 scalar boundary; the codec rounds it to an adjacent character, yielding an offset that
-    // does NOT map back to the requested column. Require the round-trip to be exact so an EDIT is
-    // only accepted at a real boundary; drop it otherwise.
-    if idx.offset_to_position(offset)? != target {
-        return None;
-    }
-    Some(offset)
+    })
 }
 
 /// Parse one tsserver-family `provideInlayHints` entry into the provider
@@ -1802,7 +1804,8 @@ pub fn parse_tsserver_inlay_hint(
     let pos = hint.get("position")?;
     let line = u32::try_from(pos.get("line")?.as_u64()?).ok()?;
     let offset = u32::try_from(pos.get("offset")?.as_u64()?).ok()?;
-    let position = tsserver_pos_to_byte_offset_checked(content?, line, offset)?;
+    let position =
+        tsserver_pos_to_byte_offset_checked(&SourceIndex::new_utf16(content?), line, offset)?;
 
     let kind = match hint.get("kind").and_then(|value| value.as_str()) {
         Some("Type") => Some(InlayHintKind::Type),
@@ -3997,9 +4000,14 @@ impl TypeProvider for TsserverTypeProvider {
 
             match semantic_result {
                 Ok(semantic_body) => {
+                    // One index for all three diagnostic passes: semantic,
+                    // syntactic and suggestion all resolve against the same
+                    // content snapshot, so the document is scanned once for the
+                    // whole pull rather than twice per diagnostic per pass.
+                    let index = content.as_deref().map(SourceIndex::new_utf16);
                     let semantic = parse_tsserver_diagnostics_body(
                         &semantic_body,
-                        content.as_deref(),
+                        index.as_ref(),
                         Some(file.as_str()),
                     );
 
@@ -4008,7 +4016,7 @@ impl TypeProvider for TsserverTypeProvider {
                         .map(|body| {
                             parse_tsserver_diagnostics_body(
                                 &body,
-                                content.as_deref(),
+                                index.as_ref(),
                                 Some(file.as_str()),
                             )
                         })
@@ -4019,7 +4027,7 @@ impl TypeProvider for TsserverTypeProvider {
                         .map(|body| {
                             parse_tsserver_diagnostics_body(
                                 &body,
-                                content.as_deref(),
+                                index.as_ref(),
                                 Some(file.as_str()),
                             )
                         })
@@ -5511,9 +5519,11 @@ pub fn parse_tsserver_location(
     };
 
     let (s, e) = if let Some(content) = content {
+        // One index serves both endpoints of the span.
+        let idx = SourceIndex::new_utf16(content);
         (
-            tsserver_pos_to_byte_offset(content, sl, so),
-            tsserver_pos_to_byte_offset(content, el, eo),
+            tsserver_pos_to_byte_offset_indexed(&idx, sl, so),
+            tsserver_pos_to_byte_offset_indexed(&idx, el, eo),
         )
     } else {
         // Fallback: store packed 0-based positions
@@ -5573,9 +5583,10 @@ pub fn parse_tsserver_rename_span(
     // would clamp it to a valid-looking EOF offset), and an inverted `start > end` span drops too.
     // The caller collects via `filter_map`, so a dropped span skips that one location, not the
     // whole rename.
-    let c = content?;
-    let s = tsserver_pos_to_byte_offset_checked(c, sl, so)?;
-    let e = tsserver_pos_to_byte_offset_checked(c, el, eo)?;
+    // One index serves both endpoints of the span.
+    let idx = SourceIndex::new_utf16(content?);
+    let s = tsserver_pos_to_byte_offset_checked(&idx, sl, so)?;
+    let e = tsserver_pos_to_byte_offset_checked(&idx, el, eo)?;
     if s > e {
         return None;
     }
@@ -5637,6 +5648,8 @@ fn parse_tsserver_file_code_edits(
             disk_content = std::fs::read_to_string(&file).ok();
             disk_content.as_deref()
         };
+        // One index per target file, shared by every edit landing in it.
+        let index = content.map(SourceIndex::new_utf16);
         if let Some(text_changes) = change.get("textChanges").and_then(|v| v.as_array()) {
             for tc in text_changes {
                 let start = tc.get("start")?;
@@ -5657,15 +5670,15 @@ fn parse_tsserver_file_code_edits(
 
                 // FAIL CLOSED: no content for this target → DROP the edit (never a packed sentinel
                 // that would write at a bogus byte offset).
-                let Some(c) = content else {
+                let Some(idx) = index.as_ref() else {
                     continue;
                 };
                 // FAIL CLOSED on an OUT-OF-RANGE position: the shared codec clamps a past-EOF
                 // line/col to a valid-looking offset, which for an EDIT would corrupt the file. The
                 // checked converter drops it instead. A malformed `start > end` also drops.
                 let (Some(s), Some(e)) = (
-                    tsserver_pos_to_byte_offset_checked(c, sl, so),
-                    tsserver_pos_to_byte_offset_checked(c, el, eo),
+                    tsserver_pos_to_byte_offset_checked(idx, sl, so),
+                    tsserver_pos_to_byte_offset_checked(idx, el, eo),
                 ) else {
                     continue;
                 };

--- a/crates/verter_type_runtime/src/tsserver/ipc.rs
+++ b/crates/verter_type_runtime/src/tsserver/ipc.rs
@@ -1793,19 +1793,21 @@ fn tsserver_pos_to_byte_offset_checked(
 /// contract's byte-offset representation.
 ///
 /// Both the managed-tsserver and extension-hosted decoders consume this shared
-/// owner. A missing content snapshot or malformed/out-of-range UTF-16 position
-/// drops the hint; packed line/column sentinels are forbidden because carrier
-/// sourcemap merging interprets [`InlayHint::position`] as a byte offset.
+/// owner. A missing index or malformed/out-of-range UTF-16 position drops the
+/// hint; packed line/column sentinels are forbidden because carrier sourcemap
+/// merging interprets [`InlayHint::position`] as a byte offset.
+///
+/// `index` is the caller's UTF-16 index over this file's content, built once for
+/// the hint batch — a per-hint rebuild would rescan the document for every hint.
 pub fn parse_tsserver_inlay_hint(
     hint: &serde_json::Value,
-    content: Option<&str>,
+    index: Option<&SourceIndex<'_>>,
 ) -> Option<InlayHint> {
     let text = hint.get("text")?.as_str()?.to_string();
     let pos = hint.get("position")?;
     let line = u32::try_from(pos.get("line")?.as_u64()?).ok()?;
     let offset = u32::try_from(pos.get("offset")?.as_u64()?).ok()?;
-    let position =
-        tsserver_pos_to_byte_offset_checked(&SourceIndex::new_utf16(content?), line, offset)?;
+    let position = tsserver_pos_to_byte_offset_checked(index?, line, offset)?;
 
     let kind = match hint.get("kind").and_then(|value| value.as_str()) {
         Some("Type") => Some(InlayHintKind::Type),
@@ -4837,15 +4839,15 @@ impl TypeProvider for TsserverTypeProvider {
                 )
                 .await;
 
+            // One index for the whole hint batch.
+            let index = content_snapshot.as_deref().map(SourceIndex::new_utf16);
             match result {
                 Ok(body) => {
                     let hints = body
                         .as_array()
                         .map(|arr| {
                             arr.iter()
-                                .filter_map(|hint| {
-                                    parse_tsserver_inlay_hint(hint, content_snapshot.as_deref())
-                                })
+                                .filter_map(|hint| parse_tsserver_inlay_hint(hint, index.as_ref()))
                                 .collect()
                         })
                         .unwrap_or_default();

--- a/crates/verter_type_runtime/src/tsserver/ipc.rs
+++ b/crates/verter_type_runtime/src/tsserver/ipc.rs
@@ -19,6 +19,7 @@ use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 use crate::codec::{
     line_column_to_offset_utf16, offset_to_line_column_utf16, LineColumn, SourceIndex,
 };
+use crate::contents_snapshot::{convert_per_target, with_target_index};
 use crate::protocol::*;
 use crate::traits::{ProviderFuture, TypeProvider};
 
@@ -1750,17 +1751,17 @@ fn tsserver_pos_to_byte_offset_indexed(idx: &SourceIndex<'_>, line: u32, offset:
 }
 
 /// Parse a tsserver wire position object (`{"line": L, "offset": C}`, 1-based)
-/// into a byte offset against `content`, failing CLOSED on a malformed or
+/// into a byte offset through `index`, failing CLOSED on a malformed or
 /// out-of-range position (the quickinfo hover range is display metadata — a
 /// clamped wrong offset would highlight the wrong span, so it is dropped).
 pub fn quickinfo_wire_pos_to_byte_offset(
-    content: &str,
+    index: &SourceIndex<'_>,
     pos: Option<&serde_json::Value>,
 ) -> Option<u32> {
     let pos = pos?;
     let line = u32::try_from(pos.get("line")?.as_u64()?).ok()?;
     let offset = u32::try_from(pos.get("offset")?.as_u64()?).ok()?;
-    tsserver_pos_to_byte_offset_checked(&SourceIndex::new_utf16(content), line, offset)
+    tsserver_pos_to_byte_offset_checked(index, line, offset)
 }
 
 /// Convert tsserver's 1-based (line, offset) to a byte offset, returning `None` when the position
@@ -3659,16 +3660,19 @@ impl TypeProvider for TsserverTypeProvider {
                             let (range_start, range_end) = {
                                 let cache = contents_cache.lock().await;
                                 match cache.get(&file) {
-                                    Some(content) => (
-                                        quickinfo_wire_pos_to_byte_offset(
-                                            content,
-                                            body.get("start"),
-                                        ),
-                                        quickinfo_wire_pos_to_byte_offset(
-                                            content,
-                                            body.get("end"),
-                                        ),
-                                    ),
+                                    Some(content) => {
+                                        let index = SourceIndex::new_utf16(content);
+                                        (
+                                            quickinfo_wire_pos_to_byte_offset(
+                                                &index,
+                                                body.get("start"),
+                                            ),
+                                            quickinfo_wire_pos_to_byte_offset(
+                                                &index,
+                                                body.get("end"),
+                                            ),
+                                        )
+                                    }
                                     None => (None, None),
                                 }
                             };
@@ -4123,11 +4127,7 @@ impl TypeProvider for TsserverTypeProvider {
                 let cache = contents_cache.lock().await;
                 result
                     .as_array()
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|loc| parse_tsserver_location(loc, &cache))
-                            .collect()
-                    })
+                    .map(|arr| parse_tsserver_locations(arr, &cache))
                     .unwrap_or_default()
             };
             for location in &mut locs {
@@ -4181,11 +4181,7 @@ impl TypeProvider for TsserverTypeProvider {
                 let cache = contents_cache.lock().await;
                 result
                     .as_array()
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|loc| parse_tsserver_location(loc, &cache))
-                            .collect()
-                    })
+                    .map(|arr| parse_tsserver_locations(arr, &cache))
                     .unwrap_or_default()
             };
             for location in &mut locs {
@@ -4236,11 +4232,7 @@ impl TypeProvider for TsserverTypeProvider {
                 result
                     .get("refs")
                     .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|loc| parse_tsserver_location(loc, &cache))
-                            .collect()
-                    })
+                    .map(|arr| parse_tsserver_locations(arr, &cache))
                     .unwrap_or_default()
             };
             for location in &mut locs {
@@ -4319,16 +4311,11 @@ impl TypeProvider for TsserverTypeProvider {
                                         .and_then(|v| v.as_str())
                                         .unwrap_or_default(),
                                 );
-                                group
+                                let spans = group
                                     .get("locs")
                                     .and_then(|v| v.as_array())
-                                    .into_iter()
-                                    .flat_map(move |spans| {
-                                        let fp = file_path.clone();
-                                        spans.iter().filter_map(move |span| {
-                                            parse_tsserver_rename_span(span, &fp, cache)
-                                        })
-                                    })
+                                    .map_or(&[][..], Vec::as_slice);
+                                parse_tsserver_rename_spans(spans, &file_path, cache)
                             })
                             .collect()
                     })
@@ -5491,20 +5478,52 @@ fn tsserver_completion_documentation(detail: &serde_json::Value) -> Option<Strin
     Some(combined)
 }
 
-/// Parse a tsserver location (used in definition/references responses).
+/// A response target's content: `contents_cache` first, then a disk read on a miss (a
+/// cross-file target the session never opened).
+fn cached_or_disk<'a>(
+    target: &str,
+    contents_cache: &'a HashMap<String, Arc<str>>,
+) -> Option<std::borrow::Cow<'a, str>> {
+    match contents_cache.get(target) {
+        Some(content) => Some(std::borrow::Cow::Borrowed(content.as_ref())),
+        None => std::fs::read_to_string(target)
+            .ok()
+            .map(std::borrow::Cow::Owned),
+    }
+}
+
+/// Parse a tsserver location batch (definition / references responses).
 ///
 /// tsserver locations have: `{ file, start: {line, offset}, end: {line, offset} }`
 /// where line and offset are 1-based, and offset counts UTF-16 code units.
 ///
-/// When content is available in `contents_cache`, positions are converted to proper
-/// byte offsets. Otherwise, falls back to packed 0-based `(line << 16) | col` format.
-pub fn parse_tsserver_location(
-    loc: &serde_json::Value,
+/// Each location converts against ITS OWN file's content — `contents_cache` first, then a disk
+/// read on a miss — and each distinct file resolves and indexes once for the whole batch. With
+/// content, positions become proper byte offsets; otherwise they fall back to packed 0-based
+/// `(line << 16) | col` format. Results keep the response order.
+pub fn parse_tsserver_locations(
+    locs: &[serde_json::Value],
     contents_cache: &HashMap<String, Arc<str>>,
+) -> Vec<TypeLocation> {
+    convert_per_target(
+        locs,
+        |loc| {
+            Some(verter_span::path::canonicalize_path(
+                loc.get("file").and_then(|v| v.as_str()).unwrap_or_default(),
+            ))
+        },
+        |file| cached_or_disk(file, contents_cache),
+        parse_tsserver_location,
+    )
+}
+
+/// One tsserver location in `file`, converted through that file's batch index (`None` when the
+/// file has no content: the packed fallback).
+fn parse_tsserver_location(
+    loc: &serde_json::Value,
+    file: &str,
+    index: Option<&SourceIndex<'_>>,
 ) -> Option<TypeLocation> {
-    let file = verter_span::path::canonicalize_path(
-        loc.get("file").and_then(|v| v.as_str()).unwrap_or_default(),
-    );
     let start = loc.get("start")?;
     let end = loc.get("end")?;
     let sl = start.get("line")?.as_u64()? as u32;
@@ -5512,20 +5531,10 @@ pub fn parse_tsserver_location(
     let el = end.get("line")?.as_u64()? as u32;
     let eo = end.get("offset")?.as_u64()? as u32;
 
-    let disk_content;
-    let content = if let Some(content) = contents_cache.get(&file) {
-        Some(content.as_ref())
-    } else {
-        disk_content = std::fs::read_to_string(&file).ok();
-        disk_content.as_deref()
-    };
-
-    let (s, e) = if let Some(content) = content {
-        // One index serves both endpoints of the span.
-        let idx = SourceIndex::new_utf16(content);
+    let (s, e) = if let Some(idx) = index {
         (
-            tsserver_pos_to_byte_offset_indexed(&idx, sl, so),
-            tsserver_pos_to_byte_offset_indexed(&idx, el, eo),
+            tsserver_pos_to_byte_offset_indexed(idx, sl, so),
+            tsserver_pos_to_byte_offset_indexed(idx, el, eo),
         )
     } else {
         // Fallback: store packed 0-based positions
@@ -5536,32 +5545,57 @@ pub fn parse_tsserver_location(
     };
 
     Some(TypeLocation {
-        path: file,
+        path: file.to_string(),
         start: s,
         end: e,
     })
 }
 
-/// Parse a tsserver rename span into a RenameLocation.
+/// Parse the spans a tsserver rename response groups under ONE `file` into RenameLocations.
 ///
-/// A tsserver rename response groups spans by file, so each span's REAL byte offset is into the
-/// GROUP's `file` — which may be a cross-file rename target the queried session never opened
-/// (e.g. an imported component's carrier or a `.ts` declaration). Resolve each span against THAT
-/// file's own content: the in-memory `contents_cache` first, then a per-target disk read on a
-/// cache miss — the SAME content-resolution [`parse_tsserver_location`] gives references /
-/// definition, and the tsgo rename path gives via `parse_range_to_offsets_strict_with_disk_fallback`.
+/// Each span's REAL byte offset is into the GROUP's `file` — which may be a cross-file rename
+/// target the queried session never opened (e.g. an imported component's carrier or a `.ts`
+/// declaration). Resolve the group against THAT file's own content, once for all of its spans:
+/// the in-memory `contents_cache` first, then a per-target disk read on a cache miss — the SAME
+/// content resolution [`parse_tsserver_locations`] gives references / definition and the tsgo
+/// rename path gives its workspace edits.
 ///
-/// The disk fallback recovers a cross-file target absent from the cache, so its rename edit lands
-/// at the real range instead of being dropped. FAIL CLOSED otherwise: when NEITHER cache nor disk
-/// has the content the span is DROPPED (returns `None`) — a rename location is a WRITE edit, so a
-/// packed `(line << 16) | col` sentinel applied at a bogus byte offset would CORRUPT the file. An
-/// out-of-range position (the shared codec would clamp it to EOF) and an inverted `start > end`
-/// span also drop. The caller collects via `filter_map`, so one dropped span never aborts the
+/// The disk fallback recovers a cross-file target absent from the cache, so its rename edits land
+/// at the real range instead of being dropped. FAIL CLOSED otherwise: a rename location is a WRITE
+/// edit — same corruption class as a code edit — so when NEITHER cache nor disk has the content
+/// every span of the group is DROPPED, never packed into a `(line << 16) | col` sentinel the merge
+/// layer would apply at a bogus byte offset. The checked converter additionally drops an
+/// out-of-range position (the shared codec would clamp it to a valid-looking EOF offset), and an
+/// inverted `start > end` span drops too; a dropped span skips only that one location, never the
 /// whole rename.
-pub fn parse_tsserver_rename_span(
-    span: &serde_json::Value,
+pub fn parse_tsserver_rename_spans(
+    spans: &[serde_json::Value],
     file: &str,
     contents_cache: &HashMap<String, Arc<str>>,
+) -> Vec<RenameLocation> {
+    if spans.is_empty() {
+        return Vec::new();
+    }
+    with_target_index(
+        file,
+        |file| cached_or_disk(file, contents_cache),
+        |index| {
+            let Some(index) = index else {
+                return Vec::new();
+            };
+            spans
+                .iter()
+                .filter_map(|span| parse_tsserver_rename_span(span, file, index))
+                .collect()
+        },
+    )
+}
+
+/// One tsserver rename span in `file`, converted through the group's index.
+fn parse_tsserver_rename_span(
+    span: &serde_json::Value,
+    file: &str,
+    index: &SourceIndex<'_>,
 ) -> Option<RenameLocation> {
     let start = span.get("start")?;
     let end = span.get("end")?;
@@ -5570,25 +5604,8 @@ pub fn parse_tsserver_rename_span(
     let el = u32::try_from(end.get("line")?.as_u64()?).ok()?;
     let eo = u32::try_from(end.get("offset")?.as_u64()?).ok()?;
 
-    let disk_content;
-    let content = if let Some(content) = contents_cache.get(file) {
-        Some(content.as_ref())
-    } else {
-        disk_content = std::fs::read_to_string(file).ok();
-        disk_content.as_deref()
-    };
-
-    // FAIL CLOSED: a rename location is a WRITE edit — same corruption class as a code edit. When the
-    // target content is unavailable (cache miss AND disk read fails) DROP the span — never pack a
-    // `(line << 16) | col` sentinel the merge layer would apply at a bogus byte offset and corrupt
-    // the file. The checked converter additionally drops an out-of-range position (the shared codec
-    // would clamp it to a valid-looking EOF offset), and an inverted `start > end` span drops too.
-    // The caller collects via `filter_map`, so a dropped span skips that one location, not the
-    // whole rename.
-    // One index serves both endpoints of the span.
-    let idx = SourceIndex::new_utf16(content?);
-    let s = tsserver_pos_to_byte_offset_checked(&idx, sl, so)?;
-    let e = tsserver_pos_to_byte_offset_checked(&idx, el, eo)?;
+    let s = tsserver_pos_to_byte_offset_checked(index, sl, so)?;
+    let e = tsserver_pos_to_byte_offset_checked(index, el, eo)?;
     if s > e {
         return None;
     }
@@ -5643,15 +5660,9 @@ fn parse_tsserver_file_code_edits(
                 .and_then(|v| v.as_str())
                 .unwrap_or_default(),
         );
-        let disk_content;
-        let content = if let Some(content) = contents_cache.get(&file) {
-            Some(content.as_ref())
-        } else {
-            disk_content = std::fs::read_to_string(&file).ok();
-            disk_content.as_deref()
-        };
         // One index per target file, shared by every edit landing in it.
-        let index = content.map(SourceIndex::new_utf16);
+        let content = cached_or_disk(&file, contents_cache);
+        let index = content.as_deref().map(SourceIndex::new_utf16);
         if let Some(text_changes) = change.get("textChanges").and_then(|v| v.as_array()) {
             for tc in text_changes {
                 let start = tc.get("start")?;

--- a/crates/verter_type_runtime/src/tsserver/ipc_tests.rs
+++ b/crates/verter_type_runtime/src/tsserver/ipc_tests.rs
@@ -802,31 +802,31 @@ fn test_format_quickinfo_hover_with_docs() {
 
 #[test]
 fn quickinfo_wire_pos_maps_to_byte_offset() {
-    let content = "const x = 1;\nconst y = 2;\n";
+    let index = SourceIndex::new_utf16("const x = 1;\nconst y = 2;\n");
     // tsserver positions are 1-based: line 2, offset 7 → byte 13 + 6.
     let pos = serde_json::json!({ "line": 2, "offset": 7 });
     assert_eq!(
-        quickinfo_wire_pos_to_byte_offset(content, Some(&pos)),
+        quickinfo_wire_pos_to_byte_offset(&index, Some(&pos)),
         Some(19)
     );
 }
 
 #[test]
 fn quickinfo_wire_pos_fails_closed_on_out_of_range_or_malformed() {
-    let content = "const x = 1;\n";
+    let index = SourceIndex::new_utf16("const x = 1;\n");
     let past_eof = serde_json::json!({ "line": 9, "offset": 1 });
     assert_eq!(
-        quickinfo_wire_pos_to_byte_offset(content, Some(&past_eof)),
+        quickinfo_wire_pos_to_byte_offset(&index, Some(&past_eof)),
         None,
         "a past-EOF wire position must be dropped, not clamped"
     );
     let malformed = serde_json::json!({ "line": 0, "offset": 0 });
     assert_eq!(
-        quickinfo_wire_pos_to_byte_offset(content, Some(&malformed)),
+        quickinfo_wire_pos_to_byte_offset(&index, Some(&malformed)),
         None,
         "a 0-based (malformed) tsserver position must be dropped"
     );
-    assert_eq!(quickinfo_wire_pos_to_byte_offset(content, None), None);
+    assert_eq!(quickinfo_wire_pos_to_byte_offset(&index, None), None);
 }
 
 // ---------------------------------------------------------------------------
@@ -891,6 +891,23 @@ fn kind_labeled_signature_is_idempotent_and_fails_closed() {
     );
 }
 
+/// One tsserver location through the batch parser.
+fn parse_one_tsserver_location(
+    loc: &serde_json::Value,
+    cache: &HashMap<String, Arc<str>>,
+) -> Option<TypeLocation> {
+    parse_tsserver_locations(std::slice::from_ref(loc), cache).pop()
+}
+
+/// One tsserver rename span through the per-file parser.
+fn parse_one_tsserver_rename_span(
+    span: &serde_json::Value,
+    file: &str,
+    cache: &HashMap<String, Arc<str>>,
+) -> Option<RenameLocation> {
+    parse_tsserver_rename_spans(std::slice::from_ref(span), file, cache).pop()
+}
+
 #[test]
 fn test_parse_tsserver_location_with_content() {
     let content = "const x = 1;\nconst y = 2;\nconst z = 3;";
@@ -903,7 +920,7 @@ fn test_parse_tsserver_location_with_content() {
         "end": { "line": 2, "offset": 8 },
     });
 
-    let parsed = parse_tsserver_location(&loc, &cache).unwrap();
+    let parsed = parse_one_tsserver_location(&loc, &cache).unwrap();
     assert_eq!(parsed.path, "d:/test/file.ts");
     // "y" is at byte 19 (line 2, col 7 in 1-based = byte 13 + 6 = 19)
     assert_eq!(parsed.start, 19, "start should be byte offset, not packed");
@@ -925,7 +942,7 @@ fn test_parse_tsserver_location_without_content() {
         "end": { "line": 2, "offset": 8 },
     });
 
-    let parsed = parse_tsserver_location(&loc, &cache).unwrap();
+    let parsed = parse_one_tsserver_location(&loc, &cache).unwrap();
     // Without content, should use packed fallback (0-based)
     let expected_start = ((2 - 1) << 16) | ((7 - 1) & 0xFFFF);
     assert_eq!(
@@ -950,7 +967,7 @@ fn test_parse_tsserver_location_line_10_not_packed() {
         "end": { "line": 10, "offset": 5 },
     });
 
-    let parsed = parse_tsserver_location(&loc, &cache).unwrap();
+    let parsed = parse_one_tsserver_location(&loc, &cache).unwrap();
     // With content, byte offset for line 10 should be reasonable (< 200 bytes)
     assert!(
         parsed.start < (10 << 16),
@@ -976,7 +993,7 @@ fn test_parse_tsserver_location_without_cache_reads_disk_content() {
         "end": { "line": 2, "offset": 8 },
     });
 
-    let parsed = parse_tsserver_location(&loc, &cache).unwrap();
+    let parsed = parse_one_tsserver_location(&loc, &cache).unwrap();
     assert_eq!(parsed.start, 27);
     assert_eq!(parsed.end, 32);
 
@@ -993,7 +1010,7 @@ fn test_parse_tsserver_rename_span_with_content() {
         "end": { "line": 2, "offset": 8 },
     });
 
-    let parsed = parse_tsserver_rename_span(&span, "d:/test/file.ts", &cache).unwrap();
+    let parsed = parse_one_tsserver_rename_span(&span, "d:/test/file.ts", &cache).unwrap();
     assert_eq!(parsed.start, 19, "start should be byte offset");
     assert_eq!(parsed.end, 20, "end should be byte offset");
     assert!(parsed.start < 100, "must not be packed");
@@ -1001,8 +1018,8 @@ fn test_parse_tsserver_rename_span_with_content() {
 
 /// A cross-file rename span whose GROUP file is absent from the in-memory contents cache must
 /// resolve its byte offsets against THAT file's own on-disk content (the per-target disk
-/// fallback) — the SAME content-resolution `parse_tsserver_location` gives references and the
-/// tsgo rename path gives via `parse_range_to_offsets_strict_with_disk_fallback`.
+/// fallback) — the SAME content resolution `parse_tsserver_locations` gives references and the
+/// tsgo rename path gives its workspace edits.
 ///
 /// Fails if a cache-miss span packs a 0-based `(line << 16) | col` sentinel the merge layer cannot
 /// map to a real range, silently dropping the cross-file edit (incomplete rename). The renamed
@@ -1026,7 +1043,7 @@ fn test_parse_tsserver_rename_span_without_cache_reads_disk_content() {
         "end": { "line": 3, "offset": 21 },
     });
 
-    let parsed = parse_tsserver_rename_span(&span, &file_key, &cache).unwrap();
+    let parsed = parse_one_tsserver_rename_span(&span, &file_key, &cache).unwrap();
     let want_start = content.find("renamed").unwrap() as u32;
     let want_end = want_start + "renamed".len() as u32;
     assert_eq!(
@@ -1068,7 +1085,7 @@ fn parse_tsserver_rename_span_drops_span_when_content_unavailable() {
     });
     let cache: HashMap<String, Arc<str>> = HashMap::new();
 
-    let parsed = parse_tsserver_rename_span(&span, &missing, &cache);
+    let parsed = parse_one_tsserver_rename_span(&span, &missing, &cache);
     assert!(
         parsed.is_none(),
         "a rename span whose content is unavailable must be DROPPED (fail-closed), never packed: \
@@ -1089,7 +1106,7 @@ fn parse_tsserver_rename_span_drops_out_of_range_position() {
         "end": { "line": 999, "offset": 4 },
     });
 
-    let parsed = parse_tsserver_rename_span(&span, "d:/proj/r.ts", &cache);
+    let parsed = parse_one_tsserver_rename_span(&span, "d:/proj/r.ts", &cache);
     assert!(
         parsed.is_none(),
         "an out-of-range rename span must be DROPPED, never clamped to EOF: {parsed:?}"
@@ -1115,7 +1132,7 @@ fn parse_tsserver_rename_span_drops_on_position_overflow() {
         "end": { "line": 1, "offset": 2 },
     });
 
-    let parsed = parse_tsserver_rename_span(&span, "d:/proj/r.ts", &cache);
+    let parsed = parse_one_tsserver_rename_span(&span, "d:/proj/r.ts", &cache);
     assert!(
         parsed.is_none(),
         "a u64>u32::MAX rename span must be DROPPED, never truncated into an in-range offset: \
@@ -1127,7 +1144,7 @@ fn parse_tsserver_rename_span_drops_on_position_overflow() {
         "start": { "line": 1, "offset": 1 },
         "end": { "line": 1, "offset": 2 },
     });
-    let ok = parse_tsserver_rename_span(&span_ok, "d:/proj/r.ts", &cache)
+    let ok = parse_one_tsserver_rename_span(&span_ok, "d:/proj/r.ts", &cache)
         .expect("an in-range rename span must still resolve");
     assert_eq!(
         (ok.start, ok.end),
@@ -1150,7 +1167,7 @@ fn test_parse_tsserver_location_non_ascii() {
         "end": { "line": 2, "offset": 6 },
     });
 
-    let parsed = parse_tsserver_location(&loc, &cache).unwrap();
+    let parsed = parse_one_tsserver_location(&loc, &cache).unwrap();
     // "café\n" = 6 bytes (c=1, a=1, f=1, é=2, \n=1)
     // "world" starts at byte 6
     assert_eq!(parsed.start, 6, "start of 'world' should be byte 6");

--- a/crates/verter_type_runtime/src/tsserver/ipc_tests.rs
+++ b/crates/verter_type_runtime/src/tsserver/ipc_tests.rs
@@ -5336,7 +5336,8 @@ fn inlay_hint_decoder_returns_byte_offsets_and_fails_closed_without_content() {
         "whitespaceBefore": true,
     });
 
-    let parsed = parse_tsserver_inlay_hint(&hint, Some(content)).expect("valid hint");
+    let parsed = parse_tsserver_inlay_hint(&hint, Some(&SourceIndex::new_utf16(content)))
+        .expect("valid hint");
     assert_eq!(
         parsed.position, 15,
         "line/offset is UTF-16 while the provider contract requires bytes"
@@ -5354,5 +5355,7 @@ fn inlay_hint_decoder_returns_byte_offsets_and_fails_closed_without_content() {
         "position": { "line": 200, "offset": 1 },
         "kind": "Type",
     });
-    assert!(parse_tsserver_inlay_hint(&out_of_range, Some(content)).is_none());
+    assert!(
+        parse_tsserver_inlay_hint(&out_of_range, Some(&SourceIndex::new_utf16(content))).is_none()
+    );
 }

--- a/crates/verter_type_runtime/src/tsserver/ipc_tests.rs
+++ b/crates/verter_type_runtime/src/tsserver/ipc_tests.rs
@@ -92,7 +92,7 @@ fn tsserver_checked_drops_mid_surrogate_column() {
     let content = "let x = '😀';";
     // 0-based col 10 == 1-based offset 11 lands on the trailing surrogate half of the emoji.
     assert_eq!(
-        tsserver_pos_to_byte_offset_checked(content, 1, 11),
+        tsserver_pos_to_byte_offset_checked(&SourceIndex::new_utf16(content), 1, 11),
         None,
         "a UTF-16 column inside an astral character is not a scalar boundary and must be dropped"
     );
@@ -102,7 +102,7 @@ fn tsserver_checked_drops_mid_surrogate_column() {
 fn tsserver_checked_accepts_position_after_astral() {
     let content = "let x = '😀';";
     // 0-based col 11 == 1-based offset 12 is the closing quote, immediately AFTER the emoji.
-    let off = tsserver_pos_to_byte_offset_checked(content, 1, 12)
+    let off = tsserver_pos_to_byte_offset_checked(&SourceIndex::new_utf16(content), 1, 12)
         .expect("the position immediately after an astral character is a valid scalar boundary");
     // `let x = '` is 9 bytes, `😀` is 4 UTF-8 bytes → byte offset 13 is the closing quote.
     assert_eq!(off, 13);
@@ -113,7 +113,7 @@ fn tsserver_checked_accepts_position_after_astral() {
 fn tsserver_checked_accepts_eol_insertion_on_astral_line() {
     let content = "let x = '😀';";
     // EOL insertion: 0-based col == line UTF-16 length (13) == 1-based offset 14.
-    let off = tsserver_pos_to_byte_offset_checked(content, 1, 14)
+    let off = tsserver_pos_to_byte_offset_checked(&SourceIndex::new_utf16(content), 1, 14)
         .expect("an end-of-line insertion position is a valid scalar boundary");
     assert_eq!(off as usize, content.len());
 }
@@ -129,7 +129,8 @@ fn test_parse_tsserver_diagnostic() {
         "category": "error"
     });
 
-    let parsed = parse_tsserver_diagnostic(&diag, Some(content), None).unwrap();
+    let parsed =
+        parse_tsserver_diagnostic(&diag, Some(&SourceIndex::new_utf16(content)), None).unwrap();
     assert_eq!(
         parsed.message,
         "Type 'number' is not assignable to type 'string'."
@@ -148,6 +149,56 @@ fn test_parse_tsserver_diagnostic() {
     );
 }
 
+/// A diagnostic pull resolves every diagnostic in every pass against ONE index
+/// built for the response batch. Sharing that index must be indistinguishable in
+/// the parsed result from indexing the source afresh for each diagnostic — the
+/// non-ASCII line is what would expose a stale or mis-encoded shared table.
+#[test]
+fn one_batch_index_parses_diagnostics_identically_to_per_diagnostic_indexing() {
+    let content = "const a😀b = 1;\nconst é: string = 42;\nconst z = 3;";
+    let batch = [
+        serde_json::json!({
+            "start": { "line": 1, "offset": 7 },
+            "end": { "line": 1, "offset": 11 },
+            "text": "first",
+            "code": 2322,
+            "category": "error"
+        }),
+        serde_json::json!({
+            "start": { "line": 2, "offset": 7 },
+            "end": { "line": 2, "offset": 13 },
+            "text": "second",
+            "code": 2322,
+            "category": "error"
+        }),
+        serde_json::json!({
+            "start": { "line": 3, "offset": 7 },
+            "end": { "line": 3, "offset": 8 },
+            "text": "third",
+            "code": 6133,
+            "category": "suggestion"
+        }),
+    ];
+
+    let shared = SourceIndex::new_utf16(content);
+    for diag in &batch {
+        let via_shared = parse_tsserver_diagnostic(diag, Some(&shared), None).unwrap();
+        let via_fresh =
+            parse_tsserver_diagnostic(diag, Some(&SourceIndex::new_utf16(content)), None).unwrap();
+        assert_eq!(
+            (via_shared.start, via_shared.end),
+            (via_fresh.start, via_fresh.end),
+            "shared-index offsets diverged for {}",
+            via_shared.message
+        );
+        // The offsets must be real byte offsets into the content, not packed
+        // line/column sentinels.
+        assert!(via_shared.start <= via_shared.end);
+        assert!(content.is_char_boundary(via_shared.start as usize));
+        assert!(content.is_char_boundary(via_shared.end as usize));
+    }
+}
+
 #[test]
 fn parse_tsserver_diagnostic_reads_reports_unnecessary_tag() {
     // tsserver flags unused-symbol suggestions (e.g. TS6133) with the
@@ -163,7 +214,8 @@ fn parse_tsserver_diagnostic_reads_reports_unnecessary_tag() {
         "reportsUnnecessary": true
     });
 
-    let parsed = parse_tsserver_diagnostic(&diag, Some(content), None).unwrap();
+    let parsed =
+        parse_tsserver_diagnostic(&diag, Some(&SourceIndex::new_utf16(content)), None).unwrap();
     assert_eq!(parsed.code, Some("6133".to_string()));
     assert_eq!(
         parsed.tags,
@@ -187,7 +239,8 @@ fn parse_tsserver_diagnostic_reads_reports_deprecated_tag() {
         "reportsDeprecated": true
     });
 
-    let parsed = parse_tsserver_diagnostic(&diag, Some(content), None).unwrap();
+    let parsed =
+        parse_tsserver_diagnostic(&diag, Some(&SourceIndex::new_utf16(content)), None).unwrap();
     assert_eq!(
         parsed.tags,
         vec![TypeDiagnosticTag::Deprecated],
@@ -209,7 +262,8 @@ fn parse_tsserver_diagnostic_without_tag_flags_stays_untagged() {
         "category": "suggestion"
     });
 
-    let parsed = parse_tsserver_diagnostic(&diag, Some(content), None).unwrap();
+    let parsed =
+        parse_tsserver_diagnostic(&diag, Some(&SourceIndex::new_utf16(content)), None).unwrap();
     assert!(
         parsed.tags.is_empty(),
         "no boolean flags ⇒ no tags, got: {:?}",
@@ -245,7 +299,12 @@ fn parse_tsserver_diagnostic_reads_same_file_related_information() {
         ]
     });
 
-    let parsed = parse_tsserver_diagnostic(&diag, Some(content), Some("/proj/dup.ts")).unwrap();
+    let parsed = parse_tsserver_diagnostic(
+        &diag,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/dup.ts"),
+    )
+    .unwrap();
     assert_eq!(
         parsed.related_information.len(),
         1,
@@ -276,7 +335,12 @@ fn parse_tsserver_diagnostic_without_related_information_is_empty() {
         "category": "error"
     });
 
-    let parsed = parse_tsserver_diagnostic(&diag, Some(content), Some("/proj/x.ts")).unwrap();
+    let parsed = parse_tsserver_diagnostic(
+        &diag,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/x.ts"),
+    )
+    .unwrap();
     assert!(
         parsed.related_information.is_empty(),
         "absent relatedInformation ⇒ empty list, got: {:?}",
@@ -317,7 +381,12 @@ fn parse_tsserver_diagnostic_drops_cross_file_related_without_content() {
         ]
     });
 
-    let parsed = parse_tsserver_diagnostic(&diag, Some(content), Some("/proj/a.ts")).unwrap();
+    let parsed = parse_tsserver_diagnostic(
+        &diag,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/a.ts"),
+    )
+    .unwrap();
     assert!(
         parsed.related_information.is_empty(),
         "a cross-file related span with no content for the related file must be \
@@ -362,7 +431,12 @@ fn parse_tsserver_related_never_stores_packed_position_anti_bogus_link() {
         ]
     });
 
-    let parsed = parse_tsserver_diagnostic(&diag, Some(content), Some("/proj/a.ts")).unwrap();
+    let parsed = parse_tsserver_diagnostic(
+        &diag,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/a.ts"),
+    )
+    .unwrap();
     // The exact packed value the pre-fix code would have stored for line 100 col 5.
     let packed = ((100u32 - 1) << 16) | ((5u32 - 1) & 0xFFFF);
     assert_eq!(
@@ -422,7 +496,12 @@ fn parse_tsserver_related_drops_same_file_out_of_range_offset() {
         ]
     });
 
-    let parsed = parse_tsserver_diagnostic(&diag, Some(content), Some("/proj/dup.ts")).unwrap();
+    let parsed = parse_tsserver_diagnostic(
+        &diag,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/dup.ts"),
+    )
+    .unwrap();
     // The primary diagnostic survives with its real in-range offsets.
     assert_eq!(parsed.start, 6, "primary start is a real in-range offset");
     assert_eq!(parsed.end, 9, "primary end is a real in-range offset");
@@ -487,7 +566,12 @@ fn parse_tsserver_related_drops_same_file_wrap_to_valid_coordinate() {
         ]
     });
 
-    let parsed = parse_tsserver_diagnostic(&diag, Some(content), Some("/proj/dup.ts")).unwrap();
+    let parsed = parse_tsserver_diagnostic(
+        &diag,
+        Some(&SourceIndex::new_utf16(content)),
+        Some("/proj/dup.ts"),
+    )
+    .unwrap();
     // The primary diagnostic survives with its real in-range offsets.
     assert_eq!(parsed.start, 6, "primary start is a real in-range offset");
     assert_eq!(parsed.end, 9, "primary end is a real in-range offset");

--- a/crates/verter_type_runtime/src/tsserver/mod.rs
+++ b/crates/verter_type_runtime/src/tsserver/mod.rs
@@ -12,8 +12,8 @@ pub use ipc::{
     completion_entry_details_to_resolve_result, concat_display_parts, dedup_error_codes,
     enrich_completion_with_entry_details, format_quickinfo_hover, merge_diagnostic_sets,
     parse_tsserver_code_action, parse_tsserver_combined_code_fix, parse_tsserver_completion,
-    parse_tsserver_diagnostic, parse_tsserver_inlay_hint, parse_tsserver_location,
-    parse_tsserver_rename_span, quickinfo_wire_pos_to_byte_offset,
+    parse_tsserver_diagnostic, parse_tsserver_inlay_hint, parse_tsserver_locations,
+    parse_tsserver_rename_spans, quickinfo_wire_pos_to_byte_offset,
     stamp_tsserver_completion_offset, tsserver_pos_to_byte_offset, AssembledSignatureLabel,
     TsserverTypeProvider, CHILD_PROCESS_ENV_DENYLIST,
 };

--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -382,7 +382,7 @@ schema = 2
 "SIMP4" = { status = "pending" }
 "SIMP5" = { status = "pending" }
 "SIMP6" = { status = "pending" }
-"SIMP7" = { status = "pending" }
+"SIMP7" = { status = "implemented", commit_message = "perf(lsp): reuse one source index per provider response batch", commit_date = "2026-09-10T12:00:00+01:00" }
 "SIMP8" = { status = "pending" }
 "SIMP9" = { status = "pending" }
 "SKL0" = { status = "pending" }


### PR DESCRIPTION
Coordinate conversion reuses state for the exact source snapshot or batch with fewer full-source scans and copies and unchanged encoding/range behavior.

Current problem: Diagnostic conversion builds and copies a full LineIndex per endpoint, potentially rebuilding the same source index 2D times for D diagnostics.

Final owner: **existing provider document snapshot and codec**. Read the binding [codebase simplification contract](../../contracts/codebase-simplification.md). This block owns one independently landable outcome; deletion and its evidence form one coherent change.

### Scope

- `crates/verter_type_runtime/src/codec.rs`
- `crates/verter_type_runtime/src/tsgo/ipc.rs`
- `crates/verter_type_runtime/src/tsserver/ipc.rs`

Bind LineIndex::new, position_to_offset_with_encoding, strict endpoint conversion and parse_lsp_diagnostic. Reuse an index per immutable source version or response batch through the existing document owner; borrow/share existing bytes as appropriate. Share only genuinely identical strict conversion logic, preserving different LSP/tsserver conventions.

Bind current paths/symbols before mutation. Keep distinct fixture behavior and isolated state; no universal test DSL. Source comments explain current non-obvious behavior, not roadmap history.

### Acceptance

- **SIMP7-AC1:** Identical source indexing is reused across response endpoints.
- **SIMP7-AC2:** Negotiated encodings, strict rejection and source-version/target identity remain correct.
- **SIMP7-AC3:** Source scans/copies decrease without another cache or unbounded retention.

Existing evidence to retain or extend: Codec/provider cases for UTF-8/UTF-16, surrogate boundaries, invalid edits, changed sources and target files; equivalent diagnostic batches measuring index builds and copied bytes.

A retired spelling, filename or prose convention needs no replacement test. A real uncovered behavioral boundary requires the smallest failing discriminating test before a behavior change. Compiler/type/capability evidence and bounded inspection are valid for non-behavioral changes; do not add scanner or mutation companions to populate acceptance IDs.

<!-- tama-workflow-publication:status:node_0mtt781ax0036mdrz:node-landing:1789057947160:publish#1:1 -->