### PR TITLE
refactor(core): delete the Svelte compatibility CarrierCompiler

### DIFF
--- a/crates/verter_compiler/src/framework_common/svelte_host_integration.rs
+++ b/crates/verter_compiler/src/framework_common/svelte_host_integration.rs
@@ -41,7 +41,7 @@ use super::catalog::{CatalogCapability, HostCap, TypedCapabilityRegistration};
 use super::registered_carrier_projection::{
     registered_projection_for, registered_semantic_for, TemplateFactsProduct,
 };
-use super::{CarrierCompiler, FrameworkParseArtifact, Present};
+use super::{FrameworkParseArtifact, Present};
 
 /// Svelte host-integration backend for the native host epoch.
 ///
@@ -1612,19 +1612,20 @@ mod tests {
         let artifact = svelte_artifact(COMPONENT);
         let alloc = oxc_allocator::Allocator::new();
         let before = host_backend_execution_count();
-        let outcome = SvelteCarrierCompiler
-            .compile_bundle(
-                COMPONENT,
-                &artifact,
-                &RuntimeCompileOptions::default(),
-                &alloc,
-            )
-            .expect("the compatibility route still compiles");
+        let opts = RuntimeCompileOptions::default();
+        let outcome = svelte_carrier_bundle(
+            COMPONENT,
+            &artifact,
+            &opts,
+            &alloc,
+            crate::framework_common::carrier_compiler::registry_route_execution_grants(&opts),
+        )
+        .expect("the shared bundle orchestration still compiles directly");
         assert!(matches!(outcome, CarrierCompileOutcome::Produced(_)));
         assert_eq!(
             host_backend_execution_count(),
             before,
-            "the generic production route must not execute the host backend"
+            "reaching the shared orchestration directly must not execute the host backend"
         );
 
         let admission = SvelteHostIntegrationBackend::new()

--- a/crates/verter_compiler/src/svelte/carrier.rs
+++ b/crates/verter_compiler/src/svelte/carrier.rs
@@ -2,8 +2,9 @@
 //!
 //! [`SvelteParseCarrier`] wraps [`ParsedSvelte`]. [`build_svelte_parse_artifact`]
 //! produces the unregistered artifact; the projector owns inventory
-//! geometry. [`SvelteCarrierCompiler`]: `parse` → neutral artifact;
-//! `compile_ide` projects IDE TSX.
+//! geometry. [`SvelteCarrierCompiler`]: `parse` → neutral artifact; the
+//! typed [`super::svelte_projection_backend::SvelteProjectionBackend`] and
+//! [`svelte_carrier_bundle`] drive IDE and runtime-bundle production.
 
 use std::any::Any;
 use std::sync::Arc;
@@ -27,9 +28,9 @@ use crate::compile_request::{
     SvelteCompileRequest,
 };
 use crate::framework_common::carrier_compiler::{
-    CarrierCompileOutcome, CarrierCompiler, CompileUnsupported, IdeCompileOptions, IdeOutput,
-    RuntimeCompileOptions, RuntimeCompileOutput, RuntimeDiagnostic, RuntimeDiagnosticSeverity,
-    RuntimeOutputDescriptor, SourceMapFidelity,
+    CarrierCompileOutcome, CompileUnsupported, IdeOutput, RuntimeCompileOptions,
+    RuntimeCompileOutput, RuntimeDiagnostic, RuntimeDiagnosticSeverity, RuntimeOutputDescriptor,
+    SourceMapFidelity,
 };
 use crate::framework_common::FrameworkParseArtifact;
 
@@ -222,7 +223,11 @@ pub fn build_svelte_parse_artifact(
     ))
 }
 
-/// The Svelte carrier compiler — the second [`CarrierCompiler`].
+/// The Svelte carrier compiler: parses source into the framework-neutral
+/// artifact and exposes the shared identity/downcast surface the typed
+/// Svelte backends ([`super::svelte_projection_backend::SvelteProjectionBackend`],
+/// [`super::svelte_runtime_backend::SvelteRuntimeBackend`], the Svelte
+/// host-integration backend) and frontend row build on.
 ///
 /// Reaches its parsed component back out of the type-erased artifact
 /// through its own inherent downcast — no capability token, since only
@@ -248,6 +253,76 @@ pub fn open_svelte_carrier(artifact: &FrameworkParseArtifact) -> Option<Arc<dyn 
 }
 
 impl SvelteCarrierCompiler {
+    /// The adapter id this compiler answers to (the registry key).
+    #[must_use]
+    pub fn adapter_id(&self) -> FrameworkAdapterId {
+        FrameworkAdapterId::svelte()
+    }
+
+    /// The carrier LANGUAGE id this compiler serves.
+    #[must_use]
+    pub fn carrier_language_id(&self) -> LanguageId {
+        LanguageId::new("svelte")
+    }
+
+    /// Parse carrier `source` into the framework-neutral artifact.
+    ///
+    /// Recoverable malformed syntax is NOT a rejection: the parser collects
+    /// diagnostics inline, so ordinary malformed input still returns `Ok`
+    /// with the problem recorded on the artifact's mapped diagnostic
+    /// channel. `Err(SyntaxReject)` is reserved for a request this frontend
+    /// cannot honor at all (an explicitly unsupported parse-option
+    /// combination) and is returned BEFORE any artifact is constructed.
+    pub fn parse(
+        &self,
+        source: &str,
+        opts: &ParseOptions,
+    ) -> Result<Arc<UnregisteredFrameworkParseArtifact>, SyntaxReject> {
+        let language = FileLanguage::svelte();
+        let syntax_profile = syntax_profile_id_for(&language, opts)
+            .expect("the built-in Svelte language has a syntax profile");
+        let parse_key = parse_key_for(
+            source,
+            &language,
+            SVELTE_SYNTAX_COMPATIBILITY_DOMAIN,
+            SVELTE_SYNTAX_COMPATIBILITY_EPOCH,
+            &syntax_profile,
+        )
+        .expect("the built-in Svelte language has a parse identity");
+        let syntax_profile = Arc::new(syntax_profile);
+        let parse_key = Arc::new(parse_key);
+        // Svelte's official `loose` parse mode is not implemented by this
+        // frontend (capability-matrix: `SVELTE-PARSE-LOCAL` is "strict
+        // parser diagnostics/recovery only; ... loose is unsupported
+        // fail-closed"). Reject before parsing — never silently downgrade
+        // to strict parsing.
+        if opts.svelte_loose {
+            return Err(SyntaxReject::UnsupportedProfile {
+                parse_key,
+                syntax_profile,
+                reason: verter_language::UnsupportedSyntaxProfileReason::UnsupportedOption,
+            });
+        }
+        // Every OTHER strict-parse / close-tag defect is a parser-owned
+        // RECOVERY point: the tokenizer is intentionally infallible and
+        // always produces a faithful tree, which is correct for the IDE
+        // projection (it owns its own error recovery) — see
+        // `SvelteStrictParseError`'s doc. Refusing publication here would
+        // make the carrier unusable for exactly the states an editor spends
+        // most of its time in (an unclosed `<script>` mid-typing, a stray
+        // close tag). The CLIENT-runtime "Verter emits a `Main` ⇔ official
+        // ACCEPTS" contract is enforced separately and later, at
+        // `official_reject_gate` (compile time) — never at this parse/publish
+        // seam.
+        let parsed = Arc::new(parse_svelte(source));
+        Ok(build_svelte_parse_artifact(
+            source,
+            parsed,
+            parse_key,
+            syntax_profile,
+        ))
+    }
+
     pub(crate) fn unregistered_carrier_arc(
         &self,
         artifact: &UnregisteredFrameworkParseArtifact,
@@ -339,122 +414,10 @@ fn svelte_ide_only_request(
     .map_err(CompileUnsupported::RequestExecutionRefused)
 }
 
-impl CarrierCompiler for SvelteCarrierCompiler {
-    fn adapter_id(&self) -> FrameworkAdapterId {
-        FrameworkAdapterId::svelte()
-    }
-
-    fn carrier_language_id(&self) -> LanguageId {
-        LanguageId::new("svelte")
-    }
-
-    fn parse(
-        &self,
-        source: &str,
-        opts: &ParseOptions,
-    ) -> Result<Arc<UnregisteredFrameworkParseArtifact>, SyntaxReject> {
-        let language = FileLanguage::svelte();
-        let syntax_profile = syntax_profile_id_for(&language, opts)
-            .expect("the built-in Svelte language has a syntax profile");
-        let parse_key = parse_key_for(
-            source,
-            &language,
-            SVELTE_SYNTAX_COMPATIBILITY_DOMAIN,
-            SVELTE_SYNTAX_COMPATIBILITY_EPOCH,
-            &syntax_profile,
-        )
-        .expect("the built-in Svelte language has a parse identity");
-        let syntax_profile = Arc::new(syntax_profile);
-        let parse_key = Arc::new(parse_key);
-        // Svelte's official `loose` parse mode is not implemented by this
-        // frontend (capability-matrix: `SVELTE-PARSE-LOCAL` is "strict
-        // parser diagnostics/recovery only; ... loose is unsupported
-        // fail-closed"). Reject before parsing — never silently downgrade
-        // to strict parsing.
-        if opts.svelte_loose {
-            return Err(SyntaxReject::UnsupportedProfile {
-                parse_key,
-                syntax_profile,
-                reason: verter_language::UnsupportedSyntaxProfileReason::UnsupportedOption,
-            });
-        }
-        // Every OTHER strict-parse / close-tag defect is a parser-owned
-        // RECOVERY point: the tokenizer is intentionally infallible and
-        // always produces a faithful tree, which is correct for the IDE
-        // projection (it owns its own error recovery) — see
-        // `SvelteStrictParseError`'s doc. Refusing publication here would
-        // make the carrier unusable for exactly the states an editor spends
-        // most of its time in (an unclosed `<script>` mid-typing, a stray
-        // close tag). The CLIENT-runtime "Verter emits a `Main` ⇔ official
-        // ACCEPTS" contract is enforced separately and later, at
-        // `official_reject_gate` (compile time) — never at this parse/publish
-        // seam.
-        let parsed = Arc::new(parse_svelte(source));
-        Ok(build_svelte_parse_artifact(
-            source,
-            parsed,
-            parse_key,
-            syntax_profile,
-        ))
-    }
-
-    fn compile_ide(
-        &self,
-        source: &str,
-        artifact: &FrameworkParseArtifact,
-        opts: &IdeCompileOptions,
-    ) -> Result<IdeOutput, CompileUnsupported> {
-        let request = svelte_ide_only_request(
-            opts.filename.clone(),
-            IdeProductRequest {
-                want_source_map: !opts.skip_source_map,
-                embed_ambient_types: opts.embed_ambient_types,
-                ..Default::default()
-            },
-        )?;
-        // This registry route carries no host-issued admission, so the
-        // projection grant is minted at the route boundary (crate-private
-        // mint); admission-issued flows carve theirs off the consumed
-        // admission instead.
-        let grant = crate::framework_common::capability::ProductExecutionGrant::mint(
-            crate::compile_request::ProductKind::IdeCompanion,
-        );
-        crate::framework_common::registered_carrier_projection::project_ide_from_catalog(
-            grant,
-            artifact,
-            source,
-            &request,
-            &crate::framework_common::registered_carrier_projection::ProjectionCatalogInputs {
-                block_content: opts.block_content.clone(),
-                ..Default::default()
-            },
-        )
-        .map(|companion| companion.ide)
-    }
-
-    fn compile_bundle(
-        &self,
-        source: &str,
-        artifact: &FrameworkParseArtifact,
-        opts: &RuntimeCompileOptions,
-        alloc: &oxc_allocator::Allocator,
-    ) -> Result<CarrierCompileOutcome, CompileUnsupported> {
-        svelte_carrier_bundle(
-            source,
-            artifact,
-            opts,
-            alloc,
-            crate::framework_common::carrier_compiler::registry_route_execution_grants(opts),
-        )
-    }
-}
-
 /// The one Svelte bundle orchestration over an admitted parse: ordered
 /// runtime, IDE-projection, and template-fact capability calls with shared
-/// prerequisites. Shared by the compatibility
-/// [`CarrierCompiler::compile_bundle`] route and the Svelte
-/// host-integration backend so both drive the identical single-population
-/// pass.
+/// prerequisites. Driven by the Svelte host-integration backend so every
+/// production caller shares the identical single-population pass.
 pub(crate) fn svelte_carrier_bundle(
     source: &str,
     artifact: &FrameworkParseArtifact,
@@ -626,15 +589,78 @@ pub(crate) fn svelte_carrier_bundle(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::framework_common::carrier_compiler::CompileBundleProducedExt;
     use crate::framework_common::sourcemap_e2e_helpers::{
         assert_token_maps_to_source, assert_token_maps_to_source_line, build_lookup_table,
         parse_ide_output,
     };
     use crate::framework_common::{
-        FrameworkSemanticAuthority, RuntimeBlockContentInput, RuntimeBlockContentInputs,
+        FrameworkSemanticAuthority, ProjectionBackend, RuntimeBlockContentInput,
+        RuntimeBlockContentInputs,
+    };
+    use crate::svelte::svelte_projection_backend::{
+        SvelteProjectionBackend, SvelteProjectionInputs,
     };
     use verter_language::ScriptRegionKind;
+
+    /// Test-only direct route onto the shared bundle orchestration, mirroring
+    /// the grant-minting the registry route used to perform — the same
+    /// production path `svelte_host_integration.rs` drives, called directly
+    /// rather than through a host admission.
+    fn compile_bundle_direct(
+        source: &str,
+        artifact: &FrameworkParseArtifact,
+        opts: &RuntimeCompileOptions,
+        alloc: &oxc_allocator::Allocator,
+    ) -> Result<CarrierCompileOutcome, CompileUnsupported> {
+        svelte_carrier_bundle(
+            source,
+            artifact,
+            opts,
+            alloc,
+            crate::framework_common::carrier_compiler::registry_route_execution_grants(opts),
+        )
+    }
+
+    /// Test-only convenience for fixtures whose carrier is known to PRODUCE —
+    /// mirrors the crate's `CompileBundleProducedExt`, over the free
+    /// [`compile_bundle_direct`] rather than a `CarrierCompiler` impl.
+    fn compile_bundle_expect_produced(
+        source: &str,
+        artifact: &FrameworkParseArtifact,
+        opts: &RuntimeCompileOptions,
+        alloc: &oxc_allocator::Allocator,
+    ) -> Result<RuntimeCompileOutput, CompileUnsupported> {
+        compile_bundle_direct(source, artifact, opts, alloc).map(|outcome| {
+            outcome
+                .into_produced()
+                .expect("this fixture's carrier produces a runtime surface")
+        })
+    }
+
+    /// Test-only direct route onto the typed IDE projection backend, for
+    /// fixtures that only need the projected companion (not a full host
+    /// admission).
+    fn project_ide_via_backend(
+        source: &str,
+        artifact: &FrameworkParseArtifact,
+        filename: Option<&str>,
+        want_source_map: bool,
+    ) -> Result<IdeOutput, crate::svelte::svelte_projection_backend::SvelteProjectionError> {
+        let request = svelte_ide_only_request(
+            filename.map(str::to_string),
+            IdeProductRequest {
+                want_source_map,
+                ..Default::default()
+            },
+        )
+        .expect("ide-only request constructs");
+        let grant = crate::framework_common::capability::ProductExecutionGrant::mint(
+            crate::compile_request::ProductKind::IdeCompanion,
+        );
+        SvelteProjectionBackend
+            .project_ide(grant, source, artifact, &request, &SvelteProjectionInputs)
+            .map(|companion| companion.ide)
+    }
 
     fn artifact_for(source: &str) -> Arc<FrameworkParseArtifact> {
         use verter_language::carrier_grammar::{
@@ -827,11 +853,10 @@ mod tests {
         // explicit request must fail closed with a typed refusal rather
         // than being silently ignored — mirrors `CompileRequest::new`'s
         // non-Vue `InlineSsrUnsupported` refusal.
-        let compiler = SvelteCarrierCompiler;
         let source = "<script>let count = $state(0);</script>\n<button onclick={() => count++}>{count}</button>\n";
         let artifact = artifact_for(source);
         let alloc = oxc_allocator::Allocator::default();
-        let result = compiler.compile_bundle(
+        let result = compile_bundle_direct(
             source,
             &artifact,
             &RuntimeCompileOptions {
@@ -861,12 +886,8 @@ mod tests {
         let artifact = artifact_for(source).remint_epoch_for_tests("unknown-epoch");
         let alloc = oxc_allocator::Allocator::default();
         let before = crate::standalone::runtime_backend_delegation_count();
-        let result = SvelteCarrierCompiler.compile_bundle(
-            source,
-            &artifact,
-            &RuntimeCompileOptions::default(),
-            &alloc,
-        );
+        let result =
+            compile_bundle_direct(source, &artifact, &RuntimeCompileOptions::default(), &alloc);
         assert!(
             matches!(
                 result,
@@ -889,20 +910,18 @@ mod tests {
         // Svelte runtime backend; the per-thread delegation counter is the
         // witness that no route-private runtime emitter remains. Refusal
         // classification travels through the same delegation.
-        let compiler = SvelteCarrierCompiler;
         let source = "<script>let count = $state(0);</script>\n<button onclick={() => count++}>{count}</button>\n";
         let artifact = artifact_for(source);
         let alloc = oxc_allocator::Allocator::default();
 
         let before = crate::standalone::runtime_backend_delegation_count();
-        compiler
-            .compile_bundle_expect_produced(
-                source,
-                &artifact,
-                &RuntimeCompileOptions::default(),
-                &alloc,
-            )
-            .expect("svelte runtime bundle");
+        compile_bundle_expect_produced(
+            source,
+            &artifact,
+            &RuntimeCompileOptions::default(),
+            &alloc,
+        )
+        .expect("svelte runtime bundle");
         assert_eq!(
             crate::standalone::runtime_backend_delegation_count(),
             before + 1,
@@ -914,14 +933,13 @@ mod tests {
             "<script>let c = $state(true);</script>\n{#snippet foo()}<p>{c}</p>{/snippet}\n";
         let refused_artifact = artifact_for(refused_source);
         let before_refused = crate::standalone::runtime_backend_delegation_count();
-        let outcome = compiler
-            .compile_bundle(
-                refused_source,
-                &refused_artifact,
-                &RuntimeCompileOptions::default(),
-                &alloc,
-            )
-            .expect("the outcome is produced-or-refused, never an Err");
+        let outcome = compile_bundle_direct(
+            refused_source,
+            &refused_artifact,
+            &RuntimeCompileOptions::default(),
+            &alloc,
+        )
+        .expect("the outcome is produced-or-refused, never an Err");
         assert!(
             matches!(outcome, CarrierCompileOutcome::RuntimeSurfaceRefused(_)),
             "the snippet component must refuse its runtime surface"
@@ -933,20 +951,19 @@ mod tests {
         );
 
         let before_ide_only = crate::standalone::runtime_backend_delegation_count();
-        compiler
-            .compile_bundle(
-                source,
-                &artifact,
-                &RuntimeCompileOptions {
-                    want_runtime: false,
-                    want_ide: true,
-                    ..Default::default()
-                },
-                &alloc,
-            )
-            .expect("the outcome is produced-or-refused, never an Err")
-            .into_produced()
-            .expect("an IDE-only request produces");
+        compile_bundle_direct(
+            source,
+            &artifact,
+            &RuntimeCompileOptions {
+                want_runtime: false,
+                want_ide: true,
+                ..Default::default()
+            },
+            &alloc,
+        )
+        .expect("the outcome is produced-or-refused, never an Err")
+        .into_produced()
+        .expect("an IDE-only request produces");
         assert_eq!(
             crate::standalone::runtime_backend_delegation_count(),
             before_ide_only,
@@ -959,18 +976,16 @@ mod tests {
         // A SUPPORTED runes component populates `main.body_code` (Svelte client JS)
         // so `has_runtime_surface()` becomes true. DISCRIMINATING: the body is the
         // client module, not empty.
-        let compiler = SvelteCarrierCompiler;
         let source = "<script>let count = $state(0);</script>\n<button onclick={() => count++}>{count}</button>\n";
         let artifact = artifact_for(source);
         let alloc = oxc_allocator::Allocator::default();
-        let bundle = compiler
-            .compile_bundle_expect_produced(
-                source,
-                &artifact,
-                &RuntimeCompileOptions::default(),
-                &alloc,
-            )
-            .expect("svelte runtime bundle");
+        let bundle = compile_bundle_expect_produced(
+            source,
+            &artifact,
+            &RuntimeCompileOptions::default(),
+            &alloc,
+        )
+        .expect("svelte runtime bundle");
         assert!(
             bundle.has_runtime_surface(),
             "a runes component must carry a runtime surface"
@@ -1000,18 +1015,16 @@ mod tests {
         // `$.prop` prop-source substrate (legacy base flags 8, accessor-call
         // reads) and the bundle carries a real Main — the former per-surface
         // export refusal is gone.
-        let compiler = SvelteCarrierCompiler;
         let source = "<script>export let label;</script>\n<p>{label}</p>\n";
         let artifact = artifact_for(source);
         let alloc = oxc_allocator::Allocator::default();
-        let bundle = compiler
-            .compile_bundle_expect_produced(
-                source,
-                &artifact,
-                &RuntimeCompileOptions::default(),
-                &alloc,
-            )
-            .expect("the bundle is produced");
+        let bundle = compile_bundle_expect_produced(
+            source,
+            &artifact,
+            &RuntimeCompileOptions::default(),
+            &alloc,
+        )
+        .expect("the bundle is produced");
         assert!(
             bundle.has_runtime_surface(),
             "a legacy export-let prop component compiles to a runtime surface"
@@ -1041,7 +1054,6 @@ mod tests {
 
     #[test]
     fn runtime_main_carries_the_demanded_client_source_map() {
-        let compiler = SvelteCarrierCompiler;
         // Keep the rune genuinely reactive: the runtime's supported-surface
         // classifier intentionally rejects a demoted/static interpolation.
         // The click write makes this a valid Main carrier and therefore a
@@ -1050,18 +1062,17 @@ mod tests {
 <button onclick={() => count += 1}>{count}</button>\n";
         let artifact = artifact_for(source);
         let alloc = oxc_allocator::Allocator::default();
-        let mapped = compiler
-            .compile_bundle_expect_produced(
-                source,
-                &artifact,
-                &RuntimeCompileOptions {
-                    filename: Some("src/Counter.svelte".to_string()),
-                    source_map: true,
-                    ..Default::default()
-                },
-                &alloc,
-            )
-            .expect("mapped Svelte runtime bundle");
+        let mapped = compile_bundle_expect_produced(
+            source,
+            &artifact,
+            &RuntimeCompileOptions {
+                filename: Some("src/Counter.svelte".to_string()),
+                source_map: true,
+                ..Default::default()
+            },
+            &alloc,
+        )
+        .expect("mapped Svelte runtime bundle");
         assert!(
             mapped.main.body_code.is_some(),
             "source-map demand must preserve the successful Main body; diagnostics: {:?}",
@@ -1082,18 +1093,17 @@ mod tests {
         assert_eq!(map.get_sources().collect::<Vec<_>>(), ["Counter.svelte"]);
         assert_eq!(map.get_source_content(0), Some(source));
 
-        let plain = compiler
-            .compile_bundle_expect_produced(
-                source,
-                &artifact,
-                &RuntimeCompileOptions {
-                    filename: Some("src/Counter.svelte".to_string()),
-                    source_map: false,
-                    ..Default::default()
-                },
-                &alloc,
-            )
-            .expect("plain Svelte runtime bundle");
+        let plain = compile_bundle_expect_produced(
+            source,
+            &artifact,
+            &RuntimeCompileOptions {
+                filename: Some("src/Counter.svelte".to_string()),
+                source_map: false,
+                ..Default::default()
+            },
+            &alloc,
+        )
+        .expect("plain Svelte runtime bundle");
         assert!(plain.main.source_map.is_empty(), "no demand, no main map");
         assert_eq!(
             mapped.main.body_code, plain.main.body_code,
@@ -1108,7 +1118,6 @@ mod tests {
         // `RuntimeCompileOptions.source_map` flag is the map demand — it
         // reaches the css RENDER through `compile_client`, and the produced
         // map + the `:global` fact ride the neutral style block.
-        let compiler = SvelteCarrierCompiler;
         let source = "<script>let c = $state(0);</script>\n<style>.r{color:red}\n:global(.x){margin:0}</style>\n<button class=\"r\" onclick={() => c++}>{c}</button>\n";
         let artifact = artifact_for(source);
         let alloc = oxc_allocator::Allocator::default();
@@ -1117,8 +1126,7 @@ mod tests {
             source_map: true,
             ..Default::default()
         };
-        let bundle = compiler
-            .compile_bundle_expect_produced(source, &artifact, &opts, &alloc)
+        let bundle = compile_bundle_expect_produced(source, &artifact, &opts, &alloc)
             .expect("svelte runtime bundle");
         let style = bundle.styles.first().expect("an external style block");
         assert!(
@@ -1143,8 +1151,7 @@ mod tests {
             filename: Some("App.svelte".to_string()),
             ..Default::default()
         };
-        let bundle_off = compiler
-            .compile_bundle_expect_produced(source, &artifact, &opts_off, &alloc)
+        let bundle_off = compile_bundle_expect_produced(source, &artifact, &opts_off, &alloc)
             .expect("svelte runtime bundle");
         assert_eq!(
             bundle_off.styles.first().expect("a style block").source_map,
@@ -1155,8 +1162,7 @@ mod tests {
         // A non-global component reports `has_global == false`.
         let non_global = "<script>let c = $state(0);</script>\n<style>.r{color:red}</style>\n<button class=\"r\" onclick={() => c++}>{c}</button>\n";
         let artifact2 = artifact_for(non_global);
-        let bundle2 = compiler
-            .compile_bundle_expect_produced(non_global, &artifact2, &opts, &alloc)
+        let bundle2 = compile_bundle_expect_produced(non_global, &artifact2, &opts, &alloc)
             .expect("svelte runtime bundle");
         assert!(
             !bundle2.styles.first().expect("a style block").has_global,
@@ -1171,7 +1177,6 @@ mod tests {
         // map: {...} }`. An EXISTING `<style>` block always publishes the external
         // artifact, even when the rendered `css.code` is empty; only the ABSENCE
         // of a style block publishes none (`compiled.css === null`).
-        let compiler = SvelteCarrierCompiler;
         let source = "<style></style><p>hi</p>\n";
         let artifact = artifact_for(source);
         let alloc = oxc_allocator::Allocator::default();
@@ -1180,8 +1185,7 @@ mod tests {
             source_map: true,
             ..Default::default()
         };
-        let bundle = compiler
-            .compile_bundle_expect_produced(source, &artifact, &opts, &alloc)
+        let bundle = compile_bundle_expect_produced(source, &artifact, &opts, &alloc)
             .expect("svelte runtime bundle");
         assert_eq!(
             bundle.styles.len(),
@@ -1206,9 +1210,9 @@ mod tests {
         // NEGATIVE: NO `<style>` block ⇒ NO artifact (official css === null).
         let source_none = "<p>hi</p>\n";
         let artifact_none = artifact_for(source_none);
-        let bundle_none = compiler
-            .compile_bundle_expect_produced(source_none, &artifact_none, &opts, &alloc)
-            .expect("svelte runtime bundle");
+        let bundle_none =
+            compile_bundle_expect_produced(source_none, &artifact_none, &opts, &alloc)
+                .expect("svelte runtime bundle");
         assert!(bundle_none.styles.is_empty(), "no style block, no artifact");
     }
 
@@ -1219,7 +1223,6 @@ mod tests {
         // there is NO bundle to hold a `tsx` beside it — the atomicity is
         // structural, not asserted over a flag. The precise reason travels on
         // the refusal itself, not recovered from diagnostic text.
-        let compiler = SvelteCarrierCompiler;
         // A `{#snippet}` declaration is an unsupported runtime surface — the
         // control-flow blocks (`{#if}`/…) ARE supported, so the refused example uses a
         // construct that genuinely still fails closed.
@@ -1233,8 +1236,7 @@ mod tests {
             want_ide: true,
             ..Default::default()
         };
-        let outcome = compiler
-            .compile_bundle(source, &artifact, &opts, &alloc)
+        let outcome = compile_bundle_direct(source, &artifact, &opts, &alloc)
             .expect("the outcome is produced-or-refused, never an Err");
 
         match outcome {
@@ -1266,7 +1268,6 @@ mod tests {
         // component, asked ONLY for its IDE product, attempts no runtime compile
         // and therefore cannot be refused one — it publishes its `tsx` normally.
         // Without this, "refuse everything" would satisfy the test above.
-        let compiler = SvelteCarrierCompiler;
         let source =
             "<script>let c = $state(true);</script>\n{#snippet foo()}<p>{c}</p>{/snippet}\n";
         let artifact = artifact_for(source);
@@ -1276,8 +1277,7 @@ mod tests {
             want_ide: true,
             ..Default::default()
         };
-        let bundle = compiler
-            .compile_bundle(source, &artifact, &opts, &alloc)
+        let bundle = compile_bundle_direct(source, &artifact, &opts, &alloc)
             .expect("the outcome is produced-or-refused, never an Err")
             .into_produced()
             .expect("an IDE-only request asks for no runtime product, so none can be refused");
@@ -1322,24 +1322,22 @@ mod tests {
         // The negative control: the same IDE-only identity on a WELL-FORMED
         // component reports no official-reject diagnostic, so the assertion above
         // discriminates malformed from clean rather than always finding one.
-        let compiler = SvelteCarrierCompiler;
         let source = "<script>let c = $state(0);</script>\n<div><span>hi</span></div>\n";
         let artifact = artifact_for(source);
         let alloc = oxc_allocator::Allocator::default();
-        let bundle = compiler
-            .compile_bundle(
-                source,
-                &artifact,
-                &RuntimeCompileOptions {
-                    want_runtime: false,
-                    want_ide: true,
-                    ..Default::default()
-                },
-                &alloc,
-            )
-            .expect("the outcome is produced-or-refused, never an Err")
-            .into_produced()
-            .expect("an IDE-only request cannot be refused a runtime surface");
+        let bundle = compile_bundle_direct(
+            source,
+            &artifact,
+            &RuntimeCompileOptions {
+                want_runtime: false,
+                want_ide: true,
+                ..Default::default()
+            },
+            &alloc,
+        )
+        .expect("the outcome is produced-or-refused, never an Err")
+        .into_produced()
+        .expect("an IDE-only request cannot be refused a runtime surface");
         assert!(
             !bundle
                 .diagnostics
@@ -1359,16 +1357,15 @@ mod tests {
     fn a_supported_component_produces_rather_than_refuses() {
         // The success direction: a SUPPORTED runes component takes the PRODUCED
         // arm and emits a Main, so the sum discriminates refusal from success.
-        let compiler = SvelteCarrierCompiler;
         let source =
             "<script>let c = $state(0);</script>\n<button onclick={() => c++}>{c}</button>\n";
         let artifact = artifact_for(source);
         let alloc = oxc_allocator::Allocator::default();
-        let bundle = compiler
-            .compile_bundle(source, &artifact, &RuntimeCompileOptions::default(), &alloc)
-            .expect("svelte runtime bundle")
-            .into_produced()
-            .expect("a supported component produces, it does not refuse");
+        let bundle =
+            compile_bundle_direct(source, &artifact, &RuntimeCompileOptions::default(), &alloc)
+                .expect("svelte runtime bundle")
+                .into_produced()
+                .expect("a supported component produces, it does not refuse");
         assert!(
             bundle.has_runtime_surface(),
             "a supported component carries a Main"
@@ -1380,19 +1377,10 @@ mod tests {
         // The sourcemap e2e (Tests #2): a script-region binding and a template
         // expression each map back to the matching ORIGINAL carrier text. The
         // unmapped prelude shifts no mapped position — the tokens still land.
-        let compiler = SvelteCarrierCompiler;
         let source =
             "<script lang=\"ts\">let myUniqueBinding = 0;</script>\n<div>{myUniqueBinding}</div>";
         let artifact = artifact_for(source);
-        let ide = compiler
-            .compile_ide(
-                source,
-                &artifact,
-                &IdeCompileOptions {
-                    filename: Some("Comp.svelte".to_string()),
-                    ..Default::default()
-                },
-            )
+        let ide = project_ide_via_backend(source, &artifact, Some("Comp.svelte"), true)
             .expect("svelte ide projection");
         let (code, sm) = parse_ide_output(&ide);
         let lookup = build_lookup_table(&sm);
@@ -1414,20 +1402,11 @@ mod tests {
         // token-precise). DISCRIMINATING: the params identifier `flyParam` is
         // unique to the directive value, so its mapped token can only come from
         // the original `transition:fly={flyParam}` position.
-        let compiler = SvelteCarrierCompiler;
         let source = "<script lang=\"ts\">import { fly } from \"svelte/transition\";\n\
              const flyParam = { delay: 0 };</script>\n\
              <div transition:fly={flyParam}>x</div>";
         let artifact = artifact_for(source);
-        let ide = compiler
-            .compile_ide(
-                source,
-                &artifact,
-                &IdeCompileOptions {
-                    filename: Some("Comp.svelte".to_string()),
-                    ..Default::default()
-                },
-            )
+        let ide = project_ide_via_backend(source, &artifact, Some("Comp.svelte"), true)
             .expect("svelte ide projection");
         let (code, sm) = parse_ide_output(&ide);
         let lookup = build_lookup_table(&sm);
@@ -1480,11 +1459,9 @@ mod tests {
 
     #[test]
     fn compile_ide_projects_a_tsx_artifact_with_the_pragma_prelude() {
-        let compiler = SvelteCarrierCompiler;
         let source = "<script lang=\"ts\">let a = 1;</script>\n<div>{a}</div>";
         let artifact = artifact_for(source);
-        let out = compiler
-            .compile_ide(source, &artifact, &IdeCompileOptions::default())
+        let out = project_ide_via_backend(source, &artifact, None, true)
             .expect("the Svelte IDE projection produces a TSX artifact");
         // A TypeScript `.svelte` projects `.tsx`.
         assert!(!out.is_jsx);
@@ -1502,7 +1479,6 @@ mod tests {
 
     #[test]
     fn compile_ide_projects_a_no_lang_component_as_valid_jsx_with_jsdoc() {
-        let compiler = SvelteCarrierCompiler;
         let source = r#"<script>
 /** @type {{ label: string }} */
 let { label } = $props();
@@ -1510,8 +1486,7 @@ let count = $state(0);
 </script>
 <button onclick={() => count += 1}>{label}: {count}</button>"#;
         let artifact = artifact_for(source);
-        let out = compiler
-            .compile_ide(source, &artifact, &IdeCompileOptions::default())
+        let out = project_ide_via_backend(source, &artifact, None, true)
             .expect("the Svelte IDE projection produces a JavaScript carrier");
 
         assert!(out.is_jsx, "a no-lang Svelte component must publish .jsx");
@@ -1537,12 +1512,11 @@ let count = $state(0);
 
     #[test]
     fn compile_ide_declines_a_foreign_artifact() {
-        let compiler = SvelteCarrierCompiler;
-        // A Vue-shaped artifact is not a Svelte carrier — the typed answer.
+        // A real foreign carrier's refusal is exercised by the shared
+        // contract tests. Here we assert the Svelte path succeeds on its
+        // own minimal artifact.
         let svelte = artifact_for("<div />");
-        // Re-wrap is unnecessary; a real foreign carrier is exercised by the
-        // shared contract tests. Here we assert the Svelte path succeeds.
-        let out = compiler.compile_ide("<div />", &svelte, &IdeCompileOptions::default());
+        let out = project_ide_via_backend("<div />", &svelte, None, true);
         assert!(out.is_ok());
     }
 
@@ -1568,8 +1542,7 @@ let count = $state(0);
             want_template_data: true,
             ..Default::default()
         };
-        let bundle = SvelteCarrierCompiler
-            .compile_bundle_expect_produced(source, &artifact, &opts, &alloc)
+        let bundle = compile_bundle_expect_produced(source, &artifact, &opts, &alloc)
             .expect("Svelte compile_bundle produces a bundle");
         let catalog =
             crate::framework_common::registered_carrier_projection::template_facts_from_catalog(
@@ -1594,8 +1567,7 @@ let count = $state(0);
         );
 
         let reminted = artifact.remint_epoch_for_tests("unknown-epoch");
-        let refused = SvelteCarrierCompiler
-            .compile_bundle_expect_produced(source, &reminted, &opts, &alloc)
+        let refused = compile_bundle_expect_produced(source, &reminted, &opts, &alloc)
             .expect("runtime/IDE-free compile still produces a bundle");
         assert!(
             refused.template_data.is_none(),
@@ -1637,14 +1609,13 @@ let count = $state(0);
         let artifact = artifact_for(source);
         let alloc = oxc_allocator::Allocator::default();
         let _ = crate::framework_common::registered_carrier_projection::take_template_facts_producer_invocations();
-        let bundle = SvelteCarrierCompiler
-            .compile_bundle_expect_produced(
-                source,
-                &artifact,
-                &template_facts_opts(Some("<Replacement />")),
-                &alloc,
-            )
-            .expect("Svelte compile_bundle produces a bundle");
+        let bundle = compile_bundle_expect_produced(
+            source,
+            &artifact,
+            &template_facts_opts(Some("<Replacement />")),
+            &alloc,
+        )
+        .expect("Svelte compile_bundle produces a bundle");
         assert!(
             bundle.template_data.is_none(),
             "selected bytes that replace the admitted markup must refuse facts, never publish the superseded <Button>"
@@ -1665,14 +1636,13 @@ let count = $state(0);
         let artifact = artifact_for(source);
         let alloc = oxc_allocator::Allocator::default();
         let _ = crate::framework_common::registered_carrier_projection::take_template_facts_producer_invocations();
-        let selected = SvelteCarrierCompiler
-            .compile_bundle_expect_produced(
-                source,
-                &artifact,
-                &template_facts_opts(Some("<Button size=\"sm\" bind:value />")),
-                &alloc,
-            )
-            .expect("Svelte compile_bundle produces a bundle");
+        let selected = compile_bundle_expect_produced(
+            source,
+            &artifact,
+            &template_facts_opts(Some("<Button size=\"sm\" bind:value />")),
+            &alloc,
+        )
+        .expect("Svelte compile_bundle produces a bundle");
         assert!(
             selected.template_data.is_none(),
             "selected template bytes cannot bind without an admitted template-host region"
@@ -1683,9 +1653,9 @@ let count = $state(0);
             "selected content without a template host must not invoke the semantic producer"
         );
 
-        let admitted = SvelteCarrierCompiler
-            .compile_bundle_expect_produced(source, &artifact, &template_facts_opts(None), &alloc)
-            .expect("Svelte compile_bundle produces a bundle");
+        let admitted =
+            compile_bundle_expect_produced(source, &artifact, &template_facts_opts(None), &alloc)
+                .expect("Svelte compile_bundle produces a bundle");
         let facts = admitted
             .template_data
             .as_ref()

--- a/crates/verter_compiler/src/svelte/carrier.rs
+++ b/crates/verter_compiler/src/svelte/carrier.rs
@@ -253,7 +253,8 @@ pub fn open_svelte_carrier(artifact: &FrameworkParseArtifact) -> Option<Arc<dyn 
 }
 
 impl SvelteCarrierCompiler {
-    /// The adapter id this compiler answers to (the registry key).
+    /// The adapter identity this compiler answers to in the immutable
+    /// capability catalog.
     #[must_use]
     pub fn adapter_id(&self) -> FrameworkAdapterId {
         FrameworkAdapterId::svelte()
@@ -532,8 +533,8 @@ pub(crate) fn svelte_carrier_bundle(
             opts.filename.clone(),
             IdeProductRequest {
                 // Per-leg override for a request-derived caller;
-                // `None` couples the IDE map to the runtime output
-                // axis (the compatibility route's historical behavior).
+                // `None` couples the IDE map demand to the runtime
+                // output axis.
                 want_source_map: opts.ide_source_map.unwrap_or(opts.source_map),
                 embed_ambient_types: opts.embed_ambient_types,
                 ..Default::default()
@@ -603,9 +604,9 @@ mod tests {
     use verter_language::ScriptRegionKind;
 
     /// Test-only direct route onto the shared bundle orchestration, mirroring
-    /// the grant-minting the registry route used to perform — the same
-    /// production path `svelte_host_integration.rs` drives, called directly
-    /// rather than through a host admission.
+    /// the grant-minting the registry-route grants helper performs — the
+    /// same production path `svelte_host_integration.rs` drives, called
+    /// directly rather than through a host admission.
     fn compile_bundle_direct(
         source: &str,
         artifact: &FrameworkParseArtifact,

--- a/crates/verter_compiler/src/svelte/carrier_frontend.rs
+++ b/crates/verter_compiler/src/svelte/carrier_frontend.rs
@@ -15,7 +15,6 @@ use verter_language::{
 
 use crate::framework_common::capability::{CarrierFrontend, FrameworkEpoch, Present};
 use crate::framework_common::catalog::{FrontendCap, TypedCapabilityRegistration};
-use crate::framework_common::CarrierCompiler;
 
 use super::carrier::SvelteCarrierCompiler;
 

--- a/crates/verter_compiler/src/svelte/mod.rs
+++ b/crates/verter_compiler/src/svelte/mod.rs
@@ -3,9 +3,10 @@
 //! This module owns the Svelte-specific compiler surface: the byte parser
 //! ([`parser`]) producing a [`parser::ParsedSvelte`], and the
 //! [`carrier::SvelteCarrierCompiler`] that lifts it into the framework-neutral
-//! [`FrameworkParseArtifact`](verter_compiler::framework_common::FrameworkParseArtifact) and
-//! drives the four [`CarrierCompiler`](crate::framework_common::CarrierCompiler)
-//! operations.
+//! [`FrameworkParseArtifact`](verter_compiler::framework_common::FrameworkParseArtifact).
+//! The typed [`svelte_projection_backend::SvelteProjectionBackend`] and
+//! [`svelte_runtime_backend::SvelteRuntimeBackend`] drive IDE projection and
+//! runtime-bundle production over that artifact.
 //!
 //! It performs NO type lowering (the thin-adapters guard). The IDE TSX
 //! projection ([`ide`]) is a pure syntactic transform via `CodeTransform` —

--- a/crates/verter_compiler/src/svelte/semantic_authority.rs
+++ b/crates/verter_compiler/src/svelte/semantic_authority.rs
@@ -12,7 +12,6 @@ use crate::compile::RawTemplateData;
 use crate::framework_common::capability::{FrameworkSemanticAuthority, Present};
 use crate::framework_common::catalog::{SemanticCap, TypedCapabilityRegistration};
 use crate::framework_common::registered_carrier_projection::TemplateFactsProduct;
-use crate::framework_common::CarrierCompiler;
 use crate::framework_common::FrameworkParseArtifact;
 use crate::svelte::carrier::SvelteParseCarrier;
 

--- a/crates/verter_compiler/src/svelte/svelte_projection_backend.rs
+++ b/crates/verter_compiler/src/svelte/svelte_projection_backend.rs
@@ -15,7 +15,7 @@ use crate::framework_common::carrier_compiler::{
     CompileUnsupported, IdeOutput, RuntimeOutputDescriptor,
 };
 use crate::framework_common::catalog::{ProjectionCap, TypedCapabilityRegistration};
-use crate::framework_common::{CarrierCompiler, FrameworkParseArtifact};
+use crate::framework_common::FrameworkParseArtifact;
 use crate::standalone::{DirectCompileError, StandaloneCompiler};
 use crate::svelte::ide::SvelteIdeUnsupportedDiagnostic;
 

--- a/crates/verter_compiler/src/svelte/svelte_runtime_backend.rs
+++ b/crates/verter_compiler/src/svelte/svelte_runtime_backend.rs
@@ -14,7 +14,7 @@ use crate::assembly::AssembledArtifact;
 use crate::compile_request::{CompileRequest, ProductKind};
 use crate::framework_common::capability::{Present, RuntimeCompilerBackend};
 use crate::framework_common::catalog::{RuntimeCap, TypedCapabilityRegistration};
-use crate::framework_common::{CarrierCompiler, FrameworkParseArtifact};
+use crate::framework_common::FrameworkParseArtifact;
 use crate::standalone::{
     DirectCompileError, DirectCompileOutput, StandaloneCompiler, SvelteExecutionInputs,
 };

--- a/crates/verter_compiler/tests/cases/projection_catalog.rs
+++ b/crates/verter_compiler/tests/cases/projection_catalog.rs
@@ -1,6 +1,7 @@
 //! Route-boundary evidence that Vue/Svelte IDE projection is selected from
-//! the built-in catalog (adapter × epoch × Projection) and that combined
-//! compile_ide / compile_bundle IDE products delegate to that backend.
+//! the built-in catalog (adapter × epoch × Projection) and that Vue's
+//! combined compile_ide / compile_bundle IDE products delegate to that
+//! backend.
 
 use std::sync::Arc;
 
@@ -20,9 +21,7 @@ use verter_compiler::framework_common::{
     FrameworkParseArtifact, IdeCompileOptions, ProjectionBackend, RuntimeCompileOptions,
     RuntimeDiagnostic, VueProjectionBackend, VueProjectionInputs,
 };
-use verter_compiler::svelte::{
-    SvelteCarrierCompiler, SvelteProjectionBackend, SvelteProjectionInputs,
-};
+use verter_compiler::svelte::{SvelteProjectionBackend, SvelteProjectionInputs};
 use verter_language::carrier_grammar::{
     CarrierGrammarAuthority, CarrierGrammarConfig, CarrierParserGrammarVersion,
     FrameworkAdapterSemanticVersion,
@@ -340,37 +339,6 @@ fn vue_compile_ide_delegates_to_the_catalog_backend_once() {
 }
 
 #[test]
-fn svelte_compile_ide_delegates_to_the_catalog_backend_once() {
-    let artifact = registered_artifact("file:///ide.svelte", SVELTE_SIMPLE, true);
-    let opts = IdeCompileOptions {
-        filename: Some("Ide.svelte".to_string()),
-        ..Default::default()
-    };
-    let request = svelte_ide_request("Ide.svelte");
-    let via_backend = SvelteProjectionBackend
-        .project_ide(
-            ide_grant(),
-            SVELTE_SIMPLE,
-            &artifact,
-            &request,
-            &SvelteProjectionInputs,
-        )
-        .expect("svelte backend");
-    let _ = take_projection_producer_invocations();
-    let via_compile_ide = SvelteCarrierCompiler
-        .compile_ide(SVELTE_SIMPLE, &artifact, &opts)
-        .expect("compile_ide");
-    assert_eq!(
-        take_projection_producer_invocations(),
-        1,
-        "compile_ide must project through the catalog once"
-    );
-    assert_eq!(via_compile_ide.code, via_backend.ide.code);
-    assert_eq!(via_compile_ide.source_map, via_backend.ide.source_map);
-    assert_eq!(via_compile_ide.is_jsx, via_backend.ide.is_jsx);
-}
-
-#[test]
 fn vue_compile_bundle_ide_product_delegates_to_the_catalog_backend_once() {
     let artifact = registered_artifact("file:///bundle.vue", VUE_SIMPLE, false);
     let request = vue_ide_request("Bundle.vue");
@@ -394,43 +362,6 @@ fn vue_compile_bundle_ide_product_delegates_to_the_catalog_backend_once() {
         &artifact,
         &RuntimeCompileOptions {
             filename: Some("Bundle.vue".to_string()),
-            source_map: true,
-            want_runtime: false,
-            want_ide: true,
-            ..Default::default()
-        },
-    );
-    assert_eq!(
-        take_projection_producer_invocations(),
-        1,
-        "the combined adapter must project its IDE product through the catalog once"
-    );
-    let tsx = bundle.tsx.expect("IDE product present");
-    assert_eq!(tsx.code, via_backend.ide.code);
-    assert_eq!(tsx.source_map, via_backend.ide.source_map);
-    assert_eq!(tsx.is_jsx, via_backend.ide.is_jsx);
-}
-
-#[test]
-fn svelte_compile_bundle_ide_product_delegates_to_the_catalog_backend_once() {
-    let artifact = registered_artifact("file:///bundle.svelte", SVELTE_SIMPLE, true);
-    let request = svelte_ide_request("Bundle.svelte");
-    let via_backend = SvelteProjectionBackend
-        .project_ide(
-            ide_grant(),
-            SVELTE_SIMPLE,
-            &artifact,
-            &request,
-            &SvelteProjectionInputs,
-        )
-        .expect("svelte backend");
-    let _ = take_projection_producer_invocations();
-    let bundle = produced_bundle(
-        &SvelteCarrierCompiler,
-        SVELTE_SIMPLE,
-        &artifact,
-        &RuntimeCompileOptions {
-            filename: Some("Bundle.svelte".to_string()),
             source_map: true,
             want_runtime: false,
             want_ide: true,

--- a/crates/verter_compiler/tests/cases/svelte_carrier_frontend.rs
+++ b/crates/verter_compiler/tests/cases/svelte_carrier_frontend.rs
@@ -5,8 +5,7 @@
 use std::sync::Arc;
 
 use verter_compiler::framework_common::{
-    CarrierCompiler, CarrierFrontend, CatalogCapability, CatalogRow, FrameworkEpoch,
-    ImmutableCapabilityCatalog,
+    CarrierFrontend, CatalogCapability, CatalogRow, FrameworkEpoch, ImmutableCapabilityCatalog,
 };
 use verter_compiler::svelte::{
     svelte_carrier_frontend_registration, SvelteCarrierCompiler, SvelteCarrierFrontend, SvelteSfc5,

--- a/crates/verter_compiler/tests/cases/svelte_carrier_parse_rejection.rs
+++ b/crates/verter_compiler/tests/cases/svelte_carrier_parse_rejection.rs
@@ -1,4 +1,3 @@
-use verter_compiler::framework_common::CarrierCompiler;
 use verter_compiler::svelte::runtime::{compile_client, ClientCompileError, SvelteRuntimeOptions};
 use verter_compiler::svelte::{parse_svelte, SvelteCarrierCompiler};
 use verter_language::{ParseOptions, SyntaxReject};

--- a/crates/verter_compiler/tests/cases/svelte_carrier_runtime_compile_options_channel.rs
+++ b/crates/verter_compiler/tests/cases/svelte_carrier_runtime_compile_options_channel.rs
@@ -1,22 +1,27 @@
 //! Characterization test for the `RuntimeCompileOptions` -> `SvelteRuntimeOptions`
-//! plumbing gap: `SvelteCarrierCompiler::compile_bundle` used to hardcode
+//! plumbing gap: the shared Svelte bundle orchestration used to hardcode
 //! `runes` / `dev_codegen` / `namespace` / `fragments` / `preserve_whitespace` /
 //! `preserve_comments` / `disclose_version` to `None`/`false` regardless of what
 //! the neutral carrier's `RuntimeCompileOptions` carried — so a caller could
 //! never reach these already-implemented, already-tested (at the
 //! `SvelteRuntimeOptions` level — see `runtime_tests.rs`'s
 //! `fixture_runtime_options`) Svelte compile options through any production
-//! route. This test exercises the CARRIER-LEVEL channel specifically: it
-//! would FAIL against the pre-fix carrier (which ignored `svelte_fragments` /
+//! route. This test exercises the CARRIER-LEVEL channel specifically, through
+//! the host-backed production lane (`SvelteHostIntegrationBackend`), which
+//! derives `RuntimeCompileOptions` off the admitted request: it would FAIL
+//! against the pre-fix carrier (which ignored `svelte_fragments` /
 //! `svelte_preserve_comments` entirely) and PASSES now that the channel
 //! threads through.
 
 use oxc_allocator::Allocator;
 use std::sync::Arc;
-use verter_compiler::framework_common::carrier_compiler::{CarrierCompiler, RuntimeCompileOptions};
+use verter_compiler::compile_request::svelte::SvelteFragmentsRequest;
+use verter_compiler::compile_request::SvelteOptionAttempt;
 use verter_compiler::framework_common::registered_carrier_projection::project_registered_accepted;
-use verter_compiler::framework_common::FrameworkParseArtifact;
-use verter_compiler::svelte::SvelteCarrierCompiler;
+use verter_compiler::framework_common::{
+    FrameworkHostIntegrationBackend as _, FrameworkParseArtifact, SvelteHostExecutionInputs,
+    SvelteHostIntegrationBackend, SvelteHostRuntimeRenderDemand,
+};
 use verter_language::carrier_grammar::{
     CarrierGrammarAuthority, CarrierGrammarConfig, CarrierParserGrammarVersion,
     FrameworkAdapterSemanticVersion,
@@ -55,16 +60,33 @@ fn registered_artifact(canonical: &str, source: &str) -> FrameworkParseArtifact 
         .into_framework_parse_artifact()
 }
 
-fn compile_body(canonical: &str, source: &str, opts: RuntimeCompileOptions) -> String {
-    let compiler = SvelteCarrierCompiler;
+fn compile_body(canonical: &str, source: &str, svelte_options: SvelteOptionAttempt) -> String {
     let artifact = registered_artifact(canonical, source);
     let alloc = Allocator::default();
-    let outcome = compiler
-        .compile_bundle(source, &artifact, &opts, &alloc)
+    let backend = SvelteHostIntegrationBackend::registered();
+    let admission = backend
+        .admit_runtime_render(
+            &artifact,
+            SvelteHostRuntimeRenderDemand {
+                svelte_options,
+                filename: Some(canonical.to_string()),
+                ..Default::default()
+            },
+        )
+        .expect("fixture demand admits");
+    let rendered = backend
+        .compile_runtime_render(
+            admission,
+            &artifact,
+            &SvelteHostExecutionInputs::default(),
+            &alloc,
+        )
         .expect("fixture source must compile");
-    outcome
-        .into_produced()
-        .and_then(|bundle| bundle.main.body_code)
+    rendered
+        .runtime_bundle()
+        .main
+        .body_code
+        .clone()
         .expect("a two-root static template must produce a runtime body")
 }
 
@@ -79,7 +101,7 @@ fn svelte_fragments_tree_reaches_codegen_through_the_neutral_carrier() {
     let default_body = compile_body(
         "file:///FragmentsDefault.svelte",
         SOURCE,
-        RuntimeCompileOptions::default(),
+        SvelteOptionAttempt::default(),
     );
     assert!(
         !default_body.contains("$.from_tree"),
@@ -87,9 +109,9 @@ fn svelte_fragments_tree_reaches_codegen_through_the_neutral_carrier() {
          default `$.from_html` skeleton, not `$.from_tree` — got:\n{default_body}"
     );
 
-    let tree_opts = RuntimeCompileOptions {
-        svelte_fragments: Some("tree".to_string()),
-        ..RuntimeCompileOptions::default()
+    let tree_opts = SvelteOptionAttempt {
+        fragments: Some(SvelteFragmentsRequest::Tree),
+        ..SvelteOptionAttempt::default()
     };
     let tree_body = compile_body("file:///FragmentsTree.svelte", SOURCE, tree_opts);
     assert!(
@@ -111,16 +133,16 @@ fn svelte_preserve_comments_reaches_codegen_through_the_neutral_carrier() {
     let default_out = compile_body(
         "file:///CommentsDefault.svelte",
         SOURCE_WITH_COMMENT,
-        RuntimeCompileOptions::default(),
+        SvelteOptionAttempt::default(),
     );
     assert!(
         !default_out.contains("kept"),
         "default (svelte_preserve_comments: None) must drop the HTML comment — got:\n{default_out}"
     );
 
-    let preserved_opts = RuntimeCompileOptions {
-        svelte_preserve_comments: Some(true),
-        ..RuntimeCompileOptions::default()
+    let preserved_opts = SvelteOptionAttempt {
+        preserve_comments: Some(true),
+        ..SvelteOptionAttempt::default()
     };
     let preserved_out = compile_body(
         "file:///CommentsPreserved.svelte",

--- a/crates/verter_compiler/tests/cases/svelte_projection_backend.rs
+++ b/crates/verter_compiler/tests/cases/svelte_projection_backend.rs
@@ -1,5 +1,5 @@
 //! Svelte IDE `ProjectionBackend`: parse-artifact projection, catalog identity,
-//! byte/map parity with `compile_ide`, IDE-only refusal, and determinism.
+//! IDE-only refusal, and determinism.
 
 use std::sync::Arc;
 
@@ -9,13 +9,12 @@ use verter_compiler::compile_request::{
     IdeProductRequest, ProductKind, RuntimeProductRequest, SvelteCompileRequest,
 };
 use verter_compiler::framework_common::{
-    CarrierCompiler, CatalogCapability, CatalogRow, CompileUnsupported, FrameworkEpoch,
-    FrameworkParseArtifact, IdeCompileOptions, ImmutableCapabilityCatalog, ProjectionBackend,
-    RuntimeOutputDescriptor,
+    CatalogCapability, CatalogRow, CompileUnsupported, FrameworkEpoch, FrameworkParseArtifact,
+    ImmutableCapabilityCatalog, ProjectionBackend, RuntimeOutputDescriptor,
 };
 use verter_compiler::svelte::{
-    svelte_projection_backend_registration, SvelteCarrierCompiler, SvelteProjectionBackend,
-    SvelteProjectionError, SvelteProjectionInputs, SvelteSfc5,
+    svelte_projection_backend_registration, SvelteProjectionBackend, SvelteProjectionError,
+    SvelteProjectionInputs, SvelteSfc5,
 };
 use verter_language::carrier_grammar::{
     CarrierGrammarAuthority, CarrierGrammarConfig, CarrierParserGrammarVersion,
@@ -162,16 +161,9 @@ fn svelte_projection_catalog_row_binds_svelte_adapter_identity() {
 }
 
 #[test]
-fn svelte_ide_projection_matches_compile_ide_on_kitchen_sink() {
+fn svelte_ide_projection_produces_a_jsx_artifact_for_the_kitchen_sink() {
     let artifact = svelte_artifact("file:///kitchen.svelte", KITCHEN_SINK);
-    let opts = IdeCompileOptions {
-        filename: Some("Kitchen.svelte".to_string()),
-        ..Default::default()
-    };
-    let via_compile_ide = SvelteCarrierCompiler
-        .compile_ide(KITCHEN_SINK, &artifact, &opts)
-        .expect("compile_ide kitchen sink");
-    let request = ide_only_request("Kitchen.svelte", !opts.skip_source_map);
+    let request = ide_only_request("Kitchen.svelte", true);
     let via_backend = SvelteProjectionBackend
         .project_ide(
             ide_grant(),
@@ -181,34 +173,14 @@ fn svelte_ide_projection_matches_compile_ide_on_kitchen_sink() {
             &SvelteProjectionInputs,
         )
         .expect("projection backend");
-    assert_eq!(via_backend.ide.code, via_compile_ide.code);
-    assert_eq!(via_backend.ide.source_map, via_compile_ide.source_map);
-    assert_eq!(via_backend.ide.is_jsx, via_compile_ide.is_jsx);
-    assert_eq!(
-        via_backend
-            .ide
-            .output_descriptor
-            .source_map
-            .declared_space_tokens,
-        via_compile_ide
-            .output_descriptor
-            .source_map
-            .declared_space_tokens
-    );
     assert!(via_backend.ide.is_jsx);
     assert!(!via_backend.ide.code.is_empty());
+    assert!(!via_backend.ide.source_map.is_empty());
 }
 
 #[test]
-fn svelte_ide_projection_matches_compile_ide_on_a_typescript_carrier() {
+fn svelte_ide_projection_produces_a_tsx_artifact_for_a_typescript_carrier() {
     let artifact = svelte_artifact("file:///simple.svelte", SIMPLE);
-    let opts = IdeCompileOptions {
-        filename: Some("Simple.svelte".to_string()),
-        ..Default::default()
-    };
-    let via_compile_ide = SvelteCarrierCompiler
-        .compile_ide(SIMPLE, &artifact, &opts)
-        .expect("compile_ide simple");
     let via_backend = SvelteProjectionBackend
         .project_ide(
             ide_grant(),
@@ -218,19 +190,26 @@ fn svelte_ide_projection_matches_compile_ide_on_a_typescript_carrier() {
             &SvelteProjectionInputs,
         )
         .expect("projection backend");
-    assert_eq!(via_backend.ide.code, via_compile_ide.code);
-    assert_eq!(via_backend.ide.source_map, via_compile_ide.source_map);
     assert!(!via_backend.ide.is_jsx);
+    assert!(!via_backend.ide.code.is_empty());
+    assert!(!via_backend.ide.source_map.is_empty());
 }
 
 #[test]
-fn svelte_carrier_compile_ide_still_projects() {
+fn svelte_ide_projection_still_projects_a_js_carrier() {
     let artifact = svelte_artifact("file:///js.svelte", JS_CARRIER);
-    let out = SvelteCarrierCompiler
-        .compile_ide(JS_CARRIER, &artifact, &IdeCompileOptions::default())
-        .expect("production compile_ide route");
-    assert!(out.is_jsx);
+    let out = SvelteProjectionBackend
+        .project_ide(
+            ide_grant(),
+            JS_CARRIER,
+            &artifact,
+            &ide_only_request("Js.svelte", true),
+            &SvelteProjectionInputs,
+        )
+        .expect("production projection route");
+    assert!(out.ide.is_jsx);
     assert!(out
+        .ide
         .code
         .starts_with("/** @jsxImportSource @verter/svelte-jsx */"));
 }
@@ -365,18 +344,23 @@ fn svelte_ide_projection_binds_request_syntax_profile_to_admitted_artifact() {
 }
 
 #[test]
-fn svelte_ide_projection_succeeds_for_foreign_namespace_like_compile_ide() {
+fn svelte_ide_projection_succeeds_for_foreign_namespace() {
+    // The IDE projection carries no namespace axis: a request naming the
+    // Foreign namespace must project identically to a plain request over
+    // the same source.
     let artifact = svelte_artifact("file:///foreign-ns.svelte", SIMPLE);
-    let opts = IdeCompileOptions {
-        filename: Some("ForeignNs.svelte".to_string()),
-        ..Default::default()
-    };
-    let via_compile_ide = SvelteCarrierCompiler
-        .compile_ide(SIMPLE, &artifact, &opts)
-        .expect("compile_ide has no namespace axis");
+    let plain = SvelteProjectionBackend
+        .project_ide(
+            ide_grant(),
+            SIMPLE,
+            &artifact,
+            &ide_only_request("ForeignNs.svelte", true),
+            &SvelteProjectionInputs,
+        )
+        .expect("a plain request has no namespace axis");
     let request = CompileRequest::new(
         vec![CompileProduct::IdeCompanion(IdeProductRequest {
-            want_source_map: !opts.skip_source_map,
+            want_source_map: true,
             ..Default::default()
         })],
         FrameworkCompileRequest::Svelte(SvelteCompileRequest {
@@ -398,10 +382,10 @@ fn svelte_ide_projection_succeeds_for_foreign_namespace_like_compile_ide() {
             &request,
             &SvelteProjectionInputs,
         )
-        .expect("IDE-only Foreign namespace must project like compile_ide");
-    assert_eq!(via_backend.ide.code, via_compile_ide.code);
-    assert_eq!(via_backend.ide.source_map, via_compile_ide.source_map);
-    assert_eq!(via_backend.ide.is_jsx, via_compile_ide.is_jsx);
+        .expect("IDE-only Foreign namespace must still project");
+    assert_eq!(via_backend.ide.code, plain.ide.code);
+    assert_eq!(via_backend.ide.source_map, plain.ide.source_map);
+    assert_eq!(via_backend.ide.is_jsx, plain.ide.is_jsx);
 }
 
 #[test]

--- a/crates/verter_compiler/tests/cases/svelte_runtime_backend.rs
+++ b/crates/verter_compiler/tests/cases/svelte_runtime_backend.rs
@@ -1,6 +1,6 @@
 //! Svelte runtime `RuntimeCompilerBackend`: parse-artifact emit, catalog
 //! identity, byte/map/diagnostic parity with the parsed core, runtime-only
-//! refusal, option preservation, and production `compile_bundle` isolation.
+//! refusal, option preservation, and production host-products isolation.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -16,8 +16,8 @@ use verter_compiler::compile_request::{
     RuntimeProductRequest, SvelteCompileRequest, SvelteOptionAttempt, VueCompileRequest,
 };
 use verter_compiler::framework_common::{
-    CarrierCompiler, CatalogCapability, CatalogRow, FrameworkEpoch, FrameworkParseArtifact,
-    ImmutableCapabilityCatalog, RuntimeCompileOptions, RuntimeCompilerBackend,
+    CatalogCapability, CatalogRow, FrameworkEpoch, FrameworkParseArtifact,
+    ImmutableCapabilityCatalog, RuntimeCompilerBackend,
 };
 use verter_compiler::standalone::{
     DirectCompileError, DirectCompileOutput, DirectExecutionInputs, StandaloneCompiler,
@@ -26,8 +26,8 @@ use verter_compiler::standalone::{
 use verter_compiler::style_planner::{prepare_supplied_style, PreparedStyleIr};
 use verter_compiler::svelte::runtime::{ClientCompileError, UnsupportedSvelteRuntimeSurface};
 use verter_compiler::svelte::{
-    svelte_runtime_backend_registration, SvelteCarrierCompiler, SvelteRuntimeBackend,
-    SvelteRuntimeError, SvelteRuntimeInputs, SvelteSfc5,
+    svelte_runtime_backend_registration, SvelteRuntimeBackend, SvelteRuntimeError,
+    SvelteRuntimeInputs, SvelteSfc5,
 };
 use verter_language::carrier_grammar::{
     CarrierGrammarAuthority, CarrierGrammarConfig, CarrierParserGrammarVersion,
@@ -638,35 +638,45 @@ fn svelte_runtime_backend_refuses_an_analysis_product_request() {
 }
 
 #[test]
-fn compile_bundle_still_emits_runtime_when_an_ide_product_is_also_requested() {
+fn compile_host_products_still_emits_runtime_when_an_ide_product_is_also_requested() {
+    use verter_compiler::framework_common::{
+        FrameworkHostIntegrationBackend as _, SvelteHostExecutionInputs,
+        SvelteHostIntegrationBackend, SvelteHostMultiProductDemand,
+    };
     let artifact = svelte_artifact("file:///bundle.svelte", SIMPLE);
-    let mixed = SvelteCarrierCompiler
-        .compile_bundle(
-            SIMPLE,
+    let backend = SvelteHostIntegrationBackend::registered();
+    let admission = backend
+        .admit_host_products(
             &artifact,
-            &RuntimeCompileOptions {
+            SvelteHostMultiProductDemand {
+                products: vec![
+                    client_product(true),
+                    CompileProduct::IdeCompanion(IdeProductRequest {
+                        want_source_map: true,
+                        ..Default::default()
+                    }),
+                ],
                 filename: Some("Bundle.svelte".to_string()),
-                want_runtime: true,
-                want_ide: true,
-                source_map: true,
                 ..Default::default()
             },
+        )
+        .expect("mixed runtime+IDE demand admits");
+    let mixed = backend
+        .compile_host_products(
+            admission,
+            &artifact,
+            &SvelteHostExecutionInputs::default(),
             &oxc_allocator::Allocator::new(),
         )
-        .expect("production compile_bundle still serves runtime");
-    match mixed {
-        verter_compiler::framework_common::CarrierCompileOutcome::Produced(bundle) => {
-            assert!(
-                bundle.has_runtime_surface(),
-                "production compile_bundle must still emit a runtime product"
-            );
-            assert!(
-                bundle.tsx.is_some(),
-                "production compile_bundle must still emit the IDE product on the combined path"
-            );
-        }
-        other => panic!("expected produced runtime+IDE bundle, got {other:?}"),
-    }
+        .expect("production compile_host_products still serves runtime");
+    assert!(
+        mixed.runtime_client_bundle().is_some(),
+        "production compile_host_products must still emit a runtime product"
+    );
+    assert!(
+        mixed.ide_companion().is_some(),
+        "production compile_host_products must still emit the IDE product on the combined path"
+    );
 
     let request = CompileRequest::new(
         vec![


### PR DESCRIPTION
Delete the unused Svelte `impl CarrierCompiler`, compatibility wrappers, and Svelte-only exports after every Svelte production route uses typed capabilities. Current compatibility ownership is `SvelteCarrierCompiler`; final execution ownership is the five Svelte typed backends. Vue's implementation and the shared trait remain separate concerns.

### Scope

- `crates/verter_compiler/src/svelte/carrier.rs` — delete the combined trait implementation, compatibility-only wrappers/imports, and implementation-only tests.
- `crates/verter_compiler/src/svelte/mod.rs` — delete only Svelte compatibility exports made unreferenced by that implementation.
- Focused Svelte runtime, IDE, conformance, and map tests may be retargeted to typed backends; they are evidence, not extra production surfaces.

Do not touch `framework_common/vue_bridge.rs`, the `CarrierCompiler` declaration/harness, generic sourcemap helpers still used by typed Svelte tests, mixed option/output DTOs, or staged artifacts.

### Acceptance

Characterize typed-versus-compatibility bytes/maps/diagnostics and work counts, remove the implementation/export population atomically, then prove the typed route alone. No shadow adapter or fallback may remain.

- **CCA1T2S-AC1:** no Svelte `CarrierCompiler` implementation, compatibility wrapper, production call, or Svelte-only compatibility export remains.
- **CCA1T2S-AC2:** Svelte frontend/semantic/projection/runtime/host outputs, maps, diagnostics, refusals, and ordering remain equivalent.
- **CCA1T2S-AC3:** fresh/incremental/cancelled behavior and complete-only admission remain unchanged.
- **CCA1T2S-AC4:** no duplicate parse, semantic, projection, compile, assembly, map, or copy work appears; inapplicable products stay zero-work.

Ceiling: 500 production LOC, 4 production files, 1 crate. Abort on a live Svelte trait consumer, Vue mutation, shared-trait deletion, cross-crate migration, or staged-artifact need. Run focused Svelte compiler/capability/conformance/map suites and `targeted-domain`; CCA1T2 joins this with CCA1T2V.

Closes #149

<!-- tama-workflow-publication:status:node_5cc4a4b15f5e1fcd218bdeb30a8f814c:node-landing:1789122054395:publish#1:1 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Svelte compilation to use shared host integration and typed projection/runtime backends.
  * Retained support for runtime bundles, IDE projections, source maps, CSS artifacts, template facts, and diagnostics.
  * Removed obsolete compilation-interface usage.

* **Tests**
  * Updated Svelte tests to validate host-backed runtime compilation and direct IDE projections.
  * Preserved coverage for runtime refusal, compilation options, source maps, and generated artifacts.
  * Removed redundant Svelte delegation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->