### PR TITLE
feat(core): add the pinned vue-benchmarks external workload probe lane

### DIFF
--- a/.github/workflows/validation-probe.yml
+++ b/.github/workflows/validation-probe.yml
@@ -1,0 +1,105 @@
+name: Validation Probe
+
+# The external workload probe lane.
+#
+# Drives Verter against one PINNED third-party corpus through the normal public
+# compile request route, classifies every case with the probe outcome taxonomy,
+# and publishes one compact machine-readable summary.
+#
+# The corpus is a WORKLOAD, never an oracle. A mismatch against the reference
+# compiler is evidence for the owning semantic node; it is never a verdict on
+# Verter and never a reason to change compiler behaviour from this lane.
+#
+# Exactly ONE probe job runs the whole slice. There is no per-fixture job and no
+# per-fixture test: which cases run, what they are expected to do, and who owns
+# that expectation are manifest data, and the runner is table-driven over it.
+#
+# The lane's disposition is a real exit, computed after publication: the summary
+# is uploaded and rendered FIRST, then `validation-probe-summary --dispose`
+# exits non-zero if any gate cell did not evaluate to a gate pass — so a run
+# that goes red still leaves behind the evidence for why.
+
+on:
+  push:
+    branches: main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: validation-probe-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # The pinned corpus. Recorded here AND in `manifest/vue.toml`; the lane
+  # checks the manifest inventory against the checkout in both directions, so
+  # the two cannot drift apart silently.
+  VUE_BENCHMARKS_REPO: pikax/vue-benchmarks
+  VUE_BENCHMARKS_REVISION: 5ac27ef2df618855c5855adcd9487488e0b18f25
+
+jobs:
+  probe:
+    name: Workload probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@1.97.1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: validation-probe
+      - uses: taiki-e/install-action@nextest
+
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The runner never links the addon: the public routes are addon methods
+      # bound for JavaScript, so the driver loads them through @verter/native.
+      - name: Build the native addon
+        run: pnpm --filter @verter/native build
+
+      # Checked out at its EXACT commit. A moving ref would make every
+      # classification in the summary unattributable.
+      - name: Check out the pinned Vue corpus
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ env.VUE_BENCHMARKS_REPO }}
+          ref: ${{ env.VUE_BENCHMARKS_REVISION }}
+          path: .integration-tests/repos/vue-benchmarks
+          persist-credentials: false
+
+      # The pull-request lane drives the manifest's bounded smoke slice; main
+      # and manual runs drive the complete ratified inventory.
+      - name: Run the workload probe
+        env:
+          VALIDATION_PROBE_LANE: ${{ github.event_name == 'pull_request' && 'smoke' || 'main' }}
+        run: cargo nextest run -p verter_validation_probe --features external-corpus
+
+      - name: Upload the summary artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-probe-summary-${{ github.run_id }}-${{ github.run_attempt }}
+          path: target/validation-probe/summary.json
+          if-no-files-found: error
+
+      - name: Render the job summary
+        if: always()
+        run: |
+          cargo run -p verter_validation_probe --bin validation-probe-summary -- \
+            --markdown >> "$GITHUB_STEP_SUMMARY"
+
+      # AFTER publication, and last: the artifact and the rendered table exist
+      # for the run this step turns red.
+      - name: Lane disposition
+        if: always()
+        run: cargo run -p verter_validation_probe --bin validation-probe-summary -- --dispose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3911,7 +3911,11 @@ name = "verter_validation_probe"
 version = "0.0.1-beta.3"
 dependencies = [
  "serde",
+ "serde_json",
+ "sha2",
  "toml",
+ "verter_language",
+ "verter_vue_conformance",
 ]
 
 [[package]]

--- a/crates/verter_session/tests/cases/architecture_guards.rs
+++ b/crates/verter_session/tests/cases/architecture_guards.rs
@@ -5252,6 +5252,15 @@ pub(crate) mod foundations_guards {
             // call, no VerterHost/WorkspaceAccess context to route
             // through. `D14_ALLOW_LIST` carries the full rationale.
             "crates/verter_test_support/src/lib.rs",
+            // test/CI-only external workload probe lane — the crate's SOLE
+            // disk boundary, through which its corpus adapter, its lane and
+            // its summary binary all read and write. Reads a pinned
+            // third-party corpus checkout (feature-gated), its own committed
+            // manifests, and its own published summary artifact; never
+            // workspace/semantic/overlay/VFS state, and no production crate
+            // may depend on the crate. `D14_ALLOW_LIST` carries the full
+            // rationale.
+            "crates/verter_validation_probe/src/disk.rs",
         ]
         .into_iter()
         .map(String::from)
@@ -9403,6 +9412,10 @@ pub(crate) mod foundations_guards {
         (
             "crates/verter_test_support/src/lib.rs",
             "dev-dependency-only shared test-harness crate (`unique_temp_dir` etc.), never depended on by production code. The only `std::fs::` calls are inside `#[cfg(test)] mod tests` — a self-test that the minted path is actually a writable scratch dir. No production-path call, and the crate has no `VerterHost`/`WorkspaceAccess` context to route through — sibling of the `verter_lsp/src/config.rs` and `verter_lsp/src/test_utils.rs` test-fixture entries above.",
+        ),
+        (
+            "crates/verter_validation_probe/src/disk.rs",
+            "test/CI-only validation-probe lane, and the crate's SOLE disk boundary — the corpus adapter, the lane and the summary binary all route through this one module, so the whole crate is this single entry rather than one per reader. It reads a pinned third-party corpus checkout under `.integration-tests/repos/` (gated behind `feature = \"external-corpus\"`), its own committed `manifest/*.toml`, and its own published `target/validation-probe/summary.json`. None of that is workspace, semantic, overlay or VFS state, and no production crate may depend on this crate (the dependency-layer guard lists it among the harnesses) — sibling of the `verter_vue_conformance/src/lib.rs` and `verter_svelte_conformance/src/generate.rs` corpus-tooling entries.",
         ),
 ];
 

--- a/crates/verter_validation_probe/Cargo.toml
+++ b/crates/verter_validation_probe/Cargo.toml
@@ -7,13 +7,33 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "Test-only validation-probe contract: the closed probe outcome taxonomy with its causal precedence fold, the per-dimension case observation, and the probe-state manifest with its expectation evaluator."
+description = "Test-only validation-probe contract: the closed probe outcome taxonomy with its causal precedence fold, the per-dimension case observation, the probe-state manifest with its expectation evaluator, and the table-driven external workload probe lane."
 publish = false
 
 # Test and CI tooling only. No production crate may depend on this crate; the
 # workspace dependency-layer guard lists it among the harnesses nothing may
 # depend on.
 
+[features]
+# Opt-in EXTERNAL lane: the workload probe reads a pinned third-party corpus
+# checked out under `.integration-tests/repos/`. OFF by default so the
+# canonical hermetic run (`node scripts/gate.mjs`) neither reads nor requires
+# any external checkout.
+external-corpus = []
+
+[[bin]]
+name = "validation-probe-summary"
+path = "src/bin/summary.rs"
+
 [dependencies]
 serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 toml = "1.1"
+# The structural comparator and its canonicalizer. The lane decides equality
+# with the existing conformance comparator and writes nothing of its own; the
+# same canonicalizer is the product's parse-and-build validity check.
+# The single file-language classification authority. The corpus walker asks
+# it which paths are carrier cases instead of matching extensions by hand.
+verter_language = { path = "../verter_language" }
+verter_vue_conformance = { path = "../verter_vue_conformance" }

--- a/crates/verter_validation_probe/driver/probe-driver.mjs
+++ b/crates/verter_validation_probe/driver/probe-driver.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+// The validation-probe JavaScript driver.
+//
+// The public compile routes are addon methods bound for JavaScript, so the
+// Rust runner never links the addon: it spawns this driver and speaks a
+// line-delimited protocol to it.
+//
+// The protocol is PHASE-AUTHENTICATED. Before each step the driver announces
+// the phase it is entering, so a termination with no line is attributable to
+// that step and nothing else:
+//
+//   { probe_id, phase: "load" }       before the addon is loaded
+//   { probe_id, phase: "compile" }    before the bracketed compileRequests call
+//   { probe_id, phase: "reference" }  before any reference work
+//
+// and emits two authenticated frames per probe, in this order:
+//
+//   { probe_id, frame: "compile", elapsed_ns, entries }
+//   { probe_id, frame: "reference", reference }
+//
+// The compile frame is written IMMEDIATELY after compileRequests returns and
+// before any reference work, so a reference-phase death can only ever cost the
+// Structural cell — never the Route/Compile terminals the runner has already
+// ingested.
+//
+// Every JavaScript step is wrapped: a failure is reported as a LINE, never as
+// an exit. A JS failure before the native call is `stage: "pre-native"`, after
+// it `stage: "post-native"`; both are harness failures. What is left — an
+// unacknowledged termination inside phase "compile" — can therefore only have
+// happened inside the native call, which is what makes crash and timeout
+// truthful classes rather than guesses.
+
+import { createInterface } from "node:readline";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DRIVER_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(DRIVER_DIR, "..", "..", "..");
+const require = createRequire(import.meta.url);
+
+const PROBE_KEYS = new Set(["probe_id", "entries"]);
+const ENTRY_KEYS = new Set(["canonicalId", "source", "request"]);
+
+function emit(line) {
+  process.stdout.write(`${JSON.stringify(line)}\n`);
+}
+
+function describe(error) {
+  if (error && typeof error === "object") {
+    const name = typeof error.name === "string" ? error.name : "Error";
+    const message = typeof error.message === "string" ? error.message : String(error);
+    return `${name}: ${message}`;
+  }
+  return String(error);
+}
+
+// ---------------------------------------------------------------------------
+// Addon
+// ---------------------------------------------------------------------------
+
+let host = null;
+
+/** Load the addon and construct one host for the whole process. */
+function ensureHost() {
+  if (host) return host;
+  const native = require(path.join(REPO_ROOT, "packages", "native", "index.js"));
+  host = new native.VerterHost();
+  return host;
+}
+
+// ---------------------------------------------------------------------------
+// Reference producers
+//
+// One producer per framework, registered explicitly. A framework with no
+// registered producer yields `{ inapplicable: <framework> }`; another
+// framework's producer is NEVER run over it. The runner decides what that
+// means from the framework's own validated manifest: `comparison = none`
+// accepts it as not applicable, `comparison = structural` classifies it a
+// reference failure — so deleting the Vue producer turns every Vue Structural
+// cell red rather than silently inapplicable.
+// ---------------------------------------------------------------------------
+
+const referenceProducers = new Map();
+
+/** The pinned upstream Vue reference compiler, loaded on first use. */
+let vueSfc = null;
+
+function loadVueSfc() {
+  if (!vueSfc) vueSfc = require("@vue/compiler-sfc");
+  return vueSfc;
+}
+
+// The reference product for one SFC, produced exactly as the direct layer of
+// the repository's own per-file comparison does: parse then compileScript then
+// compileTemplate, mode dev, non-SSR, module output.
+referenceProducers.set("vue", (source, filename) => {
+  const sfc = loadVueSfc();
+  const { descriptor, errors: parseErrors } = sfc.parse(source, { filename });
+  if (parseErrors?.length > 0) {
+    return { error: parseErrors.map((e) => e.message ?? String(e)).join("; ") };
+  }
+
+  let scriptCode = "";
+  let bindingMetadata;
+  if (descriptor.script || descriptor.scriptSetup) {
+    try {
+      const script = sfc.compileScript(descriptor, {
+        id: filename,
+        inlineTemplate: false,
+        isProd: false,
+      });
+      scriptCode = script.content;
+      bindingMetadata = script.bindings;
+    } catch (error) {
+      return { error: `compileScript: ${describe(error)}` };
+    }
+  }
+
+  let templateCode = "";
+  if (descriptor.template) {
+    try {
+      const template = sfc.compileTemplate({
+        source: descriptor.template.content,
+        filename,
+        id: filename,
+        scoped: descriptor.styles.some((style) => style.scoped),
+        isProd: false,
+        ssr: false,
+        compilerOptions: { mode: "module", bindingMetadata },
+      });
+      if (template.errors?.length > 0) {
+        const messages = template.errors.map((e) => (typeof e === "string" ? e : e.message));
+        return { error: `compileTemplate: ${messages.join("; ")}` };
+      }
+      templateCode = template.code;
+    } catch (error) {
+      return { error: `compileTemplate: ${describe(error)}` };
+    }
+  }
+
+  return { code: [scriptCode, templateCode].filter(Boolean).join("\n\n") };
+});
+
+// ---------------------------------------------------------------------------
+// Probe execution
+// ---------------------------------------------------------------------------
+
+function readProbe(line) {
+  const probe = JSON.parse(line);
+  if (probe === null || typeof probe !== "object" || Array.isArray(probe)) {
+    throw new Error("a probe request must be an object");
+  }
+  for (const key of Object.keys(probe)) {
+    if (!PROBE_KEYS.has(key)) throw new Error(`unknown field \`${key}\``);
+  }
+  if (typeof probe.probe_id !== "string" || probe.probe_id === "") {
+    throw new Error("probe_id must be a non-empty string");
+  }
+  if (!Array.isArray(probe.entries) || probe.entries.length === 0) {
+    throw new Error("entries must be a non-empty array");
+  }
+  for (const entry of probe.entries) {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error("an entry must be an object");
+    }
+    for (const key of Object.keys(entry)) {
+      if (!ENTRY_KEYS.has(key)) throw new Error(`unknown entry field \`${key}\``);
+    }
+    if (typeof entry.canonicalId !== "string" || entry.canonicalId === "") {
+      throw new Error("entry canonicalId must be a non-empty string");
+    }
+    if (typeof entry.source !== "string") throw new Error("entry source must be a string");
+    if (entry.request === null || typeof entry.request !== "object") {
+      throw new Error("entry request must be an object");
+    }
+  }
+  return probe;
+}
+
+function runProbe(probe) {
+  const { probe_id, entries } = probe;
+
+  emit({ probe_id, phase: "load" });
+  ensureHost();
+
+  emit({ probe_id, phase: "compile" });
+  let inputs;
+  try {
+    inputs = entries.map((entry) => ({
+      canonicalId: entry.canonicalId,
+      source: Buffer.from(entry.source, "utf8"),
+      request: entry.request,
+    }));
+  } catch (error) {
+    emit({ probe_id, error: describe(error), phase: "compile", stage: "pre-native" });
+    return;
+  }
+
+  const started = process.hrtime.bigint();
+  const answered = host.compileRequests(inputs);
+  const elapsed_ns = Number(process.hrtime.bigint() - started);
+
+  try {
+    emit({ probe_id, frame: "compile", elapsed_ns, entries: answered });
+  } catch (error) {
+    emit({ probe_id, error: describe(error), phase: "compile", stage: "post-native" });
+    return;
+  }
+
+  emit({ probe_id, phase: "reference" });
+  const reference = entries.map((entry) => {
+    const framework = entry.request?.framework;
+    const producer = referenceProducers.get(framework);
+    if (!producer) return { inapplicable: String(framework) };
+    try {
+      return producer(entry.source, entry.canonicalId);
+    } catch (error) {
+      return { error: describe(error) };
+    }
+  });
+  emit({ probe_id, frame: "reference", reference });
+}
+
+const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
+for await (const line of lines) {
+  if (line.trim() === "") continue;
+  let probe;
+  try {
+    probe = readProbe(line);
+  } catch (error) {
+    // No probe id is trustworthy here, so the line is reported without one and
+    // the runner attributes it to the probe it is waiting on.
+    emit({ error: describe(error), phase: "protocol" });
+    continue;
+  }
+  try {
+    runProbe(probe);
+  } catch (error) {
+    emit({
+      probe_id: probe.probe_id,
+      error: describe(error),
+      phase: "compile",
+      stage: "pre-native",
+    });
+  }
+}

--- a/crates/verter_validation_probe/driver/probe-driver.mjs
+++ b/crates/verter_validation_probe/driver/probe-driver.mjs
@@ -194,6 +194,19 @@ function readProbe(line) {
     if (entry.request === null || typeof entry.request !== "object") {
       throw new Error("entry request must be an object");
     }
+    // The one filename BOTH compilers must see, so it is required here rather
+    // than defaulted later. Substituting the case id for a missing one would
+    // compile the reference under a name the request never carried, and the
+    // comparator would report the divergence that follows — a scoped style's
+    // scope id above all — as a compiler difference. Refusing the malformed
+    // request says what actually went wrong.
+    const identity = entry.request.identity;
+    if (identity === null || typeof identity !== "object") {
+      throw new Error("entry request must carry an identity object");
+    }
+    if (typeof identity.filename !== "string" || identity.filename === "") {
+      throw new Error("entry request identity.filename must be a non-empty string");
+    }
   }
   return probe;
 }
@@ -247,8 +260,9 @@ function runProbe(probe, where) {
     // reference compiled under a different id diverges on every
     // filename-derived output — a scoped style's scope id above all — which
     // the comparator would then report as a compiler difference the harness
-    // itself manufactured.
-    const filename = entry.request?.identity?.filename ?? entry.canonicalId;
+    // itself manufactured. `readProbe` has already required this field, so
+    // there is no name to fall back to and nothing to fall back for.
+    const filename = entry.request.identity.filename;
     try {
       return producer(entry.source, filename);
     } catch (error) {

--- a/crates/verter_validation_probe/driver/probe-driver.mjs
+++ b/crates/verter_validation_probe/driver/probe-driver.mjs
@@ -24,11 +24,13 @@
 // ingested.
 //
 // Every JavaScript step is wrapped: a failure is reported as a LINE, never as
-// an exit. A JS failure before the native call is `stage: "pre-native"`, after
-// it `stage: "post-native"`; both are harness failures. What is left — an
-// unacknowledged termination inside phase "compile" — can therefore only have
-// happened inside the native call, which is what makes crash and timeout
-// truthful classes rather than guesses.
+// an exit. The line carries the phase and stage the driver was ACTUALLY in when
+// it threw — `stage: "pre-native"` before the native call, `"native"` for a
+// throw out of the call itself, `"post-native"` after it returned — and all of
+// them are harness failures. What is left — an unacknowledged termination
+// inside phase "compile" — can therefore only have happened inside the native
+// call, which is what makes crash and timeout truthful classes rather than
+// guesses.
 
 import { createInterface } from "node:readline";
 import { createRequire } from "node:module";
@@ -61,10 +63,28 @@ function describe(error) {
 
 let host = null;
 
+// The addon is reached through the @verter/native PACKAGE — its own entry, as
+// its `exports` map declares it, never a `.node` artifact this driver names
+// itself. The package directory is derived from the repository root because
+// pnpm does not link a workspace package into the workspace root's
+// node_modules, so `require("@verter/native")` from here would never resolve;
+// the directory is handed to node's package resolution rather than a
+// hardcoded entry file, and a missing build says so instead of surfacing as a
+// bare module-not-found.
+const NATIVE_PACKAGE = path.join(REPO_ROOT, "packages", "native");
+
 /** Load the addon and construct one host for the whole process. */
 function ensureHost() {
   if (host) return host;
-  const native = require(path.join(REPO_ROOT, "packages", "native", "index.js"));
+  let native;
+  try {
+    native = require(NATIVE_PACKAGE);
+  } catch (error) {
+    throw new Error(
+      `the @verter/native addon at ${NATIVE_PACKAGE} could not be loaded ` +
+        `(build it with \`pnpm --filter @verter/native build\`): ${describe(error)}`,
+    );
+  }
   host = new native.VerterHost();
   return host;
 }
@@ -178,12 +198,18 @@ function readProbe(line) {
   return probe;
 }
 
-function runProbe(probe) {
+// `where` is the driver's own account of what it was doing, kept current step
+// by step so the outer catch reports where a throw actually happened rather
+// than where the driver's first step was.
+function runProbe(probe, where) {
   const { probe_id, entries } = probe;
 
+  where.phase = "load";
+  where.stage = "pre-native";
   emit({ probe_id, phase: "load" });
   ensureHost();
 
+  where.phase = "compile";
   emit({ probe_id, phase: "compile" });
   let inputs;
   try {
@@ -197,9 +223,11 @@ function runProbe(probe) {
     return;
   }
 
+  where.stage = "native";
   const started = process.hrtime.bigint();
   const answered = host.compileRequests(inputs);
   const elapsed_ns = Number(process.hrtime.bigint() - started);
+  where.stage = "post-native";
 
   try {
     emit({ probe_id, frame: "compile", elapsed_ns, entries: answered });
@@ -208,13 +236,21 @@ function runProbe(probe) {
     return;
   }
 
+  where.phase = "reference";
   emit({ probe_id, phase: "reference" });
   const reference = entries.map((entry) => {
     const framework = entry.request?.framework;
     const producer = referenceProducers.get(framework);
     if (!producer) return { inapplicable: String(framework) };
+    // BOTH compilers see the one filename the canonical request carries. The
+    // case id is not that filename (it is prefixed by the framework), and a
+    // reference compiled under a different id diverges on every
+    // filename-derived output — a scoped style's scope id above all — which
+    // the comparator would then report as a compiler difference the harness
+    // itself manufactured.
+    const filename = entry.request?.identity?.filename ?? entry.canonicalId;
     try {
-      return producer(entry.source, entry.canonicalId);
+      return producer(entry.source, filename);
     } catch (error) {
       return { error: describe(error) };
     }
@@ -234,14 +270,15 @@ for await (const line of lines) {
     emit({ error: describe(error), phase: "protocol" });
     continue;
   }
+  const where = { phase: "load", stage: "pre-native" };
   try {
-    runProbe(probe);
+    runProbe(probe, where);
   } catch (error) {
     emit({
       probe_id: probe.probe_id,
       error: describe(error),
-      phase: "compile",
-      stage: "pre-native",
+      phase: where.phase,
+      stage: where.stage,
     });
   }
 }

--- a/crates/verter_validation_probe/manifest/README.md
+++ b/crates/verter_validation_probe/manifest/README.md
@@ -48,6 +48,11 @@ A committed manifest never contains a classless canary, an uncited cell, or a ga
 list its exact class. Observation never implies acceptance: expected classes record Verter behaviour, never
 output derived from the external corpus.
 
+Only `Route` may `gate`, and only citing `compiler.public-request-route`: a gate binds the required job, so
+it may cite only behaviour an implemented authority already owns. A product refusal, a diagnostic, a
+comparison, a runtime or a map result belongs to a framework product authority and becomes gateable when
+that authority is implemented and a promotion moves it — `ProbeStateManifest::validate` refuses the rest.
+
 ## The smoke slice
 
 `smoke` is the bounded case list a pull request runs; the broader lane runs the complete `inventory`. It is

--- a/crates/verter_validation_probe/manifest/README.md
+++ b/crates/verter_validation_probe/manifest/README.md
@@ -11,6 +11,7 @@ A manifest is added by the lane that pins its corpus. Its shape:
 framework = "vue"                  # vue | svelte
 comparison = "structural"          # structural (comparator bound) | none
 external_revision = "<commit id>"   # the full pinned corpus commit
+smoke = ["vue/<relative-path>"]    # the deterministic pull-request slice (see below)
 
 [comparator]                       # exactly when comparison = structural; equals the catalog identity
 crate = "verter_vue_conformance"
@@ -46,3 +47,12 @@ atom = "route-callable"            # durable atom id of that authority
 A committed manifest never contains a classless canary, an uncited cell, or a gate whose cited atom does not
 list its exact class. Observation never implies acceptance: expected classes record Verter behaviour, never
 output derived from the external corpus.
+
+## The smoke slice
+
+`smoke` is the bounded case list a pull request runs; the broader lane runs the complete `inventory`. It is
+listed by case id rather than computed at run time, and then checked to EQUAL its own derivation — the
+lexicographic first `min_cases` cases of each stratum, in stratum declaration order. So a reviewer reads
+exactly what the required job covers, and a slice that was emptied, padded, reordered, or hand-picked fails
+`ProbeStateManifest::validate` instead of quietly re-scoping the lane. The bound (`MAX_SMOKE_CASES`) is
+structural, never a wall clock: a size expressed as a time budget drifts with the machine.

--- a/crates/verter_validation_probe/manifest/vue.toml
+++ b/crates/verter_validation_probe/manifest/vue.toml
@@ -1,0 +1,20862 @@
+# The Vue probe-state manifest: one pinned external workload, the complete
+# ratified case inventory, and one declared cell per case per dimension.
+#
+# The corpus is a WORKLOAD, never an oracle. Nothing here derives an
+# expected output from it: a cell records what Verter is expected to do and
+# which authority owns that behaviour, and a mismatch against the reference
+# compiler is evidence for the owning semantic node, never a verdict.
+#
+# Only `Route` may gate, because `compiler.public-request-route` is the only
+# authority behind these cells whose owning node is implemented. Every
+# `Compile` and `Structural` cell is a canary or a known-fail owned by
+# `vue.runtime-client-product`, and is promoted only when that authority is
+# implemented and the promotion is ratified.
+#
+# The `smoke` slice is the deterministic lexicographic first-`min_cases` of
+# each stratum, and is checked to equal that derivation, so what a pull
+# request runs is readable here and cannot be quietly re-scoped.
+
+framework = "vue"
+comparison = "structural"
+external_revision = "5ac27ef2df618855c5855adcd9487488e0b18f25"
+
+# The deterministic pull-request slice. Listed here and checked to equal
+# the lexicographic first-`min_cases` of each stratum below.
+smoke = ["vue/tests/confirm/fixtures/lsp/App.fixed.vue","vue/tests/confirm/fixtures/lsp/App.vue","vue/tests/confirm/fixtures/lsp/Child.vue","vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue","vue/tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue","vue/tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue","vue/tests/confirm/fixtures/format/format-comments-preserved.vue","vue/tests/confirm/fixtures/format/format-generic-script-setup.vue","vue/tests/confirm/fixtures/compile/AttrsInherit.vue","vue/tests/confirm/fixtures/compile/AttrsNoInherit.vue","vue/tests/confirm/fixtures/compile/Conditional.vue","vue/tests/confirm/fixtures/compile/Counter.vue","vue/tests/confirm/fixtures/compile/CssVarBind.vue","vue/tests/confirm/fixtures/compile/CustomDirective.vue","vue/tests/confirm/fixtures/compile/DefineModelChild.vue","vue/tests/confirm/fixtures/compile/DynamicArgs.vue"]
+
+[comparator]
+crate = "verter_vue_conformance"
+path = "src/compare.rs"
+function = "compare_modules"
+atom = "product-identity"
+
+[applicability]
+# No runtime executor and no source-map validator are bound for this lane,
+# so every Runtime and Map cell is an owned skip rather than a silent pass.
+runtime = "inapplicable"
+map = "inapplicable"
+
+[[strata]]
+id = "app"
+pattern = "App*"
+min_cases = 2
+
+[[strata]]
+id = "child"
+pattern = "Child*"
+min_cases = 2
+
+[[strata]]
+id = "component"
+pattern = "Component*"
+min_cases = 2
+
+[[strata]]
+id = "format"
+pattern = "format*"
+min_cases = 2
+
+[[strata]]
+id = "feature"
+pattern = "*"
+min_cases = 8
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/AttrsInherit.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/Conditional.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/Counter.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/CssVarBind.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/CustomDirective.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/DefineModelChild.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/DynamicArgs.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/DynamicComponent.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/DynamicSlotName.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/EventModifiers.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/KeepAliveHost.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/ListItems.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/PropsEcho.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/SlotHost.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/TeleportHost.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/TemplateRef.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/VBindObject.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/VMemo.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/VModelChoice.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/VModelComponent.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/VModelInput.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/VModelModifiers.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/VOnce.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/VPre.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/VShowToggle.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/compile/VTextHtml.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-comments-preserved.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-generic-script-setup.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-idempotent.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-multiline-expressions.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-parseable.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-pre-whitespace.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-pug-template.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-style-v-bind.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-top-level-comments.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-v-pre-content.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/format/format-void-self-closing.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/clean/CleanButton.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/clean/CleanCard.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/VHtml.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lsp/App.fixed.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lsp/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/lsp/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+
+[[inventory]]
+case_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsInherit.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsInherit.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsInherit.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsInherit.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsInherit.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsInherit.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/AttrsNoInherit.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Conditional.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Conditional.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Conditional.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Conditional.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Conditional.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Conditional.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Conditional.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Conditional.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Conditional.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Conditional.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Conditional.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Conditional.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Counter.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Counter.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Counter.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Counter.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Counter.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Counter.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Counter.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Counter.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Counter.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Counter.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/Counter.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/Counter.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CssVarBind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CssVarBind.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CssVarBind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CssVarBind.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CssVarBind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CssVarBind.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CssVarBind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CssVarBind.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CssVarBind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CssVarBind.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CssVarBind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CssVarBind.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CustomDirective.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CustomDirective.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CustomDirective.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CustomDirective.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CustomDirective.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CustomDirective.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CustomDirective.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CustomDirective.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CustomDirective.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CustomDirective.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/CustomDirective.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/CustomDirective.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DefineModelChild.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DefineModelChild.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DefineModelChild.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DefineModelChild.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DefineModelChild.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DefineModelChild.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DefineModelChild.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DefineModelChild.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DefineModelChild.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DefineModelChild.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DefineModelChild.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DefineModelChild.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicArgs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicArgs.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicArgs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicArgs.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicArgs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicArgs.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicArgs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicArgs.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicArgs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicArgs.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicArgs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicArgs.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicComponent.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicComponent.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicComponent.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicComponent.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicComponent.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicComponent.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicSlotName.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicSlotName.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicSlotName.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicSlotName.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicSlotName.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicSlotName.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicSlotName.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicSlotName.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicSlotName.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicSlotName.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/DynamicSlotName.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/DynamicSlotName.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/EventModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/EventModifiers.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/EventModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/EventModifiers.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/EventModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/EventModifiers.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/EventModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/EventModifiers.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/EventModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/EventModifiers.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/EventModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/EventModifiers.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/KeepAliveHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/KeepAliveHost.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/KeepAliveHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/KeepAliveHost.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/KeepAliveHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/KeepAliveHost.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/KeepAliveHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/KeepAliveHost.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/KeepAliveHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/KeepAliveHost.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/KeepAliveHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/KeepAliveHost.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/ListItems.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/ListItems.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/ListItems.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/ListItems.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/ListItems.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/ListItems.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/ListItems.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/ListItems.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/ListItems.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/ListItems.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/ListItems.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/ListItems.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/PropsEcho.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/PropsEcho.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/PropsEcho.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/PropsEcho.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/PropsEcho.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/PropsEcho.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/PropsEcho.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/PropsEcho.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/PropsEcho.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/PropsEcho.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/PropsEcho.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/PropsEcho.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/SlotHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/SlotHost.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/SlotHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/SlotHost.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/SlotHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/SlotHost.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/SlotHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/SlotHost.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/SlotHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/SlotHost.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/SlotHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/SlotHost.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TeleportHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TeleportHost.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TeleportHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TeleportHost.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TeleportHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TeleportHost.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TeleportHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TeleportHost.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TeleportHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TeleportHost.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TeleportHost.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TeleportHost.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TemplateRef.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TemplateRef.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TemplateRef.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TemplateRef.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TemplateRef.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TemplateRef.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TemplateRef.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TemplateRef.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TemplateRef.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TemplateRef.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/TemplateRef.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/TemplateRef.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VBindObject.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VBindObject.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VBindObject.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VBindObject.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VBindObject.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VBindObject.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VBindObject.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VBindObject.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VBindObject.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VBindObject.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VBindObject.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VBindObject.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VForTemplateKeyed.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VMemo.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VMemo.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VMemo.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VMemo.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VMemo.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VMemo.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VMemo.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VMemo.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VMemo.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VMemo.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VMemo.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VMemo.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelChoice.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelChoice.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelChoice.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelChoice.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelChoice.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelChoice.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelChoice.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelChoice.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelChoice.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelChoice.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelChoice.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelChoice.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelComponent.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelComponent.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelComponent.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelComponent.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelComponent.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelComponent.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelInput.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelInput.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelInput.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelInput.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelInput.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelInput.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelInput.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelInput.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelInput.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelInput.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelInput.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelInput.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelModifiers.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelModifiers.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelModifiers.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelModifiers.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelModifiers.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VModelModifiers.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VModelModifiers.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VOnce.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VOnce.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VOnce.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VOnce.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VOnce.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VOnce.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VOnce.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VOnce.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VOnce.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VOnce.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VOnce.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VOnce.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VPre.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VPre.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VPre.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VPre.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VPre.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VPre.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VPre.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VPre.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VPre.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VPre.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VPre.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VPre.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VShowToggle.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VShowToggle.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VShowToggle.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VShowToggle.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VShowToggle.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VShowToggle.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VShowToggle.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VShowToggle.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VShowToggle.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VShowToggle.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VShowToggle.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VShowToggle.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VTextHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VTextHtml.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VTextHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VTextHtml.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VTextHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VTextHtml.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VTextHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VTextHtml.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VTextHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VTextHtml.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/compile/VTextHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/compile/VTextHtml.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/attr-name-normalization/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/basic-props/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/complex-defaults/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model-modifiers/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-model/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/define-options/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-multi-payload/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-overloads/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-runtime-validators/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/emits-type-alias/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/enum-props/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/events-emits/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose-ref-computed/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/expose/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "verter_diagnostic"
+reason = "the compiler reported an error diagnostic for this input"
+authority = "vue.runtime-client-product"
+atom = "product-diagnostic"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/external-props-import/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/full-api/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/generic-props/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/interface-extends-props/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/no-declared-api/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/options-api-component/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/prop-type-factory-defaults/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/props-destructure/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/recursive-props/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/runtime-props/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/script-mixed-blocks/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots-generic-optional/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/slots/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/union-intersection-props/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/component-meta/cases/with-defaults/Component.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-comments-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-comments-preserved.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-comments-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-comments-preserved.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-comments-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-comments-preserved.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-comments-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-comments-preserved.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-comments-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-comments-preserved.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-comments-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-comments-preserved.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-generic-script-setup.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-generic-script-setup.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-generic-script-setup.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-generic-script-setup.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-generic-script-setup.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-generic-script-setup.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-generic-script-setup.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-generic-script-setup.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-generic-script-setup.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-generic-script-setup.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-generic-script-setup.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-generic-script-setup.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+dimension = "Route"
+expected_state = "known-fail"
+expected_class = "host_failure"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+reason = "the host refuses a custom block whose content requires preprocessing"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "host_failure"
+reason = "propagated: the host refused this input before compiling"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "host_failure"
+reason = "propagated: the host refused this input before compiling"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-i18n-custom-block.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-idempotent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-idempotent.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-idempotent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-idempotent.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-idempotent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-idempotent.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-idempotent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-idempotent.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-idempotent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-idempotent.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-idempotent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-idempotent.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-multiline-expressions.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-multiline-expressions.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-multiline-expressions.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-multiline-expressions.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-multiline-expressions.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-multiline-expressions.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-multiline-expressions.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-multiline-expressions.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-multiline-expressions.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-multiline-expressions.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-multiline-expressions.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-multiline-expressions.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-parseable.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-parseable.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-parseable.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-parseable.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-parseable.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-parseable.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-parseable.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-parseable.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-parseable.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-parseable.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-parseable.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-parseable.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pre-whitespace.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pre-whitespace.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pre-whitespace.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pre-whitespace.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pre-whitespace.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pre-whitespace.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pre-whitespace.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pre-whitespace.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pre-whitespace.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pre-whitespace.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pre-whitespace.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pre-whitespace.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pug-template.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pug-template.vue"
+dimension = "Route"
+expected_state = "known-fail"
+expected_class = "host_failure"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+reason = "the host refuses a pug template whose content requires preprocessing"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pug-template.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pug-template.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "host_failure"
+reason = "propagated: the host refused this input before compiling"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pug-template.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pug-template.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "host_failure"
+reason = "propagated: the host refused this input before compiling"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pug-template.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pug-template.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pug-template.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pug-template.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-pug-template.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-pug-template.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-style-v-bind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-style-v-bind.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-style-v-bind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-style-v-bind.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-style-v-bind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-style-v-bind.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-style-v-bind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-style-v-bind.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-style-v-bind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-style-v-bind.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-style-v-bind.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-style-v-bind.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-top-level-comments.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-top-level-comments.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-top-level-comments.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-top-level-comments.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-top-level-comments.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-top-level-comments.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-top-level-comments.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-top-level-comments.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-top-level-comments.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-top-level-comments.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-top-level-comments.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-top-level-comments.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-for-expression-preserved.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-pre-content.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-pre-content.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-pre-content.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-pre-content.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-pre-content.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-pre-content.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-pre-content.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-pre-content.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-pre-content.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-pre-content.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-v-pre-content.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-v-pre-content.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-void-self-closing.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-void-self-closing.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-void-self-closing.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-void-self-closing.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-void-self-closing.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-void-self-closing.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-void-self-closing.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-void-self-closing.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-void-self-closing.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-void-self-closing.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/format/format-void-self-closing.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/format/format-void-self-closing.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanAdvanced.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanButton.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanButton.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanButton.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanButton.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanButton.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanButton.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanButton.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanButton.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanButton.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanButton.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanButton.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanButton.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanCard.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanCard.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanCard.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanCard.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanCard.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanCard.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanCard.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanCard.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanCard.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanCard.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/clean/CleanCard.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/clean/CleanCard.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/AsyncComputed.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ComputedSideEffect.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DeprecatedSlotAttr.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DupeElseIf.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/DuplicateAttrs.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ImgNoAlt.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVModel.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/InvalidVSlot.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/MutatingProps.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/PropTypeConstructor.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/RequireComponentIs.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/ReservedProps.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TemplateKey.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/TextareaMustache.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/UnusedComponents.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VForNoKey.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VHtml.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VHtml.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VHtml.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VHtml.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VHtml.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VHtml.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VHtml.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VIfWithVFor.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VOnNativeModifier.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lint/dirty/VTextOnComponent.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.fixed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.fixed.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.fixed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.fixed.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.fixed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.fixed.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.fixed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.fixed.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.fixed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.fixed.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.fixed.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.fixed.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/lsp/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/lsp/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-component-prop-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/async-setup-await/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-aria-data-unknown/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-class-style-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/attrs-unknown-fallthrough/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/boolean-prop-attr-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/clean-basic/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/component-ref-expose-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/computed-unwrap-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/custom-directive-value-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-default-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-get-set-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-read-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-modifiers-unknown-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named-modifiers-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-named/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-model-set-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-default-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-fn-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/define-slots-named-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/discriminated-union-v-model-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dollar-event-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/dynamic-component-prop-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/element-prop-type/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-unknown-event/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/emit-wrong-arg/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-emit-payload/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-ctrl-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-dollar-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-prevent-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-click-stop-prevent-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-component-once-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-keyup-enter-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/event-mod-submit-prevent-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-false-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-mono-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-multi-false-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-native-type-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-false-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-both-mono-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-mono-multi-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-multi-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/fallthrough-vif-static-prop-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-component-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-constraint-template-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-default-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-define-model-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-emit-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-fallthrough-mono-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-class-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-inherit-false-unknown/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-multi-root-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-slot-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/generic-two-params-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/global-component-prop-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-class-style-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-default-unknown/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-class-style-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inherit-attrs-false-unknown/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/inject-key-type/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/literal-union-prop-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/missing-required-prop/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-input-v-model-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-keyup-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-lazy-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-number-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/native-v-model-trim-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/optional-chain-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/options-api-prop-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/props-destructure-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/provide-inject-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ref-unwrap-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/required-slot-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/script-type-error/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-declared-omitted-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-default-implicit-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-provide-type-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-scope-payload/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-unknown-prop-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/slot-v-bind-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/static-number-attr-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/style-binding-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-infer-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-ref-type/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/template-undefined/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/ts-import-vue-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/unknown-prop-strict/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-object-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-bad/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-bind-same-name-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-else-if-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-destructure-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-item-type/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-for-tuple-type-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-discriminant-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-else-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-event-closure/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-in-narrow-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-inline-event-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-narrow-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-not-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-optional-prop-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-prop-discriminant-ok/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-bad/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-if-typeof-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+dimension = "Compile"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "product_malformed"
+reason = "the emitted module is not one the structural comparator canonicalizes"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-model-type/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/v-show-no-narrow/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/with-defaults-ok/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "semantic_mismatch"
+reason = "the emitted module differs in-contract from the reference"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/App.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "vue.runtime-client-product"
+atom = "product-shape"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+dimension = "Structural"
+expected_state = "known-fail"
+expected_class = "reference_failure"
+reason = "the reference module is not one the structural comparator canonicalizes, or the reference compiler failed"
+authority = "vue.runtime-client-product"
+atom = "product-identity"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+dimension = "Map"
+expected_state = "skip"
+authority = "vue.runtime-client-product"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "vue/tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+framework = "vue"
+case = "tests/confirm/fixtures/typecheck/cases/wrong-prop-type/Child.vue"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"

--- a/crates/verter_validation_probe/src/bin/summary.rs
+++ b/crates/verter_validation_probe/src/bin/summary.rs
@@ -1,0 +1,103 @@
+//! Read the lane's summary artifact and publish or dispose of it.
+//!
+//! Two modes, deliberately separate:
+//!
+//! * `--markdown` renders the compact human summary for the job page. It is a
+//!   publication step and never decides the job.
+//! * `--dispose` is the lane's DISPOSITION: it exits non-zero when any gate
+//!   cell evaluated to anything but a gate pass. It runs AFTER publication, so
+//!   the summary and its artifact exist for the run that turned red.
+//!
+//! Both modes validate the document first, and validation checks the presence
+//! of every required counter against the raw JSON. A summary missing a counter
+//! is refused rather than read as a zero — which is what keeps "the lane
+//! reported no regressions" from meaning "the lane forgot to count them".
+
+use std::process::ExitCode;
+
+use verter_validation_probe::summary::{Disposition, Summary};
+
+const USAGE: &str = "usage: validation-probe-summary [--markdown|--dispose] [--summary <path>]";
+
+fn main() -> ExitCode {
+    let mut markdown = false;
+    let mut dispose = false;
+    let mut path = default_summary_path();
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--markdown" => markdown = true,
+            "--dispose" => dispose = true,
+            "--summary" => match args.next() {
+                Some(value) => path = value.into(),
+                None => return fail("--summary needs a path"),
+            },
+            "--help" | "-h" => {
+                println!("{USAGE}");
+                return ExitCode::SUCCESS;
+            }
+            other => return fail(&format!("unknown argument `{other}`\n{USAGE}")),
+        }
+    }
+    if markdown == dispose {
+        return fail(&format!("exactly one of --markdown or --dispose\n{USAGE}"));
+    }
+
+    let text = match verter_validation_probe::disk::read_text(&path) {
+        Ok(text) => text,
+        Err(error) => return fail(&format!("the summary artifact could not be read: {error}")),
+    };
+    let summary = match Summary::from_json_str(&text) {
+        Ok(summary) => summary,
+        Err(error) => return fail(&format!("{}: {error}", path.display())),
+    };
+
+    if markdown {
+        print!("{}", summary.to_markdown());
+        return ExitCode::SUCCESS;
+    }
+
+    match summary.disposition() {
+        Disposition::Clean => {
+            println!(
+                "validation probe: {} attempted, {} passed, no gate regression",
+                summary.totals.attempted, summary.totals.passed
+            );
+            ExitCode::SUCCESS
+        }
+        Disposition::GateRegressed { count } => {
+            eprintln!(
+                "validation probe: {count} gate cell(s) did not evaluate to a gate pass; \
+                 the lane fails."
+            );
+            for framework in &summary.frameworks {
+                for case in &framework.cases {
+                    for cell in &case.cells {
+                        if cell.evaluation.blocks() {
+                            eprintln!(
+                                "  {} [{}]: expected {:?}, observed {:?}",
+                                cell.probe_id,
+                                cell.dimension,
+                                cell.expected_class,
+                                cell.observed_class
+                            );
+                        }
+                    }
+                }
+            }
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn fail(message: &str) -> ExitCode {
+    eprintln!("{message}");
+    ExitCode::from(2)
+}
+
+fn default_summary_path() -> std::path::PathBuf {
+    verter_validation_probe::corpus::workspace_root()
+        .join("target")
+        .join("validation-probe")
+        .join("summary.json")
+}

--- a/crates/verter_validation_probe/src/corpus/mod.rs
+++ b/crates/verter_validation_probe/src/corpus/mod.rs
@@ -1,0 +1,126 @@
+//! Corpus adapters: the only place a pinned external workload is located on
+//! disk and read.
+//!
+//! An adapter maps a stable case id (`<framework>/<relative-path-in-corpus>`)
+//! to the bytes a probe compiles. It never decides an expectation, never
+//! derives an outcome, and never treats the corpus as an oracle: what the
+//! upstream project asserts about its own fixtures is not evidence about
+//! Verter.
+
+pub mod vue_benchmarks;
+
+use std::fmt;
+use std::path::PathBuf;
+
+/// One workload case: its stable id, its corpus-relative path, and its bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CorpusCase {
+    /// `<framework>/<relative-path-in-corpus>`, the manifest's case id.
+    pub case_id: String,
+    /// The path inside the corpus checkout, POSIX-separated. This is what the
+    /// canonical request carries as `identity.filename`.
+    pub relative_path: String,
+    /// The component text, as UTF-8.
+    pub source: String,
+}
+
+/// Why a corpus could not be read. Absence is never silently an empty slice:
+/// a lane whose corpus is missing fails rather than reporting zero cases.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CorpusError {
+    /// The pinned checkout is not present.
+    CheckoutMissing {
+        /// Where the adapter looked.
+        root: PathBuf,
+    },
+    /// A case the manifest inventories does not exist in the checkout.
+    CaseMissing {
+        /// The case id.
+        case_id: String,
+        /// Where the adapter looked.
+        path: PathBuf,
+    },
+    /// A case id does not belong to this adapter's framework.
+    ForeignCaseId {
+        /// The case id.
+        case_id: String,
+    },
+    /// A case id resolves outside the corpus, or is not a relative path.
+    UnsafeCaseId {
+        /// The case id.
+        case_id: String,
+    },
+    /// The checkout could not be walked or a case could not be read.
+    Io {
+        /// What was being read.
+        path: PathBuf,
+        /// The operating system's message.
+        message: String,
+    },
+}
+
+impl fmt::Display for CorpusError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CorpusError::CheckoutMissing { root } => write!(
+                f,
+                "the pinned corpus checkout is absent at {}",
+                root.display()
+            ),
+            CorpusError::CaseMissing { case_id, path } => write!(
+                f,
+                "inventoried case `{case_id}` does not exist at {}",
+                path.display()
+            ),
+            CorpusError::ForeignCaseId { case_id } => {
+                write!(f, "case id `{case_id}` belongs to another framework")
+            }
+            CorpusError::UnsafeCaseId { case_id } => {
+                write!(
+                    f,
+                    "case id `{case_id}` does not name a path inside the corpus"
+                )
+            }
+            CorpusError::Io { path, message } => {
+                write!(f, "reading {}: {message}", path.display())
+            }
+        }
+    }
+}
+
+impl From<crate::disk::DiskError> for CorpusError {
+    fn from(error: crate::disk::DiskError) -> Self {
+        CorpusError::Io {
+            path: error.path,
+            message: error.message,
+        }
+    }
+}
+
+impl std::error::Error for CorpusError {}
+
+/// The repository root: this crate is `<root>/crates/verter_validation_probe`.
+pub fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|crates| crates.parent())
+        .expect("crate lives at <root>/crates/verter_validation_probe")
+        .to_path_buf()
+}
+
+/// Resolve a POSIX corpus-relative path against `root` without ever joining a
+/// caller-controlled separator or traversal segment.
+#[cfg(feature = "external-corpus")]
+pub(crate) fn resolve_relative(root: &std::path::Path, relative: &str) -> Option<PathBuf> {
+    if relative.is_empty() || relative.contains('\\') {
+        return None;
+    }
+    let mut out = root.to_path_buf();
+    for segment in relative.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return None;
+        }
+        out.push(segment);
+    }
+    Some(out)
+}

--- a/crates/verter_validation_probe/src/corpus/mod.rs
+++ b/crates/verter_validation_probe/src/corpus/mod.rs
@@ -50,6 +50,14 @@ pub enum CorpusError {
         /// The case id.
         case_id: String,
     },
+    /// The checkout's own commit could not be read, so which revision the
+    /// cases came from cannot be established.
+    RevisionUnreadable {
+        /// The checkout root.
+        root: PathBuf,
+        /// What could not be resolved.
+        message: String,
+    },
     /// The checkout could not be walked or a case could not be read.
     Io {
         /// What was being read.
@@ -81,6 +89,11 @@ impl fmt::Display for CorpusError {
                     "case id `{case_id}` does not name a path inside the corpus"
                 )
             }
+            CorpusError::RevisionUnreadable { root, message } => write!(
+                f,
+                "the pinned corpus checkout at {} does not say which commit it is at: {message}",
+                root.display()
+            ),
             CorpusError::Io { path, message } => {
                 write!(f, "reading {}: {message}", path.display())
             }

--- a/crates/verter_validation_probe/src/corpus/vue_benchmarks.rs
+++ b/crates/verter_validation_probe/src/corpus/vue_benchmarks.rs
@@ -39,6 +39,103 @@ pub fn checkout_root() -> PathBuf {
         .expect("the checkout root is a fixed relative path")
 }
 
+/// The commit the checkout is actually AT, read from its own Git state.
+///
+/// The pinned revision is recorded in the manifest and in the workflow, and
+/// every summary artifact republishes it. None of that is evidence that the
+/// bytes the lane compiled came from that commit: a checkout pointed at a
+/// different revision whose fixture set happens to match the inventory would
+/// publish a revision its cases did not come from, which corrupts the one fact
+/// the lane's evidence is anchored on. Reading the commit closes that.
+///
+/// Only a resolvable commit id answers; a checkout whose Git state cannot be
+/// read is reported rather than guessed at.
+#[cfg(feature = "external-corpus")]
+pub fn checkout_revision() -> Result<String, CorpusError> {
+    let root = checkout_root();
+    if !disk::is_directory(&root) {
+        return Err(CorpusError::CheckoutMissing { root });
+    }
+    let git_dir = git_dir(&root)?;
+    let head = read_git_file(&git_dir, "HEAD")?;
+    let head = head.trim();
+    // Detached at the pinned commit, which is what an exact-SHA checkout does.
+    if is_commit_id(head) {
+        return Ok(head.to_string());
+    }
+    let reference = head.strip_prefix("ref: ").map(str::trim).ok_or_else(|| {
+        CorpusError::RevisionUnreadable {
+            root: root.clone(),
+            message: "the checkout's HEAD is neither a commit id nor a symbolic ref".to_string(),
+        }
+    })?;
+    // A loose ref file, then the packed ref table: the two places a checked-out
+    // branch's commit can be.
+    if let Ok(loose) = read_git_file(&git_dir, reference) {
+        let loose = loose.trim();
+        if is_commit_id(loose) {
+            return Ok(loose.to_string());
+        }
+    }
+    let packed = read_git_file(&git_dir, "packed-refs").unwrap_or_default();
+    for line in packed.lines() {
+        let Some((commit, name)) = line.split_once(' ') else {
+            continue;
+        };
+        if name.trim() == reference && is_commit_id(commit) {
+            return Ok(commit.to_string());
+        }
+    }
+    Err(CorpusError::RevisionUnreadable {
+        root,
+        message: format!("the checkout's HEAD ref `{reference}` resolves to no commit"),
+    })
+}
+
+/// The checkout's Git directory, following a `gitdir:` pointer file when the
+/// checkout is a worktree rather than a plain clone.
+#[cfg(feature = "external-corpus")]
+fn git_dir(root: &Path) -> Result<PathBuf, CorpusError> {
+    let dot_git = root.join(".git");
+    if disk::is_directory(&dot_git) {
+        return Ok(dot_git);
+    }
+    if disk::is_file(&dot_git) {
+        let pointer = disk::read_text(&dot_git).map_err(CorpusError::from)?;
+        if let Some(target) = pointer.trim().strip_prefix("gitdir:") {
+            let target = Path::new(target.trim());
+            return Ok(if target.is_absolute() {
+                target.to_path_buf()
+            } else {
+                root.join(target)
+            });
+        }
+    }
+    Err(CorpusError::RevisionUnreadable {
+        root: root.to_path_buf(),
+        message: "the checkout carries no readable Git state".to_string(),
+    })
+}
+
+#[cfg(feature = "external-corpus")]
+fn read_git_file(git_dir: &Path, relative: &str) -> Result<String, CorpusError> {
+    let path =
+        resolve_relative(git_dir, relative).ok_or_else(|| CorpusError::RevisionUnreadable {
+            root: git_dir.to_path_buf(),
+            message: format!("`{relative}` does not name a path inside the Git directory"),
+        })?;
+    disk::read_text(&path).map_err(CorpusError::from)
+}
+
+/// Whether `value` is a full lowercase commit id.
+#[cfg(feature = "external-corpus")]
+fn is_commit_id(value: &str) -> bool {
+    value.len() == 40
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
 /// Every `.vue` case in the checkout, as sorted stable case ids.
 ///
 /// The inventory is DISCOVERED, never declared by the corpus: the manifest's

--- a/crates/verter_validation_probe/src/corpus/vue_benchmarks.rs
+++ b/crates/verter_validation_probe/src/corpus/vue_benchmarks.rs
@@ -1,0 +1,146 @@
+//! The `pikax/vue-benchmarks` corpus adapter.
+//!
+//! The corpus is an external WORKLOAD, never an oracle: this adapter reads its
+//! `.vue` fixtures and nothing else. The upstream project's own expectations,
+//! its `known-failures.json`, and its benchmark results are not read, not
+//! mirrored, and never become an expected output for Verter.
+//!
+//! The checkout is pinned by commit in `manifest/vue.toml` and provisioned only
+//! by the dedicated probe workflow. Every path into it is behind
+//! `feature = "external-corpus"`, so the canonical hermetic run neither reads
+//! nor requires it.
+
+#[cfg(feature = "external-corpus")]
+use std::path::{Path, PathBuf};
+
+use super::CorpusError;
+#[cfg(feature = "external-corpus")]
+use super::{resolve_relative, CorpusCase};
+#[cfg(feature = "external-corpus")]
+use crate::disk;
+use crate::manifest::Framework;
+
+/// The framework every case of this corpus belongs to.
+pub const FRAMEWORK: Framework = Framework::Vue;
+
+/// The fixture subtree the lane draws its cases from. Everything else in the
+/// corpus (its harness, its lockfile, its results) is workload-irrelevant.
+pub const FIXTURE_ROOT: &str = "tests/confirm/fixtures";
+
+/// Where the workflow checks the pinned corpus out, relative to the
+/// repository root.
+#[cfg(feature = "external-corpus")]
+pub const CHECKOUT_RELATIVE_ROOT: &str = ".integration-tests/repos/vue-benchmarks";
+
+/// The pinned checkout's root on this machine.
+#[cfg(feature = "external-corpus")]
+pub fn checkout_root() -> PathBuf {
+    resolve_relative(&super::workspace_root(), CHECKOUT_RELATIVE_ROOT)
+        .expect("the checkout root is a fixed relative path")
+}
+
+/// Every `.vue` case in the checkout, as sorted stable case ids.
+///
+/// The inventory is DISCOVERED, never declared by the corpus: the manifest's
+/// own inventory is then checked against this set in both directions, so a
+/// fixture added or removed upstream fails the lane instead of silently
+/// shrinking or growing what it runs.
+#[cfg(feature = "external-corpus")]
+pub fn discover_case_ids() -> Result<Vec<String>, CorpusError> {
+    let root = checkout_root();
+    if !disk::is_directory(&root) {
+        return Err(CorpusError::CheckoutMissing { root });
+    }
+    let fixtures = resolve_relative(&root, FIXTURE_ROOT).expect("the fixture root is fixed");
+    if !disk::is_directory(&fixtures) {
+        return Err(CorpusError::CheckoutMissing { root: fixtures });
+    }
+    let mut out = Vec::new();
+    collect_carriers(&fixtures, FIXTURE_ROOT, &mut out)?;
+    out.sort();
+    Ok(out)
+}
+
+/// Whether a corpus path is a case of THIS adapter's carrier language.
+///
+/// Asked of the language registry rather than matched by extension here: the
+/// registry is the single classification authority, and a hand-rolled suffix
+/// check in a corpus walker is exactly how a second one starts.
+pub fn is_case_path(path: &str) -> bool {
+    verter_language::LanguageRegistry::global()
+        .classify_static(path)
+        .static_resolution()
+        .is_vue()
+}
+
+#[cfg(feature = "external-corpus")]
+fn collect_carriers(dir: &Path, relative: &str, out: &mut Vec<String>) -> Result<(), CorpusError> {
+    let children: Vec<PathBuf> = disk::sorted_children(dir).map_err(CorpusError::from)?;
+    for child in children {
+        let Some(name) = child.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let child_relative = format!("{relative}/{name}");
+        if disk::is_directory(&child) {
+            collect_carriers(&child, &child_relative, out)?;
+        } else if is_case_path(&child_relative) {
+            out.push(case_id_for(&child_relative));
+        }
+    }
+    Ok(())
+}
+
+/// The stable case id of a corpus-relative path.
+pub fn case_id_for(relative_path: &str) -> String {
+    format!("{}/{relative_path}", FRAMEWORK.as_str())
+}
+
+/// The corpus-relative path a case id names, checked to belong to this
+/// adapter and to stay inside the corpus.
+pub fn relative_path_of(case_id: &str) -> Result<&str, CorpusError> {
+    let prefix = format!("{}/", FRAMEWORK.as_str());
+    let relative = case_id
+        .strip_prefix(&prefix)
+        .ok_or_else(|| CorpusError::ForeignCaseId {
+            case_id: case_id.to_string(),
+        })?;
+    let inside = !relative.is_empty()
+        && !relative.contains('\\')
+        && relative
+            .split('/')
+            .all(|segment| !segment.is_empty() && segment != "." && segment != "..");
+    if inside {
+        Ok(relative)
+    } else {
+        Err(CorpusError::UnsafeCaseId {
+            case_id: case_id.to_string(),
+        })
+    }
+}
+
+/// Read one case's bytes.
+///
+/// CRLF is normalized to LF so a Windows checkout and a Linux checkout feed
+/// the compiler and the reference producer the same bytes — the source is also
+/// what the structural comparator derives its authored-identifier set from, so
+/// an EOL difference must not reach either side.
+#[cfg(feature = "external-corpus")]
+pub fn load_case(case_id: &str) -> Result<CorpusCase, CorpusError> {
+    let relative_path = relative_path_of(case_id)?;
+    let root = checkout_root();
+    let path = resolve_relative(&root, relative_path).ok_or_else(|| CorpusError::UnsafeCaseId {
+        case_id: case_id.to_string(),
+    })?;
+    if !disk::is_file(&path) {
+        return Err(CorpusError::CaseMissing {
+            case_id: case_id.to_string(),
+            path,
+        });
+    }
+    let raw = disk::read_text(&path).map_err(CorpusError::from)?;
+    Ok(CorpusCase {
+        case_id: case_id.to_string(),
+        relative_path: relative_path.to_string(),
+        source: raw.replace("\r\n", "\n"),
+    })
+}

--- a/crates/verter_validation_probe/src/disk.rs
+++ b/crates/verter_validation_probe/src/disk.rs
@@ -1,0 +1,73 @@
+//! The crate's ONE disk boundary.
+//!
+//! This lane is CI tooling: it reads a pinned third-party corpus checkout, its
+//! own committed manifests, and its own published artifact. None of that is
+//! workspace, semantic, overlay or VFS state, so none of it belongs on the
+//! host's disk boundary — but it is still real filesystem access, and it is
+//! confined HERE rather than spread across the corpus adapter, the lane and
+//! the summary binary. One module to audit, one module to allowlist, and no
+//! second place for a future reader to appear.
+//!
+//! Nothing here interprets what it read. Classification, validation and
+//! expectation live in their own modules; this one only moves bytes.
+
+use std::path::{Path, PathBuf};
+
+/// Why a disk operation failed, with the path it was attempted on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DiskError {
+    /// What was being read or written.
+    pub path: PathBuf,
+    /// The operating system's message.
+    pub message: String,
+}
+
+impl std::fmt::Display for DiskError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.path.display(), self.message)
+    }
+}
+
+impl std::error::Error for DiskError {}
+
+fn at(path: &Path, error: std::io::Error) -> DiskError {
+    DiskError {
+        path: path.to_path_buf(),
+        message: error.to_string(),
+    }
+}
+
+/// Read a UTF-8 text file.
+pub fn read_text(path: &Path) -> Result<String, DiskError> {
+    std::fs::read_to_string(path).map_err(|error| at(path, error))
+}
+
+/// Write a UTF-8 text file, creating its parent directory.
+pub fn write_text(path: &Path, text: &str) -> Result<(), DiskError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| at(parent, error))?;
+    }
+    std::fs::write(path, text).map_err(|error| at(path, error))
+}
+
+/// Whether `path` is an existing directory.
+pub fn is_directory(path: &Path) -> bool {
+    path.is_dir()
+}
+
+/// Whether `path` is an existing file.
+pub fn is_file(path: &Path) -> bool {
+    path.is_file()
+}
+
+/// One directory's immediate children, sorted, so a walk over them is
+/// deterministic on every platform.
+pub fn sorted_children(dir: &Path) -> Result<Vec<PathBuf>, DiskError> {
+    let read = std::fs::read_dir(dir).map_err(|error| at(dir, error))?;
+    let mut children = Vec::new();
+    for entry in read {
+        children.push(entry.map_err(|error| at(dir, error))?.path());
+    }
+    children.sort();
+    Ok(children)
+}

--- a/crates/verter_validation_probe/src/evaluate.rs
+++ b/crates/verter_validation_probe/src/evaluate.rs
@@ -68,15 +68,97 @@ impl fmt::Display for Evaluation {
     }
 }
 
+/// What a cell observed, reduced to exactly what the decision reads.
+///
+/// A [`Terminal`] also carries the evidence behind the outcome and the reason
+/// a dimension went unreached or unexercised. None of that decides anything,
+/// and a decision that could see it could come to depend on it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ObservedOutcome {
+    /// The dimension produced this class.
+    Class(ProbeOutcomeClass),
+    /// The dimension was never reached.
+    NotRun,
+    /// The dimension cannot be exercised for this framework.
+    NotApplicable,
+}
+
+impl ObservedOutcome {
+    /// What a terminal observed.
+    pub fn of(terminal: &Terminal) -> Self {
+        match terminal {
+            Terminal::Class { class, .. } => ObservedOutcome::Class(*class),
+            Terminal::NotRun { .. } => ObservedOutcome::NotRun,
+            Terminal::NotApplicable { .. } => ObservedOutcome::NotApplicable,
+        }
+    }
+}
+
+/// Decide one cell from its expectation and its observation, and nothing else.
+///
+/// This is a pure function of the three values a published cell row carries,
+/// which is what lets the summary's read-back RE-DERIVE an evaluation instead
+/// of trusting the one written beside it. A second implementation over there
+/// would be a second authority, and two of those diverge; a document whose
+/// gate cell claims `gate_pass` beside observations that say otherwise has to
+/// be refused by the same rule that wrote it.
+///
+/// An expected class is met only by that exact class: a `crash`, `timeout`, or
+/// `harness_failure` never satisfies an expected diagnostic, refusal, or
+/// unsupported outcome. A cell without an expected class (which validation
+/// rejects for every state but `skip`) never matches.
+pub fn decide(
+    expected_state: ExpectedState,
+    expected_class: Option<ProbeOutcomeClass>,
+    observed: ObservedOutcome,
+) -> Evaluation {
+    match expected_state {
+        ExpectedState::Skip => Evaluation::Skipped,
+        ExpectedState::Gate => match (observed, expected_class) {
+            (ObservedOutcome::Class(observed), Some(expected)) if observed == expected => {
+                Evaluation::GatePass
+            }
+            _ => Evaluation::GateRegression,
+        },
+        ExpectedState::Canary | ExpectedState::KnownFail => {
+            let observed = match observed {
+                ObservedOutcome::NotRun => return Evaluation::NotRun,
+                ObservedOutcome::NotApplicable => return Evaluation::NotApplicable,
+                ObservedOutcome::Class(class) => class,
+            };
+            decide_non_gate(expected_state, expected_class, observed)
+        }
+    }
+}
+
+fn decide_non_gate(
+    expected_state: ExpectedState,
+    expected_class: Option<ProbeOutcomeClass>,
+    observed: ProbeOutcomeClass,
+) -> Evaluation {
+    let pass = ProbeOutcomeClass::Pass;
+    match (expected_state, expected_class) {
+        (ExpectedState::Canary, Some(expected)) if expected == pass => {
+            if observed == pass {
+                Evaluation::ObservedPass
+            } else {
+                Evaluation::CanaryRegression
+            }
+        }
+        (_, Some(_)) if observed == pass => Evaluation::Xpass,
+        (ExpectedState::Canary, Some(expected)) if expected == observed => {
+            Evaluation::CanaryExpected
+        }
+        (ExpectedState::KnownFail, Some(expected)) if expected == observed => {
+            Evaluation::KnownFailExpected
+        }
+        _ => Evaluation::UnrelatedRegression,
+    }
+}
+
 impl ProbeEntry {
     /// Evaluate this cell against its case's observation, reading only the
     /// terminal of the cell's own dimension.
-    ///
-    /// An expected class is met only by that exact class: a `crash`,
-    /// `timeout`, or `harness_failure` never satisfies an expected
-    /// diagnostic, refusal, or unsupported outcome. A cell without an
-    /// expected class (which validation rejects for every state but `skip`)
-    /// never matches.
     ///
     /// # Panics
     ///
@@ -88,43 +170,11 @@ impl ProbeEntry {
             self.probe_id,
             "a cell is evaluated only against its own case's observation"
         );
-        let terminal = observation.terminal(self.dimension);
-        match self.expected_state {
-            ExpectedState::Skip => Evaluation::Skipped,
-            ExpectedState::Gate => match (terminal.class(), self.expected_class) {
-                (Some(observed), Some(expected)) if observed == expected => Evaluation::GatePass,
-                _ => Evaluation::GateRegression,
-            },
-            ExpectedState::Canary | ExpectedState::KnownFail => {
-                let observed = match terminal {
-                    Terminal::NotRun { .. } => return Evaluation::NotRun,
-                    Terminal::NotApplicable { .. } => return Evaluation::NotApplicable,
-                    Terminal::Class { class, .. } => *class,
-                };
-                self.evaluate_non_gate(observed)
-            }
-        }
-    }
-
-    fn evaluate_non_gate(&self, observed: ProbeOutcomeClass) -> Evaluation {
-        let pass = ProbeOutcomeClass::Pass;
-        match (self.expected_state, self.expected_class) {
-            (ExpectedState::Canary, Some(expected)) if expected == pass => {
-                if observed == pass {
-                    Evaluation::ObservedPass
-                } else {
-                    Evaluation::CanaryRegression
-                }
-            }
-            (_, Some(_)) if observed == pass => Evaluation::Xpass,
-            (ExpectedState::Canary, Some(expected)) if expected == observed => {
-                Evaluation::CanaryExpected
-            }
-            (ExpectedState::KnownFail, Some(expected)) if expected == observed => {
-                Evaluation::KnownFailExpected
-            }
-            _ => Evaluation::UnrelatedRegression,
-        }
+        decide(
+            self.expected_state,
+            self.expected_class,
+            ObservedOutcome::of(observation.terminal(self.dimension)),
+        )
     }
 }
 

--- a/crates/verter_validation_probe/src/lane.rs
+++ b/crates/verter_validation_probe/src/lane.rs
@@ -1,0 +1,226 @@
+//! The lane: manifest in, summary out.
+//!
+//! This is the whole of the lane's orchestration, and it is deliberately
+//! small — planning a selection, driving it, and folding the result. Every
+//! decision it makes is the manifest's or the corpus adapter's:
+//!
+//! * WHICH cases run is the manifest's `smoke` slice or its complete
+//!   inventory, never a filter this module invents;
+//! * WHETHER the inventory is still true is checked against the checkout in
+//!   BOTH directions, so a fixture added or removed upstream fails the lane
+//!   rather than silently changing what it covers;
+//! * WHAT an outcome means is [`crate::runner`]'s and the manifest's, never
+//!   re-decided here.
+//!
+//! The module exists only under `external-corpus`: without a pinned checkout
+//! there is no workload, and a lane that answered anyway would be reporting
+//! about nothing.
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use crate::corpus::{vue_benchmarks, CorpusError};
+use crate::disk;
+use crate::manifest::{Framework, ManifestError, ProbeStateManifest};
+use crate::request;
+use crate::runner::{self, DriverCommand, PhaseDeadlines, PlannedCase, RunError};
+use crate::summary::{self, FrameworkRun, Lane, ObservedCase, Summary, SummaryError};
+
+/// Where the lane writes its one machine-readable artifact.
+pub const SUMMARY_RELATIVE_PATH: &str = "target/validation-probe/summary.json";
+
+/// Why a lane could not produce a summary.
+#[derive(Debug)]
+pub enum LaneError {
+    /// The manifest file could not be read.
+    ManifestUnreadable {
+        /// The path.
+        path: PathBuf,
+        /// The operating system's message.
+        message: String,
+    },
+    /// The manifest is not a valid probe-state manifest.
+    Manifest(ManifestError),
+    /// The corpus could not be read.
+    Corpus(CorpusError),
+    /// The manifest's inventory and the checkout disagree.
+    InventoryDrift {
+        /// Inventoried, absent from the checkout.
+        missing: Vec<String>,
+        /// Present in the checkout, not inventoried.
+        unlisted: Vec<String>,
+    },
+    /// The lane could not be driven.
+    Run(RunError),
+    /// An observation could not be represented, or a cell could not be
+    /// evaluated against it.
+    Observation(String),
+    /// The summary is not internally consistent.
+    Summary(SummaryError),
+    /// The summary artifact could not be written.
+    SummaryUnwritable {
+        /// The path.
+        path: PathBuf,
+        /// The operating system's message.
+        message: String,
+    },
+}
+
+impl fmt::Display for LaneError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LaneError::ManifestUnreadable { path, message } => {
+                write!(f, "reading {}: {message}", path.display())
+            }
+            LaneError::Manifest(error) => write!(f, "{error}"),
+            LaneError::Corpus(error) => write!(f, "{error}"),
+            LaneError::InventoryDrift { missing, unlisted } => write!(
+                f,
+                "the manifest inventory and the pinned checkout disagree; \
+                 inventoried but absent: [{}]; present but unlisted: [{}]",
+                missing.join(", "),
+                unlisted.join(", ")
+            ),
+            LaneError::Run(error) => write!(f, "{error}"),
+            LaneError::Observation(message) => f.write_str(message),
+            LaneError::Summary(error) => write!(f, "{error}"),
+            LaneError::SummaryUnwritable { path, message } => {
+                write!(f, "writing {}: {message}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for LaneError {}
+
+/// The manifest directory this crate owns.
+pub fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("manifest")
+}
+
+/// Load and validate one framework's manifest.
+pub fn load_manifest(framework: Framework) -> Result<ProbeStateManifest, LaneError> {
+    let file_name = format!("{}.toml", framework.as_str());
+    let path = manifest_dir().join(&file_name);
+    let text = disk::read_text(&path).map_err(|error| LaneError::ManifestUnreadable {
+        path: error.path,
+        message: error.message,
+    })?;
+    ProbeStateManifest::from_manifest_file(&file_name, &text).map_err(LaneError::Manifest)
+}
+
+/// Check the manifest's inventory against the pinned checkout, in both
+/// directions.
+pub fn check_inventory(manifest: &ProbeStateManifest) -> Result<(), LaneError> {
+    let discovered: BTreeSet<String> = vue_benchmarks::discover_case_ids()
+        .map_err(LaneError::Corpus)?
+        .into_iter()
+        .collect();
+    let inventoried: BTreeSet<&str> = manifest
+        .inventory
+        .iter()
+        .map(|case| case.case_id.as_str())
+        .collect();
+    let missing: Vec<String> = inventoried
+        .iter()
+        .filter(|case_id| !discovered.contains(**case_id))
+        .map(|case_id| case_id.to_string())
+        .collect();
+    let unlisted: Vec<String> = discovered
+        .iter()
+        .filter(|case_id| !inventoried.contains(case_id.as_str()))
+        .cloned()
+        .collect();
+    if missing.is_empty() && unlisted.is_empty() {
+        Ok(())
+    } else {
+        Err(LaneError::InventoryDrift { missing, unlisted })
+    }
+}
+
+/// The case ids `lane` selects from `manifest`.
+pub fn selection(manifest: &ProbeStateManifest, lane: Lane) -> Vec<String> {
+    match lane {
+        Lane::Smoke => manifest.smoke.clone(),
+        Lane::Main => manifest
+            .inventory
+            .iter()
+            .map(|case| case.case_id.clone())
+            .collect(),
+    }
+}
+
+/// Load every selected case's bytes.
+pub fn plan(selected: &[String]) -> Result<Vec<PlannedCase>, LaneError> {
+    selected
+        .iter()
+        .map(|case_id| {
+            vue_benchmarks::load_case(case_id)
+                .map(|case| PlannedCase {
+                    case_id: case.case_id,
+                    relative_path: case.relative_path,
+                    source: case.source,
+                })
+                .map_err(LaneError::Corpus)
+        })
+        .collect()
+}
+
+/// Run one lane end to end and return its summary.
+pub fn run(lane: Lane, deadlines: PhaseDeadlines) -> Result<Summary, LaneError> {
+    let manifest = load_manifest(Framework::Vue)?;
+    check_inventory(&manifest)?;
+    let selected = selection(&manifest, lane);
+    let cases = plan(&selected)?;
+    let driver = DriverCommand::committed(&crate::corpus::workspace_root());
+    let results =
+        runner::run_cases(&manifest, &driver, &cases, deadlines).map_err(LaneError::Run)?;
+
+    let mut observed = Vec::with_capacity(results.len());
+    for result in results {
+        let observation = result
+            .observation
+            .map_err(|error| LaneError::Observation(format!("{}: {error}", result.case_id)))?;
+        observed.push(ObservedCase {
+            case_id: result.case_id,
+            request_digest: result.request_digest,
+            elapsed_ns: result.elapsed_ns,
+            observation,
+        });
+    }
+
+    let run = FrameworkRun {
+        manifest: &manifest,
+        selected,
+        observed,
+    };
+    summary::build(lane, std::slice::from_ref(&run)).map_err(LaneError::Summary)
+}
+
+/// Write the summary artifact and return where it landed.
+pub fn write_summary(summary: &Summary) -> Result<PathBuf, LaneError> {
+    let path = summary_path();
+    disk::write_text(&path, &summary.to_json()).map_err(|error| LaneError::SummaryUnwritable {
+        path: error.path,
+        message: error.message,
+    })?;
+    Ok(path)
+}
+
+/// Where the summary artifact lands.
+pub fn summary_path() -> PathBuf {
+    resolve(&crate::corpus::workspace_root(), SUMMARY_RELATIVE_PATH)
+}
+
+fn resolve(root: &Path, relative: &str) -> PathBuf {
+    relative
+        .split('/')
+        .fold(root.to_path_buf(), |path, segment| path.join(segment))
+}
+
+/// The canonical request template and its digest, for a caller recording what
+/// the lane asked without re-deriving it.
+pub fn request_identity() -> (&'static str, String) {
+    (request::REQUEST_VUE, request::template_digest())
+}

--- a/crates/verter_validation_probe/src/lane.rs
+++ b/crates/verter_validation_probe/src/lane.rs
@@ -6,6 +6,8 @@
 //!
 //! * WHICH cases run is the manifest's `smoke` slice or its complete
 //!   inventory, never a filter this module invents;
+//! * WHETHER the checkout is the pinned one is read from its own Git state, so
+//!   a summary can never record a revision its cases did not come from;
 //! * WHETHER the inventory is still true is checked against the checkout in
 //!   BOTH directions, so a fixture added or removed upstream fails the lane
 //!   rather than silently changing what it covers;
@@ -44,6 +46,13 @@ pub enum LaneError {
     Manifest(ManifestError),
     /// The corpus could not be read.
     Corpus(CorpusError),
+    /// The checkout is at a commit other than the pinned one.
+    RevisionDrift {
+        /// What the manifest pins.
+        pinned: String,
+        /// What the checkout is at.
+        checked_out: String,
+    },
     /// The manifest's inventory and the checkout disagree.
     InventoryDrift {
         /// Inventoried, absent from the checkout.
@@ -75,6 +84,14 @@ impl fmt::Display for LaneError {
             }
             LaneError::Manifest(error) => write!(f, "{error}"),
             LaneError::Corpus(error) => write!(f, "{error}"),
+            LaneError::RevisionDrift {
+                pinned,
+                checked_out,
+            } => write!(
+                f,
+                "the manifest pins `{pinned}` but the checkout is at `{checked_out}`; every \
+                 classification would be recorded against a revision its cases did not come from"
+            ),
             LaneError::InventoryDrift { missing, unlisted } => write!(
                 f,
                 "the manifest inventory and the pinned checkout disagree; \
@@ -99,15 +116,41 @@ pub fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("manifest")
 }
 
-/// Load and validate one framework's manifest.
+/// Load and validate one framework's committed manifest.
 pub fn load_manifest(framework: Framework) -> Result<ProbeStateManifest, LaneError> {
+    load_manifest_from(&manifest_dir(), framework)
+}
+
+/// Load and validate one framework's manifest from `dir`.
+///
+/// The directory is a PARAMETER so the lane can be driven over a planted
+/// manifest without overwriting the committed one: a lane whose zero-selection
+/// refusal could only be proven by editing the file it ships is a refusal
+/// nobody can test.
+pub fn load_manifest_from(
+    dir: &Path,
+    framework: Framework,
+) -> Result<ProbeStateManifest, LaneError> {
     let file_name = format!("{}.toml", framework.as_str());
-    let path = manifest_dir().join(&file_name);
+    let path = dir.join(&file_name);
     let text = disk::read_text(&path).map_err(|error| LaneError::ManifestUnreadable {
         path: error.path,
         message: error.message,
     })?;
     ProbeStateManifest::from_manifest_file(&file_name, &text).map_err(LaneError::Manifest)
+}
+
+/// Check the checkout is at the commit the manifest pins.
+pub fn check_revision(manifest: &ProbeStateManifest) -> Result<(), LaneError> {
+    let checked_out = vue_benchmarks::checkout_revision().map_err(LaneError::Corpus)?;
+    if checked_out == manifest.external_revision.as_str() {
+        Ok(())
+    } else {
+        Err(LaneError::RevisionDrift {
+            pinned: manifest.external_revision.as_str().to_string(),
+            checked_out,
+        })
+    }
 }
 
 /// Check the manifest's inventory against the pinned checkout, in both
@@ -169,7 +212,17 @@ pub fn plan(selected: &[String]) -> Result<Vec<PlannedCase>, LaneError> {
 
 /// Run one lane end to end and return its summary.
 pub fn run(lane: Lane, deadlines: PhaseDeadlines) -> Result<Summary, LaneError> {
-    let manifest = load_manifest(Framework::Vue)?;
+    run_with_manifest_dir(lane, deadlines, &manifest_dir())
+}
+
+/// Run one lane end to end over the manifests in `manifest_dir`.
+pub fn run_with_manifest_dir(
+    lane: Lane,
+    deadlines: PhaseDeadlines,
+    manifest_dir: &Path,
+) -> Result<Summary, LaneError> {
+    let manifest = load_manifest_from(manifest_dir, Framework::Vue)?;
+    check_revision(&manifest)?;
     check_inventory(&manifest)?;
     let selected = selection(&manifest, lane);
     let cases = plan(&selected)?;
@@ -192,6 +245,7 @@ pub fn run(lane: Lane, deadlines: PhaseDeadlines) -> Result<Summary, LaneError> 
 
     let run = FrameworkRun {
         manifest: &manifest,
+        request_template: request::REQUEST_VUE,
         selected,
         observed,
     };

--- a/crates/verter_validation_probe/src/lib.rs
+++ b/crates/verter_validation_probe/src/lib.rs
@@ -55,4 +55,4 @@ pub use outcome::{
     NotApplicableReason, ProbeOutcomeClass, Terminal,
 };
 pub use runner::{classify_execution, ExecutionEvent, Phase, ProbeRun};
-pub use summary::{Counters, Disposition, Lane, Summary, SummaryError};
+pub use summary::{Counters, Disposition, Lane, ObservedTerminal, Summary, SummaryError};

--- a/crates/verter_validation_probe/src/lib.rs
+++ b/crates/verter_validation_probe/src/lib.rs
@@ -12,6 +12,18 @@
 //!   catalog data, never encoded here.
 //! * [`evaluate`] — [`ProbeEntry::evaluate`], the only place an expectation
 //!   meets an observation.
+//! * [`disk`] — the crate's ONE disk boundary; nothing else in the crate
+//!   touches the filesystem.
+//! * [`corpus`] — the corpus adapters: the only place a pinned external
+//!   workload is located on disk and read.
+//! * [`request`] — the one immutable canonical compile request every Vue
+//!   workload case issues, and its digests.
+//! * [`runner`] — the table-driven workload runner: one driver process, the
+//!   ONE public compile route, structural classification, attributable
+//!   termination.
+//! * [`lane`] — under `external-corpus` only: manifest in, summary out.
+//! * [`summary`] — the lane's one compact machine-readable summary and its
+//!   real-exit disposition.
 //!
 //! Observation never implies acceptance: a manifest entry records evidence
 //! about Verter behaviour and never derives expected output from an external
@@ -19,18 +31,28 @@
 //! an implemented authority's atom that lists the gate's exact class.
 
 pub mod authority;
+pub mod corpus;
+pub mod disk;
 pub mod evaluate;
+#[cfg(feature = "external-corpus")]
+pub mod lane;
 pub mod manifest;
 pub mod outcome;
+pub mod request;
+pub mod runner;
+pub mod summary;
 
 pub use authority::Authority;
+pub use corpus::{CorpusCase, CorpusError};
 pub use evaluate::Evaluation;
 pub use manifest::{
     Applicability, ApplicabilityFlags, Case, CellId, ComparatorIdentity, Comparison, ExpectedState,
     Framework, ManifestError, ManifestViolation, ProbeEntry, ProbeStateManifest, Sha256, Sha40,
-    Stratum,
+    Stratum, MAX_SMOKE_CASES,
 };
 pub use outcome::{
     CaseObservation, Dimension, DimensionInput, Evidence, EvidenceSource, InvalidObservation,
     NotApplicableReason, ProbeOutcomeClass, Terminal,
 };
+pub use runner::{classify_execution, ExecutionEvent, Phase, ProbeRun};
+pub use summary::{Counters, Disposition, Lane, Summary, SummaryError};

--- a/crates/verter_validation_probe/src/manifest.rs
+++ b/crates/verter_validation_probe/src/manifest.rs
@@ -446,6 +446,18 @@ pub enum ManifestViolation {
         /// The cell.
         cell: CellId,
     },
+    /// A gate cell at a dimension other than `Route`.
+    GateOutsideRoute {
+        /// The cell.
+        cell: CellId,
+    },
+    /// A gate cell citing an authority other than the public request route.
+    GateAuthorityNotRoute {
+        /// The cell.
+        cell: CellId,
+        /// The authority cited.
+        authority: Authority,
+    },
     /// The smoke slice selects no case, so the required lane would publish a
     /// green summary having run nothing.
     EmptySmokeSlice,
@@ -556,6 +568,16 @@ impl fmt::Display for ManifestViolation {
                     "{cell}: the dimension is inapplicable, so the cell must be a skip"
                 )
             }
+            ManifestViolation::GateOutsideRoute { cell } => write!(
+                f,
+                "{cell}: only Route may gate; every other dimension's behaviour is owned by \
+                 an authority that is not yet implemented"
+            ),
+            ManifestViolation::GateAuthorityNotRoute { cell, authority } => write!(
+                f,
+                "{cell}: a gate may cite only `{}`, not `{authority}`",
+                Authority::CompilerPublicRequestRoute
+            ),
             ManifestViolation::EmptySmokeSlice => f.write_str("the smoke slice selects no case"),
             ManifestViolation::SmokeSliceTooLarge { listed } => write!(
                 f,
@@ -932,6 +954,27 @@ impl ProbeStateManifest {
             }
             (Some(_), Some(_)) => {}
             _ => violations.push(ManifestViolation::MissingCitation { cell: cell.clone() }),
+        }
+        // Which cells may GATE is an invariant of every manifest, not a
+        // property of the one this repository happens to ship: a gate binds the
+        // required job, so it may only ever cite behaviour an implemented
+        // authority owns. Today that is the public request route's callability
+        // and typed refusal, both of which are Route outcomes. A product
+        // refusal, a diagnostic, a comparison, a runtime or a map result is
+        // owned by a framework product authority, and becomes gateable only
+        // when that authority is implemented and a promotion moves it.
+        if entry.expected_state == ExpectedState::Gate {
+            if entry.dimension != Dimension::Route {
+                violations.push(ManifestViolation::GateOutsideRoute { cell: cell.clone() });
+            }
+            if let Some(authority) = entry.authority {
+                if authority != Authority::CompilerPublicRequestRoute {
+                    violations.push(ManifestViolation::GateAuthorityNotRoute {
+                        cell: cell.clone(),
+                        authority,
+                    });
+                }
+            }
         }
         match (entry.expected_state, entry.expected_class) {
             (ExpectedState::Skip, Some(_)) => {

--- a/crates/verter_validation_probe/src/manifest.rs
+++ b/crates/verter_validation_probe/src/manifest.rs
@@ -20,6 +20,13 @@ use crate::outcome::{
     Terminal,
 };
 
+/// The largest smoke slice a pull-request lane accepts.
+///
+/// The bound is STRUCTURAL, not a wall clock: a lane whose size is a time
+/// budget grows silently as machines get faster and shrinks as they get
+/// loaded, and neither tells a reviewer what the required job covers.
+pub const MAX_SMOKE_CASES: usize = 24;
+
 /// A first-class Verter target framework. Always a case attribute, never a
 /// runner variant.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -300,6 +307,16 @@ pub struct ProbeStateManifest {
     /// The complete ratified case list.
     #[serde(default)]
     pub inventory: Vec<Case>,
+    /// The deterministic pull-request smoke slice, by case id.
+    ///
+    /// Listed rather than computed at run time, and then checked to EQUAL its
+    /// own derivation — the lexicographic first `min_cases` of each stratum in
+    /// declaration order. A reviewer reads exactly what a pull request runs,
+    /// and a hand-edited, reordered, emptied, or padded slice fails
+    /// [`ProbeStateManifest::validate`] instead of quietly changing what the
+    /// required lane covers.
+    #[serde(default)]
+    pub smoke: Vec<String>,
     /// One cell per `{ probe_id, dimension }` for every inventory case.
     #[serde(default)]
     pub entries: Vec<ProbeEntry>,
@@ -429,6 +446,21 @@ pub enum ManifestViolation {
         /// The cell.
         cell: CellId,
     },
+    /// The smoke slice selects no case, so the required lane would publish a
+    /// green summary having run nothing.
+    EmptySmokeSlice,
+    /// The smoke slice is larger than the bound a pull-request lane accepts.
+    SmokeSliceTooLarge {
+        /// The cases listed.
+        listed: usize,
+    },
+    /// The smoke slice is not the deterministic derivation of its own strata.
+    SmokeSliceNotDerived {
+        /// The lexicographic first-`min_cases`-per-stratum slice.
+        expected: Vec<String>,
+        /// What the manifest lists.
+        listed: Vec<String>,
+    },
 }
 
 impl fmt::Display for ManifestViolation {
@@ -524,6 +556,19 @@ impl fmt::Display for ManifestViolation {
                     "{cell}: the dimension is inapplicable, so the cell must be a skip"
                 )
             }
+            ManifestViolation::EmptySmokeSlice => f.write_str("the smoke slice selects no case"),
+            ManifestViolation::SmokeSliceTooLarge { listed } => write!(
+                f,
+                "the smoke slice lists {listed} cases, above the {MAX_SMOKE_CASES} a \
+                 pull-request lane accepts"
+            ),
+            ManifestViolation::SmokeSliceNotDerived { expected, listed } => write!(
+                f,
+                "the smoke slice is not the lexicographic first-min_cases-per-stratum \
+                 derivation; expected [{}], found [{}]",
+                expected.join(", "),
+                listed.join(", ")
+            ),
         }
     }
 }
@@ -694,6 +739,7 @@ impl ProbeStateManifest {
         self.validate_header(&mut violations);
         let inventory = self.validate_inventory(&mut violations);
         self.validate_strata(&mut violations);
+        self.validate_smoke(&mut violations);
         self.validate_cells(&inventory, &mut violations);
         if violations.is_empty() {
             Ok(())
@@ -773,6 +819,57 @@ impl ProbeStateManifest {
                     matched,
                 });
             }
+        }
+    }
+
+    /// The deterministic smoke slice this manifest's strata and inventory
+    /// derive: within each stratum, in declaration order, the lexicographic
+    /// first `min_cases` inventory cases that fall into it.
+    ///
+    /// A case belongs to the FIRST stratum whose pattern matches its file
+    /// name, exactly as the stratum-coverage check assigns it, so the two can
+    /// never disagree about which family a case counts towards.
+    pub fn derived_smoke_slice(&self) -> Vec<String> {
+        let mut buckets: Vec<Vec<&str>> = vec![Vec::new(); self.strata.len()];
+        for case in &self.inventory {
+            let file_name = case.case_id.rsplit('/').next().unwrap_or_default();
+            if let Some(index) = self
+                .strata
+                .iter()
+                .position(|stratum| glob_matches(&stratum.pattern, file_name))
+            {
+                buckets[index].push(case.case_id.as_str());
+            }
+        }
+        let mut slice = Vec::new();
+        for (stratum, bucket) in self.strata.iter().zip(buckets.iter_mut()) {
+            bucket.sort_unstable();
+            slice.extend(
+                bucket
+                    .iter()
+                    .take(stratum.min_cases as usize)
+                    .map(|case_id| case_id.to_string()),
+            );
+        }
+        slice
+    }
+
+    fn validate_smoke(&self, violations: &mut Vec<ManifestViolation>) {
+        if self.smoke.is_empty() {
+            violations.push(ManifestViolation::EmptySmokeSlice);
+            return;
+        }
+        if self.smoke.len() > MAX_SMOKE_CASES {
+            violations.push(ManifestViolation::SmokeSliceTooLarge {
+                listed: self.smoke.len(),
+            });
+        }
+        let expected = self.derived_smoke_slice();
+        if expected != self.smoke {
+            violations.push(ManifestViolation::SmokeSliceNotDerived {
+                expected,
+                listed: self.smoke.clone(),
+            });
         }
     }
 

--- a/crates/verter_validation_probe/src/request.rs
+++ b/crates/verter_validation_probe/src/request.rs
@@ -1,0 +1,83 @@
+//! The one canonical compile request every Vue workload case issues.
+//!
+//! The template is IMMUTABLE and carried verbatim into the summary and every
+//! observation artifact beside its digest, so a reader can tell what was asked
+//! without trusting the runner's description of it. There is exactly one
+//! substitution — `identity.filename` — and it is applied to the template
+//! text, never to a re-serialized object: a request the lane reports and a
+//! request the lane sent cannot drift apart.
+//!
+//! The template omits every optional option deliberately. Absent means "the
+//! host's own default", which is what makes this request comparable with the
+//! reference compiler's `dev`, non-SSR, VDOM compile: the defaults are the
+//! compiler's to choose, not the probe's to assert.
+
+use sha2::{Digest, Sha256};
+
+/// The placeholder `identity.filename` holds in the template.
+pub const FILENAME_PLACEHOLDER: &str = "<case relative path>";
+
+/// The canonical `HostCompileRequest` template for the `vue` arm: canonical
+/// JSON, keys sorted at every level, no whitespace.
+pub const REQUEST_VUE: &str = concat!(
+    r#"{"framework":"vue","#,
+    r#""identity":{"componentId":null,"filename":"<case relative path>","forceJs":false,"isProduction":false},"#,
+    r#""options":{"babelParserPlugins":[],"backend":"vdom","isCustomElement":[],"ssr":false},"#,
+    r#""products":[{"inline":null,"kind":"runtimeClient","runtimeSourceMap":false}]}"#,
+);
+
+/// Lowercase hex of `bytes`' SHA-256.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push(char::from_digit((byte >> 4) as u32, 16).expect("nibble"));
+        out.push(char::from_digit((byte & 0x0f) as u32, 16).expect("nibble"));
+    }
+    out
+}
+
+/// The template's own digest, recorded once per summary and per observation
+/// artifact header.
+pub fn template_digest() -> String {
+    sha256_hex(REQUEST_VUE.as_bytes())
+}
+
+/// The template with `identity.filename` set to `relative_path`.
+///
+/// The path is JSON-escaped rather than interpolated raw: a corpus path is
+/// upstream-controlled text, and a quote or backslash in one must produce an
+/// escaped string, never a request whose shape the corpus decided.
+pub fn substitute(relative_path: &str) -> String {
+    REQUEST_VUE.replace(
+        &json_string(FILENAME_PLACEHOLDER),
+        &json_string(relative_path),
+    )
+}
+
+/// The digest of one case's substituted request, recorded on its summary row
+/// and every observation row.
+pub fn request_digest(relative_path: &str) -> String {
+    sha256_hex(substitute(relative_path).as_bytes())
+}
+
+/// `value` as a JSON string literal, including its quotes.
+fn json_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str(r#"\""#),
+            '\\' => out.push_str(r"\\"),
+            '\n' => out.push_str(r"\n"),
+            '\r' => out.push_str(r"\r"),
+            '\t' => out.push_str(r"\t"),
+            ch if (ch as u32) < 0x20 => {
+                let _ = std::fmt::Write::write_fmt(&mut out, format_args!(r"\u{:04x}", ch as u32));
+            }
+            ch => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}

--- a/crates/verter_validation_probe/src/runner.rs
+++ b/crates/verter_validation_probe/src/runner.rs
@@ -110,23 +110,26 @@ impl fmt::Display for Phase {
 }
 
 /// A raw execution event, before any per-dimension folding.
+///
+/// The phase each arm carries is [`ProbeRun::outcome_phase`] — the step that
+/// was still running, which is not always the last one announced.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ExecutionEvent {
     /// The driver process could not be started.
     SpawnFailed,
     /// A phase exceeded its deadline.
     TimedOut {
-        /// The last phase the driver announced.
+        /// The phase this outcome belongs to.
         phase: Option<Phase>,
     },
     /// The process died by signal.
     Signaled {
-        /// The last phase the driver announced.
+        /// The phase this outcome belongs to.
         phase: Option<Phase>,
     },
     /// The process exited.
     Exited {
-        /// The last phase the driver announced.
+        /// The phase this outcome belongs to.
         phase: Option<Phase>,
         /// The exit code.
         code: i32,
@@ -577,8 +580,22 @@ impl ProbeRun {
         &self.probe_id
     }
 
-    /// The last phase the driver announced for this probe.
-    pub fn phase(&self) -> Option<Phase> {
+    /// The phase a process outcome belongs to.
+    ///
+    /// Usually the last phase the driver announced — but the COMPILE FRAME
+    /// also moves the probe on, ahead of the marker that follows it. That
+    /// frame is written only once the native call has returned, so from the
+    /// moment it is ingested nothing of the compiler is still running and a
+    /// death or a deadline can only have struck the reference work. Reading
+    /// the marker alone would report a reference that hung before announcing
+    /// itself as a compiler TIMEOUT, and one that died there as a compiler
+    /// CRASH: a verdict about Verter drawn from a step Verter had already
+    /// finished. This is the boundary the reference deadline is armed at, so
+    /// the budget a probe is held to and the cause it is attributed to agree.
+    pub fn outcome_phase(&self) -> Option<Phase> {
+        if self.compile.is_some() {
+            return Some(Phase::Reference);
+        }
         self.phase
     }
 
@@ -1406,7 +1423,7 @@ fn drive_probe(
             Err(RecvTimeoutError::Timeout) => {
                 let _ = child.kill();
                 *stop = Some(LaneStop::Process(ExecutionEvent::TimedOut {
-                    phase: run.phase(),
+                    phase: run.outcome_phase(),
                 }));
                 return;
             }
@@ -1414,12 +1431,16 @@ fn drive_probe(
                 *stop = Some(LaneStop::Process(match child.wait() {
                     Ok(status) => match status.code() {
                         Some(code) => ExecutionEvent::Exited {
-                            phase: run.phase(),
+                            phase: run.outcome_phase(),
                             code,
                         },
-                        None => ExecutionEvent::Signaled { phase: run.phase() },
+                        None => ExecutionEvent::Signaled {
+                            phase: run.outcome_phase(),
+                        },
                     },
-                    Err(_) => ExecutionEvent::Signaled { phase: run.phase() },
+                    Err(_) => ExecutionEvent::Signaled {
+                        phase: run.outcome_phase(),
+                    },
                 }));
                 return;
             }

--- a/crates/verter_validation_probe/src/runner.rs
+++ b/crates/verter_validation_probe/src/runner.rs
@@ -59,6 +59,17 @@ pub struct PhaseDeadlines {
     pub reference: Duration,
 }
 
+impl PhaseDeadlines {
+    /// The deadline that bounds `phase`.
+    pub const fn of(self, phase: Phase) -> Duration {
+        match phase {
+            Phase::Load => self.load,
+            Phase::Compile => self.compile,
+            Phase::Reference => self.reference,
+        }
+    }
+}
+
 impl Default for PhaseDeadlines {
     fn default() -> Self {
         PhaseDeadlines {
@@ -298,11 +309,23 @@ impl DiagnosticsSnapshot {
             .any(|diagnostic| diagnostic.severity == "error")
     }
 
-    /// The comparator's severity-ordered row projection.
-    fn rows(&self) -> Vec<verter_vue_conformance::compare::DiagnosticRow> {
+    /// The comparator's severity-ordered row projection, ERROR severity only.
+    ///
+    /// The reference producer reports only errors — a reference that emitted
+    /// one is a `reference_failure` and is never compared — so for a produced
+    /// module its diagnostics channel carries no warning and no tip. Comparing
+    /// Verter's warnings against that structurally empty side would report a
+    /// difference the harness itself created by discarding the other compiler's
+    /// warnings, and would report it on exactly the cases whose products match:
+    /// each of those would be held back from surfacing as a promotion
+    /// candidate. Restricting both sides to errors keeps the difference that is
+    /// real — Verter erroring where the reference did not — and drops the one
+    /// that is an artefact of a channel nobody captured.
+    fn error_rows(&self) -> Vec<verter_vue_conformance::compare::DiagnosticRow> {
         let mut rows: Vec<_> = self
             .diagnostics
             .iter()
+            .filter(|diagnostic| diagnostic.severity == "error")
             .map(
                 |diagnostic| verter_vue_conformance::compare::DiagnosticRow {
                     kind: diagnostic.severity.clone(),
@@ -452,9 +475,9 @@ struct CompileFrame {
 /// Why a frame was refused before anything was classified from it.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FrameViolation {
-    /// A frame for a probe the runner never requested.
+    /// A line naming a probe other than the one being driven.
     UnknownProbe {
-        /// The id the frame claimed.
+        /// The id the line claimed.
         probe_id: String,
     },
     /// A second compile frame for one probe.
@@ -500,7 +523,7 @@ impl fmt::Display for FrameViolation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FrameViolation::UnknownProbe { probe_id } => {
-                write!(f, "frame for unrequested probe `{probe_id}`")
+                write!(f, "a line arrived naming another probe, `{probe_id}`")
             }
             FrameViolation::DuplicateCompileFrame { probe_id } => {
                 write!(f, "`{probe_id}`: a second compile frame arrived")
@@ -571,12 +594,35 @@ impl ProbeRun {
 
     /// Ingest one driver line.
     ///
-    /// A frame is validated against the entry set this probe holds BEFORE it
-    /// is retained: the count must match, each position's id must be the one
+    /// A line is believed only for the probe it NAMES: the protocol is one
+    /// probe at a time, so a line claiming another probe means the stream and
+    /// the runner are out of step, and pairing it here would attribute one
+    /// case's product, reference, or failure to another case.
+    ///
+    /// A frame is then validated against the entry set this probe holds BEFORE
+    /// it is retained: the count must match, each position's id must be the one
     /// requested there, and no id may repeat. A violation records a harness
     /// failure and the frame is dropped whole — nothing is paired positionally
     /// from a frame that failed its own identity check.
     pub fn ingest_frame(&mut self, line: DriverLine) -> Result<(), FrameViolation> {
+        let claimed = match &line {
+            DriverLine::Phase { probe_id, .. }
+            | DriverLine::Compile { probe_id, .. }
+            | DriverLine::Reference { probe_id, .. } => Some(probe_id.as_str()),
+            // The driver cannot always attribute an error: a probe line it
+            // could not even parse carries no id it could trust. Such a line
+            // belongs to the probe the runner is waiting on.
+            DriverLine::Error { probe_id, .. } => probe_id.as_deref(),
+        };
+        if let Some(claimed) = claimed {
+            if claimed != self.probe_id {
+                let violation = FrameViolation::UnknownProbe {
+                    probe_id: claimed.to_string(),
+                };
+                self.harness.push(violation.to_string());
+                return Err(violation);
+            }
+        }
         match line {
             DriverLine::Phase { phase, .. } => {
                 self.phase = Some(phase);
@@ -719,19 +765,26 @@ impl ProbeRun {
         let mut evidence = Vec::new();
 
         let diagnostics = match (&entry.response, &entry.failure) {
-            (Some(response), _) => &response.diagnostics,
+            (Some(response), None) => &response.diagnostics,
             (None, Some(failure)) => &failure.diagnostics,
-            (None, None) => {
-                // Neither arm: the route answered nothing the classifier can
-                // read. Failing closed keeps an unexplained envelope from
-                // reading as a pass.
+            // Neither arm, or both. The route answers exactly one of them; an
+            // envelope carrying none says nothing the classifier can read, and
+            // one carrying both says two contradictory things. Failing closed on
+            // each keeps an unexplained envelope from reading as a pass and
+            // keeps the runner from silently preferring one arm over the other.
+            (response, failure) => {
+                let message = if response.is_none() && failure.is_none() {
+                    "route entry carries neither a response nor a failure"
+                } else {
+                    "route entry carries both a response and a failure"
+                };
                 return self.all_dimensions(
                     manifest,
                     requested,
                     ProbeOutcomeClass::HarnessFailure,
                     vec![Evidence {
                         source: EvidenceSource::Driver,
-                        message: "route entry carries neither a response nor a failure".to_string(),
+                        message: message.to_string(),
                     }],
                 );
             }
@@ -987,7 +1040,7 @@ impl ProbeRun {
             .as_ref()
             .and_then(|frame| frame.entries.get(position))
             .and_then(|entry| entry.response.as_ref())
-            .map(|response| response.diagnostics.rows())
+            .map(|response| response.diagnostics.error_rows())
             .unwrap_or_default()
     }
 
@@ -1145,10 +1198,44 @@ impl DriverCommand {
     }
 }
 
+/// Why the runner stopped driving probes through this process.
+///
+/// The two arms exist because they are not the same evidence. A process
+/// outcome is classified by the phase it happened in, which is what makes a
+/// compiler crash distinguishable from an addon that would not load. A harness
+/// stop is the probe's own transport or protocol failing — a broken stdout
+/// pipe, a line the runner could not parse, a frame naming another probe — and
+/// running that through the phase map would report a crash or a timeout the
+/// compiler never had.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LaneStop {
+    /// The process ended, or was killed for exceeding a phase deadline.
+    Process(ExecutionEvent),
+    /// The harness could not keep speaking to a process that may still be
+    /// alive and healthy.
+    Harness,
+}
+
+impl LaneStop {
+    /// The process outcome, when this stop was one.
+    fn process(&self) -> Option<ExecutionEvent> {
+        match self {
+            LaneStop::Process(event) => Some(*event),
+            LaneStop::Harness => None,
+        }
+    }
+}
+
 /// Drive every planned case through one driver process and fold the results.
 ///
 /// One process serves the whole lane, and each case is its own probe, so a
-/// per-case failure is attributed to that case while the rest keep running.
+/// per-case failure is attributed to that case while the rest keep running:
+/// a driver that reports a failure as a LINE has finished that probe, and the
+/// next one is sent.
+///
+/// Only a [`LaneStop`] ends the lane — the process died, or the harness can no
+/// longer trust what it is reading — and every case after it is recorded as a
+/// harness failure rather than left without an outcome.
 pub fn run_cases(
     manifest: &ProbeStateManifest,
     driver: &DriverCommand,
@@ -1186,7 +1273,7 @@ pub fn run_cases(
     let lines = spawn_reader(stdout);
 
     let mut results = Vec::with_capacity(cases.len());
-    let mut terminated: Option<ExecutionEvent> = None;
+    let mut stop: Option<LaneStop> = None;
     for case in cases {
         let requested = vec![RequestedEntry {
             canonical_id: case.case_id.clone(),
@@ -1194,18 +1281,20 @@ pub fn run_cases(
             request_digest: request::request_digest(&case.relative_path),
         }];
         let mut run = ProbeRun::new(case.case_id.clone(), requested);
-        if terminated.is_none() {
+        if stop.is_none() {
             match write_probe(&mut child, case) {
-                Ok(()) => drive_probe(&mut run, &lines, deadlines, &mut terminated, &mut child),
+                Ok(()) => drive_probe(&mut run, &lines, deadlines, &mut stop, &mut child),
                 Err(message) => {
                     run.record_harness_failure(message);
                 }
             }
         } else {
-            run.record_harness_failure("the driver terminated before this probe was sent");
+            run.record_harness_failure(
+                "the driver stopped serving probes before this one was sent",
+            );
         }
         let elapsed_ns = run.compile.as_ref().map(|frame| frame.elapsed_ns);
-        let observations = run.finish(manifest, terminated);
+        let observations = run.finish(manifest, stop.as_ref().and_then(LaneStop::process));
         results.push(CaseResult {
             case_id: case.case_id.clone(),
             request_digest: request::request_digest(&case.relative_path),
@@ -1245,7 +1334,7 @@ fn drive_probe(
     run: &mut ProbeRun,
     lines: &Receiver<Result<String, String>>,
     deadlines: PhaseDeadlines,
-    terminated: &mut Option<ExecutionEvent>,
+    stop: &mut Option<LaneStop>,
     child: &mut Child,
 ) {
     let mut deadline = Instant::now() + deadlines.load;
@@ -1254,40 +1343,75 @@ fn drive_probe(
         match lines.recv_timeout(remaining) {
             Ok(Ok(line)) => match parse_line(&line) {
                 Ok(parsed) => {
-                    if let DriverLine::Phase { phase, .. } = &parsed {
-                        deadline = Instant::now()
-                            + match phase {
-                                Phase::Load => deadlines.load,
-                                Phase::Compile => deadlines.compile,
-                                Phase::Reference => deadlines.reference,
-                            };
+                    match &parsed {
+                        DriverLine::Phase { phase, .. } => {
+                            deadline = Instant::now() + deadlines.of(*phase);
+                        }
+                        // The compile frame IS the native call's answer, so
+                        // what remains for this probe is reference work and the
+                        // reference deadline is what bounds it. Leaving the
+                        // compile deadline armed would report a reference that
+                        // hung before announcing its phase as a compiler
+                        // timeout — the one distinction the taxonomy leans on
+                        // hardest.
+                        DriverLine::Compile { .. } => {
+                            deadline = Instant::now() + deadlines.reference;
+                        }
+                        DriverLine::Reference { .. } | DriverLine::Error { .. } => {}
                     }
-                    let done = matches!(parsed, DriverLine::Reference { .. });
-                    let _ = run.ingest_frame(parsed);
+                    // A reference frame completes the probe — and so does a
+                    // driver error, which the driver writes INSTEAD of
+                    // finishing the protocol before going back to waiting for
+                    // the next probe. Waiting for a frame that will never come
+                    // would spend the whole deadline and then kill a healthy
+                    // driver, turning one recoverable per-case failure into a
+                    // lane that reports nothing about every case after it.
+                    let done = matches!(
+                        parsed,
+                        DriverLine::Reference { .. } | DriverLine::Error { .. }
+                    );
+                    if run.ingest_frame(parsed).is_err() {
+                        // The line failed its own identity or cardinality
+                        // check, so the stream and the probes are out of step
+                        // and the next probe's lines cannot be told from this
+                        // one's. Stopping the lane deliberately keeps the
+                        // misalignment from cascading into cases whose
+                        // evidence describes a different case.
+                        let _ = child.kill();
+                        *stop = Some(LaneStop::Harness);
+                        return;
+                    }
                     if done {
                         return;
                     }
                 }
                 Err(message) => {
                     run.record_harness_failure(format!("unparseable driver line: {message}"));
+                    // How much of the protocol that line was is unknowable, so
+                    // the same reasoning applies: stop rather than read the
+                    // next probe's lines as this one's.
+                    let _ = child.kill();
+                    *stop = Some(LaneStop::Harness);
                     return;
                 }
             },
             Ok(Err(message)) => {
                 run.record_harness_failure(format!("reading the driver: {message}"));
-                *terminated = Some(ExecutionEvent::Exited {
-                    phase: run.phase(),
-                    code: -1,
-                });
+                // A broken pipe is the harness's own transport failing, NOT a
+                // process outcome: classifying it through the phase map would
+                // report a crash the compiler never had.
+                *stop = Some(LaneStop::Harness);
                 return;
             }
             Err(RecvTimeoutError::Timeout) => {
                 let _ = child.kill();
-                *terminated = Some(ExecutionEvent::TimedOut { phase: run.phase() });
+                *stop = Some(LaneStop::Process(ExecutionEvent::TimedOut {
+                    phase: run.phase(),
+                }));
                 return;
             }
             Err(RecvTimeoutError::Disconnected) => {
-                *terminated = Some(match child.wait() {
+                *stop = Some(LaneStop::Process(match child.wait() {
                     Ok(status) => match status.code() {
                         Some(code) => ExecutionEvent::Exited {
                             phase: run.phase(),
@@ -1296,7 +1420,7 @@ fn drive_probe(
                         None => ExecutionEvent::Signaled { phase: run.phase() },
                     },
                     Err(_) => ExecutionEvent::Signaled { phase: run.phase() },
-                });
+                }));
                 return;
             }
         }

--- a/crates/verter_validation_probe/src/runner.rs
+++ b/crates/verter_validation_probe/src/runner.rs
@@ -1,0 +1,1326 @@
+//! The table-driven workload runner.
+//!
+//! There is no per-fixture test and no per-case CI job: the runner reads a
+//! validated probe-state manifest, asks its corpus adapter for the listed
+//! cases, drives them through the ONE public compile route, and folds what it
+//! saw into a [`CaseObservation`] per case. `framework` is a case attribute
+//! throughout — never a runner variant — so a second corpus plugs in by
+//! registering an adapter and a reference producer, not by forking this file.
+//!
+//! Three properties the rest of the lane depends on:
+//!
+//! * **Classification reads structure, never message text.** A failure is
+//!   classified by its `kind`, its diagnostics' severities, and the shape of
+//!   the product it did or did not produce. No branch matches on a message.
+//! * **Frames are authenticated before they are believed.** A frame is paired
+//!   with its probe by id and checked for cardinality and per-position
+//!   identity before anything is classified, so a dropped, duplicated, or
+//!   reordered entry can never attach one case's product or reference to
+//!   another case.
+//! * **Termination is attributable.** The driver announces each phase, so a
+//!   death with no line is attributed to the step that was running: an addon
+//!   that fails to load is a harness failure, a compiler that hangs is a
+//!   timeout, and a reference producer that dies costs only the Structural
+//!   cell.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::manifest::{Comparison, Framework, ProbeStateManifest};
+use crate::outcome::{
+    CaseObservation, Dimension, DimensionInput, Evidence, EvidenceSource, InvalidObservation,
+    NotApplicableReason, ProbeOutcomeClass,
+};
+use crate::request;
+
+/// The comparator's reason cap. Fixed in the crate: a lane that tuned it per
+/// run would report a different number of reasons for the same difference.
+pub const MAX_REASONS: usize = 32;
+
+/// How long each phase may take before the driver is killed.
+///
+/// Per phase, not per process: a compiler that hangs is a `timeout` and a
+/// reference producer that hangs is a `reference_failure`, and neither can be
+/// mistaken for the other.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PhaseDeadlines {
+    /// Addon load and driver start.
+    pub load: Duration,
+    /// The bracketed `compileRequests` call.
+    pub compile: Duration,
+    /// Reference production.
+    pub reference: Duration,
+}
+
+impl Default for PhaseDeadlines {
+    fn default() -> Self {
+        PhaseDeadlines {
+            load: Duration::from_secs(120),
+            compile: Duration::from_secs(120),
+            reference: Duration::from_secs(120),
+        }
+    }
+}
+
+/// The step the driver announced it was entering.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    /// Loading the addon.
+    Load,
+    /// Inside the bracketed compile call.
+    Compile,
+    /// Producing the reference product.
+    Reference,
+}
+
+impl Phase {
+    /// The serialized name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Phase::Load => "load",
+            Phase::Compile => "compile",
+            Phase::Reference => "reference",
+        }
+    }
+}
+
+impl fmt::Display for Phase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A raw execution event, before any per-dimension folding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExecutionEvent {
+    /// The driver process could not be started.
+    SpawnFailed,
+    /// A phase exceeded its deadline.
+    TimedOut {
+        /// The last phase the driver announced.
+        phase: Option<Phase>,
+    },
+    /// The process died by signal.
+    Signaled {
+        /// The last phase the driver announced.
+        phase: Option<Phase>,
+    },
+    /// The process exited.
+    Exited {
+        /// The last phase the driver announced.
+        phase: Option<Phase>,
+        /// The exit code.
+        code: i32,
+    },
+}
+
+/// Classify one raw execution event.
+///
+/// The phase is what makes the three failures distinct rather than one
+/// undifferentiated "the driver died":
+///
+/// * before any marker, or in `load` — the driver or the addon never got
+///   started, which is the harness's own failure and says nothing about the
+///   compiler;
+/// * in `compile` — the only code running is inside the native call, because
+///   every JavaScript step around it reports as a line rather than an exit, so
+///   this is genuinely the compiler crashing or hanging;
+/// * in `reference` — the compiler already answered and its frame is already
+///   ingested, so the loss is confined to the comparison input.
+///
+/// A clean exit is not an event any probe is classified from: it finalizes the
+/// protocol per probe, which [`ProbeRun`] does from the frames it did and did
+/// not receive.
+pub fn classify_execution(event: ExecutionEvent) -> ProbeOutcomeClass {
+    match event {
+        ExecutionEvent::SpawnFailed => ProbeOutcomeClass::HarnessFailure,
+        ExecutionEvent::TimedOut { phase } => match phase {
+            None | Some(Phase::Load) => ProbeOutcomeClass::HarnessFailure,
+            Some(Phase::Compile) => ProbeOutcomeClass::Timeout,
+            Some(Phase::Reference) => ProbeOutcomeClass::ReferenceFailure,
+        },
+        ExecutionEvent::Signaled { phase } => match phase {
+            None | Some(Phase::Load) => ProbeOutcomeClass::HarnessFailure,
+            Some(Phase::Compile) => ProbeOutcomeClass::Crash,
+            Some(Phase::Reference) => ProbeOutcomeClass::ReferenceFailure,
+        },
+        ExecutionEvent::Exited { phase, code } => {
+            if code == 0 {
+                // A clean exit decides nothing on its own: the protocol is
+                // finalized per probe from the frames that did and did not
+                // arrive.
+                ProbeOutcomeClass::Pass
+            } else {
+                match phase {
+                    None | Some(Phase::Load) => ProbeOutcomeClass::HarnessFailure,
+                    Some(Phase::Compile) => ProbeOutcomeClass::Crash,
+                    Some(Phase::Reference) => ProbeOutcomeClass::ReferenceFailure,
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Driver wire shapes
+// ---------------------------------------------------------------------------
+
+/// One line the driver wrote. The arms are distinguished structurally, by the
+/// fields a line carries, never by inspecting a message.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DriverLine {
+    /// A phase marker.
+    Phase {
+        /// The probe it belongs to.
+        probe_id: String,
+        /// The phase being entered.
+        phase: Phase,
+    },
+    /// The compile frame.
+    Compile {
+        /// The probe it belongs to.
+        probe_id: String,
+        /// Nanoseconds bracketing exactly the compile call.
+        elapsed_ns: u64,
+        /// The route's answer, one entry per requested entry, in order.
+        entries: Vec<RouteEntry>,
+    },
+    /// The reference frame.
+    Reference {
+        /// The probe it belongs to.
+        probe_id: String,
+        /// One reference result per requested entry, in order.
+        reference: Vec<ReferenceResult>,
+    },
+    /// A driver-level exception.
+    Error {
+        /// The probe it belongs to, when the driver could attribute one.
+        probe_id: Option<String>,
+        /// The message, verbatim; retained as evidence, never classified from.
+        error: String,
+    },
+}
+
+/// One `compileRequests` answer, carried whole.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct RouteEntry {
+    /// The id the route answered for this position.
+    #[serde(rename = "canonicalId")]
+    pub canonical_id: String,
+    /// The success arm.
+    #[serde(default)]
+    pub response: Option<RouteResponse>,
+    /// The typed failure arm.
+    #[serde(default)]
+    pub failure: Option<RouteFailure>,
+}
+
+/// A typed compile response.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct RouteResponse {
+    /// The diagnostics snapshot, intact.
+    pub diagnostics: DiagnosticsSnapshot,
+    /// The products, intact.
+    pub products: Vec<RouteProduct>,
+}
+
+/// One product row.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct RouteProduct {
+    /// The product's wire tag.
+    pub kind: String,
+    /// The separately-addressed outputs, when this product has them.
+    #[serde(default)]
+    pub nodes: Option<Vec<RouteNode>>,
+}
+
+/// One addressed output of a runtime product.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct RouteNode {
+    /// Which addressed output this is.
+    pub node: VirtualNodeKind,
+    /// The emitted module.
+    pub code: String,
+}
+
+/// The route's virtual-node kind, carried as the route spells it.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct VirtualNodeKind {
+    /// The kind's wire tag.
+    pub kind: String,
+}
+
+/// A typed terminal failure.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct RouteFailure {
+    /// The failure's wire tag — the field classification reads.
+    pub kind: String,
+    /// The message, retained as evidence only.
+    #[serde(default)]
+    pub message: String,
+    /// The diagnostics the failure carries, intact.
+    pub diagnostics: DiagnosticsSnapshot,
+}
+
+/// The diagnostics snapshot both arms carry.
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+pub struct DiagnosticsSnapshot {
+    /// The diagnostics, in the order the compiler reported them.
+    #[serde(default)]
+    pub diagnostics: Vec<RouteDiagnostic>,
+}
+
+/// One diagnostic.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct RouteDiagnostic {
+    /// The severity, the field classification reads.
+    pub severity: String,
+    /// The diagnostic code.
+    #[serde(default)]
+    pub code: String,
+    /// The message, retained as evidence only.
+    #[serde(default)]
+    pub message: String,
+}
+
+impl DiagnosticsSnapshot {
+    fn has_error(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.severity == "error")
+    }
+
+    /// The comparator's severity-ordered row projection.
+    fn rows(&self) -> Vec<verter_vue_conformance::compare::DiagnosticRow> {
+        let mut rows: Vec<_> = self
+            .diagnostics
+            .iter()
+            .map(
+                |diagnostic| verter_vue_conformance::compare::DiagnosticRow {
+                    kind: diagnostic.severity.clone(),
+                    code: (!diagnostic.code.is_empty()).then(|| diagnostic.code.clone()),
+                    message: diagnostic.message.clone(),
+                },
+            )
+            .collect();
+        rows.sort_by(|left, right| left.kind.cmp(&right.kind));
+        rows
+    }
+
+    fn evidence(&self) -> Vec<Evidence> {
+        self.diagnostics
+            .iter()
+            .map(|diagnostic| Evidence {
+                source: EvidenceSource::AddonDiagnostic,
+                message: format!(
+                    "{}[{}]: {}",
+                    diagnostic.severity, diagnostic.code, diagnostic.message
+                ),
+            })
+            .collect()
+    }
+}
+
+/// One reference result: a product, a failure, or no producer at all.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ReferenceResult {
+    /// The reference compiler produced a module.
+    Produced {
+        /// The emitted module.
+        code: String,
+    },
+    /// The reference compiler failed.
+    Failed {
+        /// Its message, retained as evidence only.
+        error: String,
+    },
+    /// No reference producer is registered for this framework.
+    Inapplicable {
+        /// The framework with no producer.
+        inapplicable: String,
+    },
+}
+
+/// Parse one driver line. A line whose shape is not one of the four is not
+/// resolved into a plausible arm — it is rejected, and the caller classifies
+/// the probe a harness failure.
+pub fn parse_line(line: &str) -> Result<DriverLine, String> {
+    let value: serde_json::Value = serde_json::from_str(line).map_err(|error| error.to_string())?;
+    let object = value.as_object().ok_or("a driver line must be an object")?;
+    let probe_id = object
+        .get("probe_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    if object.contains_key("error") {
+        return Ok(DriverLine::Error {
+            probe_id,
+            error: object
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        });
+    }
+    let probe_id = probe_id.ok_or("a driver line must carry a probe_id")?;
+    if let Some(phase) = object.get("phase").and_then(serde_json::Value::as_str) {
+        let phase = match phase {
+            "load" => Phase::Load,
+            "compile" => Phase::Compile,
+            "reference" => Phase::Reference,
+            other => return Err(format!("unknown phase `{other}`")),
+        };
+        return Ok(DriverLine::Phase { probe_id, phase });
+    }
+    match object.get("frame").and_then(serde_json::Value::as_str) {
+        Some("compile") => {
+            let elapsed_ns = object
+                .get("elapsed_ns")
+                .and_then(serde_json::Value::as_u64)
+                .ok_or("a compile frame must carry elapsed_ns")?;
+            let entries: Vec<RouteEntry> = serde_json::from_value(
+                object
+                    .get("entries")
+                    .cloned()
+                    .ok_or("a compile frame must carry entries")?,
+            )
+            .map_err(|error| error.to_string())?;
+            Ok(DriverLine::Compile {
+                probe_id,
+                elapsed_ns,
+                entries,
+            })
+        }
+        Some("reference") => {
+            let reference: Vec<ReferenceResult> = serde_json::from_value(
+                object
+                    .get("reference")
+                    .cloned()
+                    .ok_or("a reference frame must carry a reference array")?,
+            )
+            .map_err(|error| error.to_string())?;
+            Ok(DriverLine::Reference {
+                probe_id,
+                reference,
+            })
+        }
+        Some(other) => Err(format!("unknown frame `{other}`")),
+        None => Err("a driver line must carry a phase, a frame, or an error".to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming probe state
+// ---------------------------------------------------------------------------
+
+/// What one probe asked for, and what has arrived so far.
+#[derive(Clone, Debug)]
+pub struct ProbeRun {
+    probe_id: String,
+    requested: Vec<RequestedEntry>,
+    phase: Option<Phase>,
+    compile: Option<CompileFrame>,
+    reference: Option<Vec<ReferenceResult>>,
+    harness: Vec<String>,
+}
+
+/// One entry the runner asked the driver to compile.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RequestedEntry {
+    /// The case id, which is also the entry's `canonicalId`.
+    pub canonical_id: String,
+    /// The component text handed to the driver.
+    pub source: String,
+    /// The case's own request digest.
+    pub request_digest: String,
+}
+
+#[derive(Clone, Debug)]
+struct CompileFrame {
+    elapsed_ns: u64,
+    entries: Vec<RouteEntry>,
+}
+
+/// Why a frame was refused before anything was classified from it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FrameViolation {
+    /// A frame for a probe the runner never requested.
+    UnknownProbe {
+        /// The id the frame claimed.
+        probe_id: String,
+    },
+    /// A second compile frame for one probe.
+    DuplicateCompileFrame {
+        /// The probe.
+        probe_id: String,
+    },
+    /// A reference frame whose compile frame never arrived.
+    ReferenceWithoutCompile {
+        /// The probe.
+        probe_id: String,
+    },
+    /// A frame that answers a different number of entries than were asked.
+    CountMismatch {
+        /// The probe.
+        probe_id: String,
+        /// What was asked.
+        requested: usize,
+        /// What arrived.
+        answered: usize,
+    },
+    /// A frame that answers a different id at a position than was asked.
+    IdentityMismatch {
+        /// The probe.
+        probe_id: String,
+        /// The position.
+        position: usize,
+        /// What was asked for there.
+        requested: String,
+        /// What arrived there.
+        answered: String,
+    },
+    /// One id answered twice in the same frame.
+    DuplicateEntry {
+        /// The probe.
+        probe_id: String,
+        /// The repeated id.
+        canonical_id: String,
+    },
+}
+
+impl fmt::Display for FrameViolation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FrameViolation::UnknownProbe { probe_id } => {
+                write!(f, "frame for unrequested probe `{probe_id}`")
+            }
+            FrameViolation::DuplicateCompileFrame { probe_id } => {
+                write!(f, "`{probe_id}`: a second compile frame arrived")
+            }
+            FrameViolation::ReferenceWithoutCompile { probe_id } => {
+                write!(
+                    f,
+                    "`{probe_id}`: a reference frame arrived with no compile frame"
+                )
+            }
+            FrameViolation::CountMismatch {
+                probe_id,
+                requested,
+                answered,
+            } => write!(
+                f,
+                "`{probe_id}`: {answered} answered entries for {requested} requested"
+            ),
+            FrameViolation::IdentityMismatch {
+                probe_id,
+                position,
+                requested,
+                answered,
+            } => write!(
+                f,
+                "`{probe_id}`: position {position} answered `{answered}`, requested `{requested}`"
+            ),
+            FrameViolation::DuplicateEntry {
+                probe_id,
+                canonical_id,
+            } => write!(f, "`{probe_id}`: `{canonical_id}` answered twice"),
+        }
+    }
+}
+
+impl ProbeRun {
+    /// Begin streaming state for one probe.
+    pub fn new(probe_id: impl Into<String>, requested: Vec<RequestedEntry>) -> Self {
+        ProbeRun {
+            probe_id: probe_id.into(),
+            requested,
+            phase: None,
+            compile: None,
+            reference: None,
+            harness: Vec::new(),
+        }
+    }
+
+    /// The probe's id.
+    pub fn probe_id(&self) -> &str {
+        &self.probe_id
+    }
+
+    /// The last phase the driver announced for this probe.
+    pub fn phase(&self) -> Option<Phase> {
+        self.phase
+    }
+
+    /// Whether the compile frame has been ingested.
+    pub fn has_compile_frame(&self) -> bool {
+        self.compile.is_some()
+    }
+
+    /// Record a harness-side failure against this probe.
+    pub fn record_harness_failure(&mut self, message: impl Into<String>) {
+        self.harness.push(message.into());
+    }
+
+    /// Ingest one driver line.
+    ///
+    /// A frame is validated against the entry set this probe holds BEFORE it
+    /// is retained: the count must match, each position's id must be the one
+    /// requested there, and no id may repeat. A violation records a harness
+    /// failure and the frame is dropped whole — nothing is paired positionally
+    /// from a frame that failed its own identity check.
+    pub fn ingest_frame(&mut self, line: DriverLine) -> Result<(), FrameViolation> {
+        match line {
+            DriverLine::Phase { phase, .. } => {
+                self.phase = Some(phase);
+                Ok(())
+            }
+            DriverLine::Error { error, .. } => {
+                self.harness.push(error);
+                Ok(())
+            }
+            DriverLine::Compile {
+                elapsed_ns,
+                entries,
+                ..
+            } => {
+                if self.compile.is_some() {
+                    let violation = FrameViolation::DuplicateCompileFrame {
+                        probe_id: self.probe_id.clone(),
+                    };
+                    self.harness.push(violation.to_string());
+                    return Err(violation);
+                }
+                self.check_cardinality(entries.len())?;
+                let mut seen = std::collections::BTreeSet::new();
+                for (position, entry) in entries.iter().enumerate() {
+                    let requested = &self.requested[position].canonical_id;
+                    if &entry.canonical_id != requested {
+                        let violation = FrameViolation::IdentityMismatch {
+                            probe_id: self.probe_id.clone(),
+                            position,
+                            requested: requested.clone(),
+                            answered: entry.canonical_id.clone(),
+                        };
+                        self.harness.push(violation.to_string());
+                        return Err(violation);
+                    }
+                    if !seen.insert(entry.canonical_id.clone()) {
+                        let violation = FrameViolation::DuplicateEntry {
+                            probe_id: self.probe_id.clone(),
+                            canonical_id: entry.canonical_id.clone(),
+                        };
+                        self.harness.push(violation.to_string());
+                        return Err(violation);
+                    }
+                }
+                self.compile = Some(CompileFrame {
+                    elapsed_ns,
+                    entries,
+                });
+                Ok(())
+            }
+            DriverLine::Reference { reference, .. } => {
+                if self.compile.is_none() {
+                    let violation = FrameViolation::ReferenceWithoutCompile {
+                        probe_id: self.probe_id.clone(),
+                    };
+                    self.harness.push(violation.to_string());
+                    return Err(violation);
+                }
+                self.check_cardinality(reference.len())?;
+                self.reference = Some(reference);
+                Ok(())
+            }
+        }
+    }
+
+    fn check_cardinality(&mut self, answered: usize) -> Result<(), FrameViolation> {
+        if answered == self.requested.len() {
+            return Ok(());
+        }
+        let violation = FrameViolation::CountMismatch {
+            probe_id: self.probe_id.clone(),
+            requested: self.requested.len(),
+            answered,
+        };
+        self.harness.push(violation.to_string());
+        Err(violation)
+    }
+
+    /// Fold this probe's state into one observation per requested entry.
+    ///
+    /// `terminated` is the process outcome when the driver died before the
+    /// protocol completed, and `None` when it ran to a clean exit.
+    pub fn finish(
+        &self,
+        manifest: &ProbeStateManifest,
+        terminated: Option<ExecutionEvent>,
+    ) -> Vec<Result<CaseObservation, InvalidObservation>> {
+        let terminal = terminated.map(classify_execution);
+        self.requested
+            .iter()
+            .enumerate()
+            .map(|(position, requested)| self.observe(manifest, position, requested, terminal))
+            .collect()
+    }
+
+    fn observe(
+        &self,
+        manifest: &ProbeStateManifest,
+        position: usize,
+        requested: &RequestedEntry,
+        terminal: Option<ProbeOutcomeClass>,
+    ) -> Result<CaseObservation, InvalidObservation> {
+        let harness_evidence: Vec<Evidence> = self
+            .harness
+            .iter()
+            .map(|message| Evidence {
+                source: EvidenceSource::Driver,
+                message: message.clone(),
+            })
+            .collect();
+
+        // The harness failing to observe outranks anything it might have
+        // observed: a probe whose protocol broke reports that, not a verdict
+        // about the compiler it could not watch.
+        if !self.harness.is_empty() {
+            return self.all_dimensions(
+                manifest,
+                requested,
+                ProbeOutcomeClass::HarnessFailure,
+                harness_evidence,
+            );
+        }
+
+        let Some(compile) = self.compile.as_ref() else {
+            // No compile frame: either the process died mid-compile, or it
+            // exited cleanly without completing its protocol. Both leave the
+            // Route dimension unanswered.
+            let class = terminal.unwrap_or(ProbeOutcomeClass::HarnessFailure);
+            let class = if class == ProbeOutcomeClass::Pass {
+                ProbeOutcomeClass::HarnessFailure
+            } else {
+                class
+            };
+            return self.all_dimensions(manifest, requested, class, harness_evidence);
+        };
+
+        let entry = &compile.entries[position];
+        let mut route = Vec::new();
+        let mut compile_classes = Vec::new();
+        let mut evidence = Vec::new();
+
+        let diagnostics = match (&entry.response, &entry.failure) {
+            (Some(response), _) => &response.diagnostics,
+            (None, Some(failure)) => &failure.diagnostics,
+            (None, None) => {
+                // Neither arm: the route answered nothing the classifier can
+                // read. Failing closed keeps an unexplained envelope from
+                // reading as a pass.
+                return self.all_dimensions(
+                    manifest,
+                    requested,
+                    ProbeOutcomeClass::HarnessFailure,
+                    vec![Evidence {
+                        source: EvidenceSource::Driver,
+                        message: "route entry carries neither a response nor a failure".to_string(),
+                    }],
+                );
+            }
+        };
+        evidence.extend(diagnostics.evidence());
+        // (i) An error-severity diagnostic is a Compile outcome whichever arm
+        // carried it: the route ANSWERED, so Route is a pass.
+        if diagnostics.has_error() {
+            compile_classes.push(ProbeOutcomeClass::VerterDiagnostic);
+        }
+
+        if let Some(failure) = &entry.failure {
+            evidence.push(Evidence {
+                source: EvidenceSource::Driver,
+                message: format!("failure.kind={}: {}", failure.kind, failure.message),
+            });
+            match failure.kind.as_str() {
+                // The route's typed refusal of a binding or a framework: a
+                // public-boundary outcome, never hidden as a harness defect.
+                "binding" | "frameworkMismatch" => {
+                    route.push(ProbeOutcomeClass::RequestRefused);
+                }
+                "host" => route.push(ProbeOutcomeClass::HostFailure),
+                "runtimeSurfaceRefused" | "unsupportedProduct" => {
+                    compile_classes.push(ProbeOutcomeClass::Unsupported);
+                }
+                "productNotProduced" => compile_classes.push(ProbeOutcomeClass::ProductNotProduced),
+                // `refused` contributes nothing of its own: the live route
+                // constructs it whenever compile diagnostics carry errors, so
+                // it folds to `verter_diagnostic` through rule (i). A
+                // `refused` with no diagnostic is unexplained, and fails
+                // closed rather than being read as a product outcome.
+                "refused" => {
+                    if !diagnostics.has_error() {
+                        compile_classes.push(ProbeOutcomeClass::HarnessFailure);
+                    }
+                }
+                _ => compile_classes.push(ProbeOutcomeClass::HarnessFailure),
+            }
+        }
+
+        let mut product_code: Option<&str> = None;
+        if let Some(response) = &entry.response {
+            match extract_main(response) {
+                Ok(code) => product_code = Some(code),
+                Err(class) => compile_classes.push(class),
+            }
+        }
+
+        if route.is_empty() {
+            route.push(ProbeOutcomeClass::Pass);
+        }
+        let route_failed = route.iter().any(|class| class.is_failure());
+        // A Route failure is contributed to Compile as well, not left to
+        // propagate. Propagation only fills a dimension that observed nothing,
+        // so a host failure or a typed refusal that ALSO carried an error
+        // diagnostic would otherwise be replaced at Compile by the lower-
+        // precedence diagnostic — and a host failure would silently satisfy a
+        // diagnostic expectation. Contributing it here makes the Compile fold
+        // apply the taxonomy's own precedence and retain the diagnostic as
+        // secondary evidence.
+        if route_failed {
+            compile_classes.extend(route.iter().copied().filter(|class| class.is_failure()));
+        }
+
+        // The product's own validity check: the same canonicalizer the
+        // comparator runs, so a module that cannot be compared is reported as
+        // malformed here rather than as a comparator error later.
+        let authored = verter_vue_conformance::authored_identifiers(&requested.source);
+        if let Some(code) = product_code {
+            if let Err(message) =
+                verter_vue_conformance::canon::canonicalize_module(code, &authored)
+            {
+                compile_classes.push(ProbeOutcomeClass::ProductMalformed);
+                evidence.push(Evidence {
+                    source: EvidenceSource::Parser,
+                    message,
+                });
+                product_code = None;
+            }
+        }
+
+        if compile_classes.is_empty() && !route_failed {
+            compile_classes.push(ProbeOutcomeClass::Pass);
+        }
+
+        let mut inputs = BTreeMap::new();
+        inputs.insert(
+            Dimension::Route,
+            DimensionInput::Observed {
+                classes: route.clone(),
+                evidence: evidence.clone(),
+            },
+        );
+        inputs.insert(
+            Dimension::Compile,
+            if compile_classes.is_empty() {
+                DimensionInput::Unreached
+            } else {
+                DimensionInput::Observed {
+                    classes: compile_classes.clone(),
+                    evidence: evidence.clone(),
+                }
+            },
+        );
+        inputs.insert(
+            Dimension::Structural,
+            self.structural(manifest, position, product_code, &authored, terminal),
+        );
+        inputs.insert(
+            Dimension::Runtime,
+            not_applicable_or_unreached(manifest, Dimension::Runtime),
+        );
+        inputs.insert(
+            Dimension::Map,
+            not_applicable_or_unreached(manifest, Dimension::Map),
+        );
+        inputs.insert(
+            Dimension::Performance,
+            DimensionInput::Observed {
+                classes: vec![ProbeOutcomeClass::Pass],
+                evidence: vec![Evidence {
+                    source: EvidenceSource::Driver,
+                    message: format!("elapsed_ns={}", compile.elapsed_ns),
+                }],
+            },
+        );
+        CaseObservation::fold(requested.canonical_id.clone(), inputs)
+    }
+
+    fn structural(
+        &self,
+        manifest: &ProbeStateManifest,
+        position: usize,
+        product_code: Option<&str>,
+        authored: &std::collections::BTreeSet<String>,
+        terminal: Option<ProbeOutcomeClass>,
+    ) -> DimensionInput {
+        if manifest.comparison == Comparison::None {
+            return DimensionInput::NotApplicable(NotApplicableReason::ComparatorAbsent);
+        }
+        let reference_failure =
+            |message: String, source: EvidenceSource| DimensionInput::Observed {
+                classes: vec![ProbeOutcomeClass::ReferenceFailure],
+                evidence: vec![Evidence { source, message }],
+            };
+        let Some(reference) = self.reference.as_ref() else {
+            // The compile frame arrived and the reference frame did not. The
+            // reference frame is REQUIRED for every probe of every framework —
+            // an unregistered producer still answers `inapplicable` — so its
+            // absence is the protocol breaking, not a comparator that does not
+            // exist.
+            let class = match terminal {
+                Some(ProbeOutcomeClass::ReferenceFailure) => ProbeOutcomeClass::ReferenceFailure,
+                Some(class) if class.is_failure() => class,
+                _ => ProbeOutcomeClass::HarnessFailure,
+            };
+            return DimensionInput::Observed {
+                classes: vec![class],
+                evidence: vec![Evidence {
+                    source: EvidenceSource::Driver,
+                    message: "the reference frame never arrived".to_string(),
+                }],
+            };
+        };
+        match &reference[position] {
+            ReferenceResult::Failed { error } => {
+                reference_failure(error.clone(), EvidenceSource::Reference)
+            }
+            ReferenceResult::Inapplicable { inapplicable } => reference_failure(
+                format!(
+                    "no reference producer is registered for `{inapplicable}`, but this \
+                     framework's manifest declares comparison = structural"
+                ),
+                EvidenceSource::Reference,
+            ),
+            ReferenceResult::Produced { code } => {
+                let Some(product) = product_code else {
+                    // No comparable product: the Compile dimension already
+                    // says why, and it propagates here. Emitting a comparison
+                    // class would claim a comparison that never ran.
+                    return DimensionInput::Unreached;
+                };
+                // The reference side is prevalidated with the SAME check the
+                // Compile cell applies to the product, so `compare_modules`
+                // is only ever called on two modules the comparator can
+                // canonicalize — which is what makes a `CompareError` below
+                // an internal comparator failure rather than an input it was
+                // never able to read.
+                if let Err(message) =
+                    verter_vue_conformance::canon::canonicalize_module(code, authored)
+                {
+                    return reference_failure(
+                        format!(
+                            "the reference produced a module the structural comparator does \
+                             not canonicalize: {message}"
+                        ),
+                        EvidenceSource::Reference,
+                    );
+                }
+                let verter = verter_vue_conformance::compare::ModuleInput {
+                    code: product.to_string(),
+                    diagnostics: self.diagnostic_rows(position),
+                };
+                let golden = verter_vue_conformance::compare::ModuleInput {
+                    code: code.clone(),
+                    diagnostics: Vec::new(),
+                };
+                match verter_vue_conformance::compare::compare_modules(
+                    &verter,
+                    &golden,
+                    authored,
+                    MAX_REASONS,
+                ) {
+                    // Both inputs prevalidated, so a comparator error here is
+                    // the comparator's own failure, not either module's.
+                    Err(error) => DimensionInput::Observed {
+                        classes: vec![ProbeOutcomeClass::HarnessFailure],
+                        evidence: vec![Evidence {
+                            source: EvidenceSource::Comparator,
+                            message: error.to_string(),
+                        }],
+                    },
+                    Ok(comparison) if comparison.passed() => DimensionInput::Observed {
+                        classes: vec![ProbeOutcomeClass::Pass],
+                        evidence: Vec::new(),
+                    },
+                    Ok(comparison) => DimensionInput::Observed {
+                        classes: vec![ProbeOutcomeClass::SemanticMismatch],
+                        evidence: comparison
+                            .reasons
+                            .iter()
+                            .map(|reason| Evidence {
+                                source: EvidenceSource::Comparator,
+                                message: reason.summary(),
+                            })
+                            .chain(std::iter::once(Evidence {
+                                source: EvidenceSource::Comparator,
+                                message: format!("{} in-contract differences", comparison.total),
+                            }))
+                            .collect(),
+                    },
+                }
+            }
+        }
+    }
+
+    fn diagnostic_rows(
+        &self,
+        position: usize,
+    ) -> Vec<verter_vue_conformance::compare::DiagnosticRow> {
+        self.compile
+            .as_ref()
+            .and_then(|frame| frame.entries.get(position))
+            .and_then(|entry| entry.response.as_ref())
+            .map(|response| response.diagnostics.rows())
+            .unwrap_or_default()
+    }
+
+    fn all_dimensions(
+        &self,
+        manifest: &ProbeStateManifest,
+        requested: &RequestedEntry,
+        class: ProbeOutcomeClass,
+        evidence: Vec<Evidence>,
+    ) -> Result<CaseObservation, InvalidObservation> {
+        let mut inputs = BTreeMap::new();
+        for dimension in Dimension::ALL {
+            let input = match manifest.not_applicable_reason(dimension) {
+                Some(reason) => DimensionInput::NotApplicable(reason),
+                None if dimension == Dimension::Route => DimensionInput::Observed {
+                    classes: vec![class],
+                    evidence: evidence.clone(),
+                },
+                None => DimensionInput::Unreached,
+            };
+            inputs.insert(dimension, input);
+        }
+        CaseObservation::fold(requested.canonical_id.clone(), inputs)
+    }
+}
+
+fn not_applicable_or_unreached(
+    manifest: &ProbeStateManifest,
+    dimension: Dimension,
+) -> DimensionInput {
+    match manifest.not_applicable_reason(dimension) {
+        Some(reason) => DimensionInput::NotApplicable(reason),
+        None => DimensionInput::Unreached,
+    }
+}
+
+/// Extract the one `main` node of the one `runtimeClient` product.
+///
+/// The request asks for exactly one product, so the answer's shape is exact:
+/// anything other than one `runtimeClient` product holding exactly one `main`
+/// node is reported as absent or malformed rather than searched through for
+/// something usable.
+fn extract_main(response: &RouteResponse) -> Result<&str, ProbeOutcomeClass> {
+    if response.products.is_empty() {
+        return Err(ProbeOutcomeClass::ProductNotProduced);
+    }
+    if response.products.len() > 1 {
+        return Err(ProbeOutcomeClass::ProductMalformed);
+    }
+    let product = &response.products[0];
+    if product.kind != "runtimeClient" {
+        return Err(ProbeOutcomeClass::ProductMalformed);
+    }
+    let nodes = product.nodes.as_deref().unwrap_or_default();
+    // The `main` node is the emitted module; `script` and `template` are the
+    // route's separately-addressed halves of it, and comparing one of those
+    // against the reference's whole module would compare two different things.
+    let mains: Vec<&RouteNode> = nodes
+        .iter()
+        .filter(|node| node.node.kind == "main")
+        .collect();
+    match mains.len() {
+        0 => Err(ProbeOutcomeClass::ProductNotProduced),
+        1 => Ok(mains[0].code.as_str()),
+        _ => Err(ProbeOutcomeClass::ProductMalformed),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Driving the lane
+// ---------------------------------------------------------------------------
+
+/// One case's evaluated outcome.
+#[derive(Clone, Debug)]
+pub struct CaseResult {
+    /// The case id.
+    pub case_id: String,
+    /// The case's own request digest.
+    pub request_digest: String,
+    /// Nanoseconds the bracketed compile call took, when it was observed.
+    pub elapsed_ns: Option<u64>,
+    /// The folded observation, or why one could not be represented.
+    pub observation: Result<CaseObservation, InvalidObservation>,
+}
+
+/// Why a lane could not run at all. A lane that cannot execute reports that;
+/// it never publishes a summary of zero cases.
+#[derive(Clone, Debug)]
+pub enum RunError {
+    /// The selection is empty.
+    EmptySelection,
+    /// A selected case is not in the manifest inventory.
+    UnselectableCase {
+        /// The case id.
+        case_id: String,
+    },
+    /// The driver could not be spawned.
+    SpawnFailed {
+        /// The operating system's message.
+        message: String,
+    },
+    /// The driver's stdin or stdout could not be used.
+    Io {
+        /// The operating system's message.
+        message: String,
+    },
+}
+
+impl fmt::Display for RunError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RunError::EmptySelection => f.write_str("the lane selected no case"),
+            RunError::UnselectableCase { case_id } => {
+                write!(f, "case `{case_id}` is not in the manifest inventory")
+            }
+            RunError::SpawnFailed { message } => write!(f, "spawning the driver: {message}"),
+            RunError::Io { message } => write!(f, "driving the probe: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for RunError {}
+
+/// One case the runner will drive.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlannedCase {
+    /// The stable case id.
+    pub case_id: String,
+    /// The corpus-relative path, which the request carries as its filename.
+    pub relative_path: String,
+    /// The component text.
+    pub source: String,
+}
+
+/// Where the driver and its interpreter live.
+#[derive(Clone, Debug)]
+pub struct DriverCommand {
+    /// The interpreter.
+    pub program: PathBuf,
+    /// The driver script.
+    pub script: PathBuf,
+}
+
+impl DriverCommand {
+    /// The committed driver, run by `node`.
+    pub fn committed(repo_root: &Path) -> Self {
+        DriverCommand {
+            program: PathBuf::from("node"),
+            script: repo_root
+                .join("crates")
+                .join("verter_validation_probe")
+                .join("driver")
+                .join("probe-driver.mjs"),
+        }
+    }
+}
+
+/// Drive every planned case through one driver process and fold the results.
+///
+/// One process serves the whole lane, and each case is its own probe, so a
+/// per-case failure is attributed to that case while the rest keep running.
+pub fn run_cases(
+    manifest: &ProbeStateManifest,
+    driver: &DriverCommand,
+    cases: &[PlannedCase],
+    deadlines: PhaseDeadlines,
+) -> Result<Vec<CaseResult>, RunError> {
+    if cases.is_empty() {
+        return Err(RunError::EmptySelection);
+    }
+    let inventory: std::collections::BTreeSet<&str> = manifest
+        .inventory
+        .iter()
+        .map(|case| case.case_id.as_str())
+        .collect();
+    for case in cases {
+        if !inventory.contains(case.case_id.as_str()) {
+            return Err(RunError::UnselectableCase {
+                case_id: case.case_id.clone(),
+            });
+        }
+    }
+
+    let mut child = Command::new(&driver.program)
+        .arg(&driver.script)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(|error| RunError::SpawnFailed {
+            message: error.to_string(),
+        })?;
+    let stdout = child.stdout.take().ok_or_else(|| RunError::Io {
+        message: "the driver exposes no stdout".to_string(),
+    })?;
+    let lines = spawn_reader(stdout);
+
+    let mut results = Vec::with_capacity(cases.len());
+    let mut terminated: Option<ExecutionEvent> = None;
+    for case in cases {
+        let requested = vec![RequestedEntry {
+            canonical_id: case.case_id.clone(),
+            source: case.source.clone(),
+            request_digest: request::request_digest(&case.relative_path),
+        }];
+        let mut run = ProbeRun::new(case.case_id.clone(), requested);
+        if terminated.is_none() {
+            match write_probe(&mut child, case) {
+                Ok(()) => drive_probe(&mut run, &lines, deadlines, &mut terminated, &mut child),
+                Err(message) => {
+                    run.record_harness_failure(message);
+                }
+            }
+        } else {
+            run.record_harness_failure("the driver terminated before this probe was sent");
+        }
+        let elapsed_ns = run.compile.as_ref().map(|frame| frame.elapsed_ns);
+        let observations = run.finish(manifest, terminated);
+        results.push(CaseResult {
+            case_id: case.case_id.clone(),
+            request_digest: request::request_digest(&case.relative_path),
+            elapsed_ns,
+            observation: observations
+                .into_iter()
+                .next()
+                .expect("one requested entry yields one observation"),
+        });
+    }
+    drop(child.stdin.take());
+    let _ = child.wait();
+    Ok(results)
+}
+
+fn write_probe(child: &mut Child, case: &PlannedCase) -> Result<(), String> {
+    let request: serde_json::Value =
+        serde_json::from_str(&request::substitute(&case.relative_path))
+            .map_err(|error| format!("the canonical request is not JSON: {error}"))?;
+    let probe = serde_json::json!({
+        "probe_id": case.case_id,
+        "entries": [{
+            "canonicalId": case.case_id,
+            "source": case.source,
+            "request": request,
+        }],
+    });
+    let stdin = child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| "the driver exposes no stdin".to_string())?;
+    writeln!(stdin, "{probe}").map_err(|error| error.to_string())?;
+    stdin.flush().map_err(|error| error.to_string())
+}
+
+fn drive_probe(
+    run: &mut ProbeRun,
+    lines: &Receiver<Result<String, String>>,
+    deadlines: PhaseDeadlines,
+    terminated: &mut Option<ExecutionEvent>,
+    child: &mut Child,
+) {
+    let mut deadline = Instant::now() + deadlines.load;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match lines.recv_timeout(remaining) {
+            Ok(Ok(line)) => match parse_line(&line) {
+                Ok(parsed) => {
+                    if let DriverLine::Phase { phase, .. } = &parsed {
+                        deadline = Instant::now()
+                            + match phase {
+                                Phase::Load => deadlines.load,
+                                Phase::Compile => deadlines.compile,
+                                Phase::Reference => deadlines.reference,
+                            };
+                    }
+                    let done = matches!(parsed, DriverLine::Reference { .. });
+                    let _ = run.ingest_frame(parsed);
+                    if done {
+                        return;
+                    }
+                }
+                Err(message) => {
+                    run.record_harness_failure(format!("unparseable driver line: {message}"));
+                    return;
+                }
+            },
+            Ok(Err(message)) => {
+                run.record_harness_failure(format!("reading the driver: {message}"));
+                *terminated = Some(ExecutionEvent::Exited {
+                    phase: run.phase(),
+                    code: -1,
+                });
+                return;
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                let _ = child.kill();
+                *terminated = Some(ExecutionEvent::TimedOut { phase: run.phase() });
+                return;
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                *terminated = Some(match child.wait() {
+                    Ok(status) => match status.code() {
+                        Some(code) => ExecutionEvent::Exited {
+                            phase: run.phase(),
+                            code,
+                        },
+                        None => ExecutionEvent::Signaled { phase: run.phase() },
+                    },
+                    Err(_) => ExecutionEvent::Signaled { phase: run.phase() },
+                });
+                return;
+            }
+        }
+    }
+}
+
+fn spawn_reader(stdout: ChildStdout) -> Receiver<Result<String, String>> {
+    let (sender, receiver) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let message = line.map_err(|error| error.to_string());
+            if sender.send(message).is_err() {
+                return;
+            }
+        }
+    });
+    receiver
+}
+
+/// The framework a case id names, for a runner that never branches on one.
+pub fn framework_of(case_id: &str) -> Option<Framework> {
+    match case_id.split('/').next() {
+        Some("vue") => Some(Framework::Vue),
+        Some("svelte") => Some(Framework::Svelte),
+        _ => None,
+    }
+}

--- a/crates/verter_validation_probe/src/summary.rs
+++ b/crates/verter_validation_probe/src/summary.rs
@@ -1,0 +1,604 @@
+//! The lane's one compact machine-readable summary.
+//!
+//! The summary is evidence, not a verdict dressed as a number. Every counter
+//! it carries is required — a summary missing one is refused rather than read
+//! as a zero — and the lane's disposition is a real process exit computed from
+//! the gate cells, so a required job cannot go green while a gate regressed.
+//!
+//! The shape is framework-neutral: `framework` is a row attribute and a
+//! per-framework counter block, never a summary variant, so a second corpus
+//! reports through this same document.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use serde::{Deserialize, Serialize};
+
+use crate::evaluate::Evaluation;
+use crate::manifest::{ExpectedState, Framework, ProbeStateManifest};
+use crate::outcome::{CaseObservation, Dimension, ProbeOutcomeClass, Terminal};
+use crate::request;
+
+/// The summary document's schema version. A reader that does not recognise it
+/// refuses the document rather than guessing at its fields.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Which lane produced a summary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Lane {
+    /// The bounded pull-request slice.
+    Smoke,
+    /// The complete ratified inventory.
+    Main,
+}
+
+impl Lane {
+    /// The serialized name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Lane::Smoke => "smoke",
+            Lane::Main => "main",
+        }
+    }
+}
+
+/// Every counter the summary must carry. All of them are required: a document
+/// missing one is refused by [`Summary::validate`].
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Counters {
+    /// Cases the lane selected.
+    pub selected: usize,
+    /// Cases the lane actually drove.
+    pub attempted: usize,
+    /// Cases that actually succeeded: every exercised cell observed `pass`,
+    /// and no cell was left unreached.
+    ///
+    /// Deliberately NOT "every cell met its expectation": a case whose
+    /// `Compile` cell is a recorded known-fail is behaving exactly as declared,
+    /// and counting it as passed would report a lane of known failures as a
+    /// lane of successes. Whether expectations were met is what the gate,
+    /// canary, known-fail and XPASS counters carry.
+    pub passed: usize,
+    /// Gate cells that evaluated to anything but a gate pass.
+    pub gated_regressions: usize,
+    /// Canary cells that met their expected failure class, by class.
+    pub canary_failures: BTreeMap<String, usize>,
+    /// Known-fail cells that met their expected failure class, by class.
+    pub known_failures: BTreeMap<String, usize>,
+    /// Cells the manifest declares skipped.
+    pub skips: usize,
+    /// Failure canary or known-fail cells that observed a pass.
+    pub xpass_candidates: usize,
+    /// Cells whose terminal is `crash`.
+    pub crashes: usize,
+    /// Cells whose terminal is `timeout`.
+    pub timeouts: usize,
+    /// Cells whose terminal is `harness_failure`.
+    pub harness_failures: usize,
+}
+
+impl Counters {
+    /// The counter names every summary must carry, in document order.
+    pub const REQUIRED: [&'static str; 11] = [
+        "selected",
+        "attempted",
+        "passed",
+        "gated_regressions",
+        "canary_failures",
+        "known_failures",
+        "skips",
+        "xpass_candidates",
+        "crashes",
+        "timeouts",
+        "harness_failures",
+    ];
+}
+
+/// One evaluated cell.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CellRow {
+    /// The case.
+    pub probe_id: String,
+    /// The dimension.
+    pub dimension: Dimension,
+    /// What the manifest declared.
+    pub expected_state: ExpectedState,
+    /// The exact class the manifest expected, when it declared one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_class: Option<ProbeOutcomeClass>,
+    /// The class observed, when the dimension produced one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_class: Option<ProbeOutcomeClass>,
+    /// The evaluation.
+    pub evaluation: Evaluation,
+}
+
+/// One case's row.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CaseRow {
+    /// The stable case id.
+    pub case_id: String,
+    /// The case's framework.
+    pub framework: Framework,
+    /// The SHA-256 of this case's substituted canonical request.
+    pub request_digest: String,
+    /// Nanoseconds the bracketed compile call took, when it was observed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_ns: Option<u64>,
+    /// Every cell of this case, in dimension order.
+    pub cells: Vec<CellRow>,
+}
+
+/// One framework's block of the summary.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FrameworkSummary {
+    /// The framework.
+    pub framework: Framework,
+    /// The pinned corpus revision this framework's cases came from.
+    pub external_revision: String,
+    /// The canonical request template, verbatim.
+    pub request_template: String,
+    /// The template's SHA-256.
+    pub template_digest: String,
+    /// This framework's counters.
+    pub counters: Counters,
+    /// This framework's case rows, in case-id order.
+    pub cases: Vec<CaseRow>,
+}
+
+/// The lane's summary document.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Summary {
+    /// The document schema.
+    pub schema_version: u32,
+    /// Which lane produced it.
+    pub lane: Lane,
+    /// One block per framework, in framework order.
+    pub frameworks: Vec<FrameworkSummary>,
+    /// The totals across every framework.
+    pub totals: Counters,
+}
+
+/// Why a summary is not usable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SummaryError {
+    /// The document declares a schema this reader does not know.
+    UnknownSchema {
+        /// The declared version.
+        schema_version: u32,
+    },
+    /// A required counter is missing from a framework block.
+    MissingCounter {
+        /// The framework.
+        framework: String,
+        /// The counter.
+        counter: String,
+    },
+    /// A framework attempted a different case set than it selected.
+    InventoryMismatch {
+        /// The framework.
+        framework: String,
+        /// What was selected.
+        selected: usize,
+        /// What was attempted.
+        attempted: usize,
+    },
+    /// A framework selected no case at all.
+    EmptySelection {
+        /// The framework.
+        framework: String,
+    },
+    /// A framework's rows do not equal the case set its counters claim.
+    RowCountMismatch {
+        /// The framework.
+        framework: String,
+        /// The rows present.
+        rows: usize,
+        /// The cases attempted.
+        attempted: usize,
+    },
+    /// The totals are not the sum of the per-framework counters.
+    TotalsMismatch,
+    /// The document could not be parsed.
+    Parse(String),
+}
+
+impl std::fmt::Display for SummaryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SummaryError::UnknownSchema { schema_version } => {
+                write!(f, "unknown summary schema version {schema_version}")
+            }
+            SummaryError::MissingCounter { framework, counter } => {
+                write!(f, "{framework}: required counter `{counter}` is missing")
+            }
+            SummaryError::InventoryMismatch {
+                framework,
+                selected,
+                attempted,
+            } => write!(
+                f,
+                "{framework}: attempted {attempted} of {selected} selected cases"
+            ),
+            SummaryError::EmptySelection { framework } => {
+                write!(f, "{framework}: the lane selected no case")
+            }
+            SummaryError::RowCountMismatch {
+                framework,
+                rows,
+                attempted,
+            } => write!(
+                f,
+                "{framework}: {rows} case rows for {attempted} attempted cases"
+            ),
+            SummaryError::TotalsMismatch => {
+                f.write_str("the totals are not the sum of the per-framework counters")
+            }
+            SummaryError::Parse(message) => write!(f, "summary malformed: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for SummaryError {}
+
+/// The lane's disposition: a real exit, computed from the gate cells alone.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Disposition {
+    /// Every gate cell evaluated to a gate pass.
+    Clean,
+    /// At least one gate cell did not.
+    GateRegressed {
+        /// How many.
+        count: usize,
+    },
+}
+
+impl Disposition {
+    /// The process exit code this disposition demands.
+    pub const fn exit_code(self) -> i32 {
+        match self {
+            Disposition::Clean => 0,
+            Disposition::GateRegressed { .. } => 1,
+        }
+    }
+}
+
+impl Summary {
+    /// Parse a summary document, checking every required counter is present
+    /// before any value of it is read.
+    ///
+    /// Presence is checked against the RAW document, not the deserialized
+    /// struct: a missing counter would otherwise deserialize to its type's
+    /// default and read as an honest zero.
+    pub fn from_json_str(text: &str) -> Result<Self, SummaryError> {
+        let raw: serde_json::Value =
+            serde_json::from_str(text).map_err(|error| SummaryError::Parse(error.to_string()))?;
+        let frameworks = raw
+            .get("frameworks")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| SummaryError::Parse("frameworks must be an array".to_string()))?;
+        for block in frameworks {
+            let name = block
+                .get("framework")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("?")
+                .to_string();
+            let counters = block.get("counters").and_then(serde_json::Value::as_object);
+            for counter in Counters::REQUIRED {
+                let present = counters.is_some_and(|counters| counters.contains_key(counter));
+                if !present {
+                    return Err(SummaryError::MissingCounter {
+                        framework: name,
+                        counter: counter.to_string(),
+                    });
+                }
+            }
+        }
+        let totals = raw.get("totals").and_then(serde_json::Value::as_object);
+        for counter in Counters::REQUIRED {
+            if !totals.is_some_and(|totals| totals.contains_key(counter)) {
+                return Err(SummaryError::MissingCounter {
+                    framework: "totals".to_string(),
+                    counter: counter.to_string(),
+                });
+            }
+        }
+        let summary: Summary =
+            serde_json::from_value(raw).map_err(|error| SummaryError::Parse(error.to_string()))?;
+        summary.validate()?;
+        Ok(summary)
+    }
+
+    /// Check the document's own internal consistency.
+    ///
+    /// The inventory check runs in BOTH directions: a framework that attempted
+    /// fewer cases than it selected has silently skipped work, and one that
+    /// attempted more has run work no manifest ratified.
+    pub fn validate(&self) -> Result<(), SummaryError> {
+        if self.schema_version != SCHEMA_VERSION {
+            return Err(SummaryError::UnknownSchema {
+                schema_version: self.schema_version,
+            });
+        }
+        let mut totals = Counters::default();
+        for block in &self.frameworks {
+            let name = block.framework.as_str().to_string();
+            if block.counters.selected == 0 {
+                return Err(SummaryError::EmptySelection { framework: name });
+            }
+            if block.counters.attempted != block.counters.selected {
+                return Err(SummaryError::InventoryMismatch {
+                    framework: name,
+                    selected: block.counters.selected,
+                    attempted: block.counters.attempted,
+                });
+            }
+            if block.cases.len() != block.counters.attempted {
+                return Err(SummaryError::RowCountMismatch {
+                    framework: name,
+                    rows: block.cases.len(),
+                    attempted: block.counters.attempted,
+                });
+            }
+            add(&mut totals, &block.counters);
+        }
+        if totals != self.totals {
+            return Err(SummaryError::TotalsMismatch);
+        }
+        Ok(())
+    }
+
+    /// The lane's disposition.
+    pub fn disposition(&self) -> Disposition {
+        match self.totals.gated_regressions {
+            0 => Disposition::Clean,
+            count => Disposition::GateRegressed { count },
+        }
+    }
+
+    /// The document, as canonical JSON.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).expect("the summary is serializable")
+    }
+
+    /// The compact human summary: one table, every counter, per framework and
+    /// total.
+    pub fn to_markdown(&self) -> String {
+        let mut out = String::new();
+        let _ = writeln!(out, "### Validation probe — {} lane\n", self.lane.as_str());
+        let _ = writeln!(
+            out,
+            "| framework | attempted | passed | gated regressions | canary failures | \
+             known failures | skips | XPASS candidates | crashes | timeouts | harness failures |"
+        );
+        let _ = writeln!(
+            out,
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+        );
+        for block in &self.frameworks {
+            row(&mut out, block.framework.as_str(), &block.counters);
+        }
+        row(&mut out, "**total**", &self.totals);
+        let _ = writeln!(out);
+        for block in &self.frameworks {
+            let _ = writeln!(
+                out,
+                "`{}` pinned at `{}`, request `{}`.",
+                block.framework.as_str(),
+                block.external_revision,
+                block.template_digest
+            );
+        }
+        if !self.totals.canary_failures.is_empty() || !self.totals.known_failures.is_empty() {
+            let _ = writeln!(out, "\nBy outcome class:\n");
+            let _ = writeln!(out, "| class | canary | known-fail |");
+            let _ = writeln!(out, "| --- | ---: | ---: |");
+            let mut classes: Vec<&String> = self
+                .totals
+                .canary_failures
+                .keys()
+                .chain(self.totals.known_failures.keys())
+                .collect();
+            classes.sort();
+            classes.dedup();
+            for class in classes {
+                let _ = writeln!(
+                    out,
+                    "| {class} | {} | {} |",
+                    self.totals.canary_failures.get(class).copied().unwrap_or(0),
+                    self.totals.known_failures.get(class).copied().unwrap_or(0),
+                );
+            }
+        }
+        out
+    }
+}
+
+fn row(out: &mut String, name: &str, counters: &Counters) {
+    let _ = writeln!(
+        out,
+        "| {name} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+        counters.attempted,
+        counters.passed,
+        counters.gated_regressions,
+        counters.canary_failures.values().sum::<usize>(),
+        counters.known_failures.values().sum::<usize>(),
+        counters.skips,
+        counters.xpass_candidates,
+        counters.crashes,
+        counters.timeouts,
+        counters.harness_failures,
+    );
+}
+
+fn add(totals: &mut Counters, counters: &Counters) {
+    totals.selected += counters.selected;
+    totals.attempted += counters.attempted;
+    totals.passed += counters.passed;
+    totals.gated_regressions += counters.gated_regressions;
+    totals.skips += counters.skips;
+    totals.xpass_candidates += counters.xpass_candidates;
+    totals.crashes += counters.crashes;
+    totals.timeouts += counters.timeouts;
+    totals.harness_failures += counters.harness_failures;
+    for (class, count) in &counters.canary_failures {
+        *totals.canary_failures.entry(class.clone()).or_insert(0) += count;
+    }
+    for (class, count) in &counters.known_failures {
+        *totals.known_failures.entry(class.clone()).or_insert(0) += count;
+    }
+}
+
+/// One framework's evaluated run, ready to be folded into a summary.
+pub struct FrameworkRun<'a> {
+    /// The framework's validated manifest.
+    pub manifest: &'a ProbeStateManifest,
+    /// The case ids the lane selected, in order.
+    pub selected: Vec<String>,
+    /// Each attempted case's observation, request digest, and elapsed time.
+    pub observed: Vec<ObservedCase>,
+}
+
+/// One attempted case.
+pub struct ObservedCase {
+    /// The case id.
+    pub case_id: String,
+    /// The SHA-256 of this case's substituted canonical request.
+    pub request_digest: String,
+    /// Nanoseconds the bracketed compile call took, when it was observed.
+    pub elapsed_ns: Option<u64>,
+    /// The folded observation.
+    pub observation: CaseObservation,
+}
+
+/// Build the summary from every framework's evaluated run.
+///
+/// Evaluation goes through [`ProbeStateManifest::evaluate_case`], never
+/// [`crate::manifest::ProbeEntry::evaluate`] directly, so a driver reporting a
+/// dimension inapplicable that this manifest declares applicable is refused
+/// rather than silently counted as a non-blocking skip.
+pub fn build(lane: Lane, runs: &[FrameworkRun<'_>]) -> Result<Summary, SummaryError> {
+    let mut frameworks = Vec::with_capacity(runs.len());
+    let mut totals = Counters::default();
+    for run in runs {
+        let mut counters = Counters {
+            selected: run.selected.len(),
+            attempted: run.observed.len(),
+            ..Counters::default()
+        };
+        let mut cases = Vec::with_capacity(run.observed.len());
+        for observed in &run.observed {
+            let evaluated = run
+                .manifest
+                .evaluate_case(&observed.observation)
+                .map_err(|error| SummaryError::Parse(error.to_string()))?;
+            let mut cells = Vec::with_capacity(evaluated.len());
+            let mut case_clean = true;
+            for (entry, evaluation) in evaluated {
+                let terminal = observed.observation.terminal(entry.dimension);
+                let observed_class = terminal.class();
+                count_cell(&mut counters, entry.expected_state, evaluation, terminal);
+                let cell_succeeded = match terminal {
+                    Terminal::Class { class, .. } => !class.is_failure(),
+                    Terminal::NotApplicable { .. } => true,
+                    Terminal::NotRun { .. } => false,
+                };
+                if !cell_succeeded {
+                    case_clean = false;
+                }
+                cells.push(CellRow {
+                    probe_id: entry.probe_id.clone(),
+                    dimension: entry.dimension,
+                    expected_state: entry.expected_state,
+                    expected_class: entry.expected_class,
+                    observed_class,
+                    evaluation,
+                });
+            }
+            if case_clean {
+                counters.passed += 1;
+            }
+            cases.push(CaseRow {
+                case_id: observed.case_id.clone(),
+                framework: run.manifest.framework,
+                request_digest: observed.request_digest.clone(),
+                elapsed_ns: observed.elapsed_ns,
+                cells,
+            });
+        }
+        cases.sort_by(|left, right| left.case_id.cmp(&right.case_id));
+        add(&mut totals, &counters);
+        frameworks.push(FrameworkSummary {
+            framework: run.manifest.framework,
+            external_revision: run.manifest.external_revision.as_str().to_string(),
+            request_template: request::REQUEST_VUE.to_string(),
+            template_digest: request::template_digest(),
+            counters,
+            cases,
+        });
+    }
+    let summary = Summary {
+        schema_version: SCHEMA_VERSION,
+        lane,
+        frameworks,
+        totals,
+    };
+    summary.validate()?;
+    Ok(summary)
+}
+
+fn count_cell(
+    counters: &mut Counters,
+    expected_state: ExpectedState,
+    evaluation: Evaluation,
+    terminal: &Terminal,
+) {
+    match evaluation {
+        Evaluation::GateRegression => counters.gated_regressions += 1,
+        Evaluation::Skipped => counters.skips += 1,
+        Evaluation::Xpass => counters.xpass_candidates += 1,
+        Evaluation::CanaryExpected => {
+            if let Some(class) = terminal.class() {
+                *counters
+                    .canary_failures
+                    .entry(class.as_str().to_string())
+                    .or_insert(0) += 1;
+            }
+        }
+        Evaluation::KnownFailExpected => {
+            if let Some(class) = terminal.class() {
+                *counters
+                    .known_failures
+                    .entry(class.as_str().to_string())
+                    .or_insert(0) += 1;
+            }
+        }
+        Evaluation::CanaryRegression | Evaluation::UnrelatedRegression => {
+            // A regression against a non-gate expectation is reported through
+            // its own observed class below; it never becomes a gate here.
+            let bucket = match expected_state {
+                ExpectedState::KnownFail => &mut counters.known_failures,
+                _ => &mut counters.canary_failures,
+            };
+            if let Some(class) = terminal.class() {
+                *bucket.entry(class.as_str().to_string()).or_insert(0) += 1;
+            }
+        }
+        Evaluation::GatePass
+        | Evaluation::ObservedPass
+        | Evaluation::NotRun
+        | Evaluation::NotApplicable => {}
+    }
+    match terminal.class() {
+        Some(ProbeOutcomeClass::Crash) => counters.crashes += 1,
+        Some(ProbeOutcomeClass::Timeout) => counters.timeouts += 1,
+        Some(ProbeOutcomeClass::HarnessFailure) => counters.harness_failures += 1,
+        _ => {}
+    }
+}

--- a/crates/verter_validation_probe/src/summary.rs
+++ b/crates/verter_validation_probe/src/summary.rs
@@ -64,9 +64,21 @@ pub struct Counters {
     /// Gate cells that evaluated to anything but a gate pass.
     pub gated_regressions: usize,
     /// Canary cells that met their expected failure class, by class.
+    ///
+    /// EXPECTED failures only. A canary that changed class counts in
+    /// `canary_regressions` instead, so "the canaries are behaving as
+    /// recorded" and "a canary's class changed" are never the same number.
     pub canary_failures: BTreeMap<String, usize>,
     /// Known-fail cells that met their expected failure class, by class.
+    ///
+    /// EXPECTED failures only, on the same reasoning as `canary_failures`; a
+    /// known-fail that changed class counts in `unrelated_regressions`.
     pub known_failures: BTreeMap<String, usize>,
+    /// `pass` canaries that observed a failure, by the class they observed.
+    pub canary_regressions: BTreeMap<String, usize>,
+    /// Failure canaries and known-fails that observed a DIFFERENT failure
+    /// class than the one recorded, by the class they observed.
+    pub unrelated_regressions: BTreeMap<String, usize>,
     /// Cells the manifest declares skipped.
     pub skips: usize,
     /// Failure canary or known-fail cells that observed a pass.
@@ -81,19 +93,49 @@ pub struct Counters {
 
 impl Counters {
     /// The counter names every summary must carry, in document order.
-    pub const REQUIRED: [&'static str; 11] = [
+    pub const REQUIRED: [&'static str; 13] = [
         "selected",
         "attempted",
         "passed",
         "gated_regressions",
         "canary_failures",
         "known_failures",
+        "canary_regressions",
+        "unrelated_regressions",
         "skips",
         "xpass_candidates",
         "crashes",
         "timeouts",
         "harness_failures",
     ];
+}
+
+/// Which terminal a cell's dimension reached.
+///
+/// Recorded because "no class" is two different facts: a dimension that could
+/// not be exercised at all, and one that was never reached because a lower one
+/// failed. A reader recomputing the counters from the cell rows — which is
+/// what makes the counters auditable rather than self-declared — cannot tell
+/// them apart from `observed_class: null`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservedTerminal {
+    /// An outcome class, carried in `observed_class`.
+    Class,
+    /// The dimension was never reached.
+    NotRun,
+    /// The dimension cannot be exercised for this framework.
+    NotApplicable,
+}
+
+impl ObservedTerminal {
+    fn of(terminal: &Terminal) -> Self {
+        match terminal {
+            Terminal::Class { .. } => ObservedTerminal::Class,
+            Terminal::NotRun { .. } => ObservedTerminal::NotRun,
+            Terminal::NotApplicable { .. } => ObservedTerminal::NotApplicable,
+        }
+    }
 }
 
 /// One evaluated cell.
@@ -109,11 +151,34 @@ pub struct CellRow {
     /// The exact class the manifest expected, when it declared one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_class: Option<ProbeOutcomeClass>,
+    /// Which terminal the dimension reached.
+    pub observed_terminal: ObservedTerminal,
     /// The class observed, when the dimension produced one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_class: Option<ProbeOutcomeClass>,
     /// The evaluation.
     pub evaluation: Evaluation,
+}
+
+impl CellRow {
+    /// Whether this cell actually succeeded — not whether it met its
+    /// expectation. A recorded known failure is behaving as declared and is
+    /// still not a success.
+    fn succeeded(&self) -> bool {
+        match self.observed_terminal {
+            ObservedTerminal::Class => self.observed_class.is_some_and(|class| !class.is_failure()),
+            ObservedTerminal::NotApplicable => true,
+            ObservedTerminal::NotRun => false,
+        }
+    }
+
+    /// Whether the row's two observation fields agree. A `class` terminal
+    /// carries its class and the other two carry none; a row that says
+    /// otherwise is malformed, and recomputing counters from it would produce
+    /// a number that looks honest.
+    fn is_coherent(&self) -> bool {
+        self.observed_class.is_some() == (self.observed_terminal == ObservedTerminal::Class)
+    }
 }
 
 /// One case's row.
@@ -141,10 +206,16 @@ pub struct FrameworkSummary {
     pub framework: Framework,
     /// The pinned corpus revision this framework's cases came from.
     pub external_revision: String,
-    /// The canonical request template, verbatim.
+    /// The canonical request template this framework's cases issued, verbatim.
     pub request_template: String,
     /// The template's SHA-256.
     pub template_digest: String,
+    /// The case ids the lane selected, in order.
+    ///
+    /// Recorded so the attempted-versus-selected claim can be AUDITED from the
+    /// document instead of trusted: a run that observed one case twice and
+    /// skipped another has the right count and the wrong work.
+    pub selected_cases: Vec<String>,
     /// This framework's counters.
     pub counters: Counters,
     /// This framework's case rows, in case-id order.
@@ -194,6 +265,34 @@ pub enum SummaryError {
         /// The framework.
         framework: String,
     },
+    /// The document carries no framework block at all, so its all-zero totals
+    /// would dispose clean having reported nothing.
+    NoFrameworks,
+    /// A framework's attempted case set is not its selection, whatever the
+    /// counts say.
+    SelectionMismatch {
+        /// The framework.
+        framework: String,
+        /// What the disagreement is.
+        detail: String,
+    },
+    /// A counter does not equal what the document's own cell rows add up to.
+    CounterMismatch {
+        /// The framework.
+        framework: String,
+        /// The counter.
+        counter: String,
+    },
+    /// A cell row's terminal and class contradict each other.
+    MalformedCell {
+        /// The case.
+        probe_id: String,
+        /// The dimension.
+        dimension: Dimension,
+    },
+    /// An observation could not be evaluated against the manifest that
+    /// produced it — a runner defect, not a malformed document.
+    Observation(String),
     /// A framework's rows do not equal the case set its counters claim.
     RowCountMismatch {
         /// The framework.
@@ -228,6 +327,26 @@ impl std::fmt::Display for SummaryError {
             ),
             SummaryError::EmptySelection { framework } => {
                 write!(f, "{framework}: the lane selected no case")
+            }
+            SummaryError::NoFrameworks => {
+                f.write_str("the summary carries no framework block at all")
+            }
+            SummaryError::SelectionMismatch { framework, detail } => {
+                write!(f, "{framework}: {detail}")
+            }
+            SummaryError::CounterMismatch { framework, counter } => write!(
+                f,
+                "{framework}: counter `{counter}` is not what the cell rows add up to"
+            ),
+            SummaryError::MalformedCell {
+                probe_id,
+                dimension,
+            } => write!(
+                f,
+                "{probe_id} [{dimension}]: the cell's terminal and observed class disagree"
+            ),
+            SummaryError::Observation(message) => {
+                write!(f, "an observation could not be evaluated: {message}")
             }
             SummaryError::RowCountMismatch {
                 framework,
@@ -317,14 +436,28 @@ impl Summary {
 
     /// Check the document's own internal consistency.
     ///
-    /// The inventory check runs in BOTH directions: a framework that attempted
-    /// fewer cases than it selected has silently skipped work, and one that
-    /// attempted more has run work no manifest ratified.
+    /// Every counter is RECOMPUTED from the cell rows the document carries and
+    /// compared with what it declared. Without that, the disposition reads a
+    /// self-declared number: a document whose rows hold gate regressions and
+    /// whose counter claims zero would be accepted and disposed clean, which is
+    /// precisely the inconsistency this read-back exists to catch.
+    ///
+    /// The inventory check runs in BOTH directions and over the case ids, not
+    /// only their count: a framework that attempted fewer cases than it
+    /// selected has silently skipped work, one that attempted more has run work
+    /// no manifest ratified, and one that observed a case twice has the right
+    /// count and the wrong work.
     pub fn validate(&self) -> Result<(), SummaryError> {
         if self.schema_version != SCHEMA_VERSION {
             return Err(SummaryError::UnknownSchema {
                 schema_version: self.schema_version,
             });
+        }
+        if self.frameworks.is_empty() {
+            // All-zero totals are internally consistent with no blocks at all,
+            // so the same fail-open `EmptySelection` closes per framework has
+            // to be closed here too.
+            return Err(SummaryError::NoFrameworks);
         }
         let mut totals = Counters::default();
         for block in &self.frameworks {
@@ -346,6 +479,9 @@ impl Summary {
                     attempted: block.counters.attempted,
                 });
             }
+            check_selection(block)?;
+            let recounted = recount(block)?;
+            compare_counters(&name, &block.counters, &recounted)?;
             add(&mut totals, &block.counters);
         }
         if totals != self.totals {
@@ -374,12 +510,14 @@ impl Summary {
         let _ = writeln!(out, "### Validation probe — {} lane\n", self.lane.as_str());
         let _ = writeln!(
             out,
-            "| framework | attempted | passed | gated regressions | canary failures | \
-             known failures | skips | XPASS candidates | crashes | timeouts | harness failures |"
+            "| framework | selected | attempted | passed | gated regressions | \
+             canary failures | known failures | canary regressions | unrelated regressions | \
+             skips | XPASS candidates | crashes | timeouts | harness failures |"
         );
         let _ = writeln!(
             out,
-            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | \
+             ---: | ---: | ---: |"
         );
         for block in &self.frameworks {
             row(&mut out, block.framework.as_str(), &block.counters);
@@ -389,30 +527,36 @@ impl Summary {
         for block in &self.frameworks {
             let _ = writeln!(
                 out,
-                "`{}` pinned at `{}`, request `{}`.",
+                "`{}` pinned at `{}`, request template digest `{}`.",
                 block.framework.as_str(),
                 block.external_revision,
                 block.template_digest
             );
         }
-        if !self.totals.canary_failures.is_empty() || !self.totals.known_failures.is_empty() {
+        let by_class = [
+            &self.totals.canary_failures,
+            &self.totals.known_failures,
+            &self.totals.canary_regressions,
+            &self.totals.unrelated_regressions,
+        ];
+        if by_class.iter().any(|map| !map.is_empty()) {
             let _ = writeln!(out, "\nBy outcome class:\n");
-            let _ = writeln!(out, "| class | canary | known-fail |");
-            let _ = writeln!(out, "| --- | ---: | ---: |");
-            let mut classes: Vec<&String> = self
-                .totals
-                .canary_failures
-                .keys()
-                .chain(self.totals.known_failures.keys())
-                .collect();
+            let _ = writeln!(
+                out,
+                "| class | canary | known-fail | canary regression | unrelated regression |"
+            );
+            let _ = writeln!(out, "| --- | ---: | ---: | ---: | ---: |");
+            let mut classes: Vec<&String> = by_class.iter().flat_map(|map| map.keys()).collect();
             classes.sort();
             classes.dedup();
             for class in classes {
                 let _ = writeln!(
                     out,
-                    "| {class} | {} | {} |",
-                    self.totals.canary_failures.get(class).copied().unwrap_or(0),
-                    self.totals.known_failures.get(class).copied().unwrap_or(0),
+                    "| {class} | {} | {} | {} | {} |",
+                    by_class[0].get(class).copied().unwrap_or(0),
+                    by_class[1].get(class).copied().unwrap_or(0),
+                    by_class[2].get(class).copied().unwrap_or(0),
+                    by_class[3].get(class).copied().unwrap_or(0),
                 );
             }
         }
@@ -423,12 +567,15 @@ impl Summary {
 fn row(out: &mut String, name: &str, counters: &Counters) {
     let _ = writeln!(
         out,
-        "| {name} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+        "| {name} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+        counters.selected,
         counters.attempted,
         counters.passed,
         counters.gated_regressions,
         counters.canary_failures.values().sum::<usize>(),
         counters.known_failures.values().sum::<usize>(),
+        counters.canary_regressions.values().sum::<usize>(),
+        counters.unrelated_regressions.values().sum::<usize>(),
         counters.skips,
         counters.xpass_candidates,
         counters.crashes,
@@ -447,18 +594,171 @@ fn add(totals: &mut Counters, counters: &Counters) {
     totals.crashes += counters.crashes;
     totals.timeouts += counters.timeouts;
     totals.harness_failures += counters.harness_failures;
-    for (class, count) in &counters.canary_failures {
-        *totals.canary_failures.entry(class.clone()).or_insert(0) += count;
+    for (map, source) in [
+        (&mut totals.canary_failures, &counters.canary_failures),
+        (&mut totals.known_failures, &counters.known_failures),
+        (&mut totals.canary_regressions, &counters.canary_regressions),
+        (
+            &mut totals.unrelated_regressions,
+            &counters.unrelated_regressions,
+        ),
+    ] {
+        for (class, count) in source {
+            *map.entry(class.clone()).or_insert(0) += count;
+        }
     }
-    for (class, count) in &counters.known_failures {
-        *totals.known_failures.entry(class.clone()).or_insert(0) += count;
+}
+
+/// Check a block's attempted case set IS its selection — the same ids, each
+/// exactly once.
+fn check_selection(block: &FrameworkSummary) -> Result<(), SummaryError> {
+    let framework = block.framework.as_str().to_string();
+    if block.selected_cases.len() != block.counters.selected {
+        return Err(SummaryError::SelectionMismatch {
+            framework,
+            detail: format!(
+                "{} selected case ids recorded for {} selected",
+                block.selected_cases.len(),
+                block.counters.selected
+            ),
+        });
     }
+    let selected: BTreeMap<&str, usize> = tally(block.selected_cases.iter().map(String::as_str));
+    let attempted: BTreeMap<&str, usize> = tally(block.cases.iter().map(|case| &*case.case_id));
+    if let Some((case_id, _)) = attempted.iter().find(|(_, count)| **count > 1) {
+        return Err(SummaryError::SelectionMismatch {
+            framework,
+            detail: format!("`{case_id}` was attempted more than once"),
+        });
+    }
+    if selected != attempted {
+        let missing: Vec<&str> = selected
+            .keys()
+            .filter(|case_id| !attempted.contains_key(*case_id))
+            .copied()
+            .collect();
+        let extra: Vec<&str> = attempted
+            .keys()
+            .filter(|case_id| !selected.contains_key(*case_id))
+            .copied()
+            .collect();
+        return Err(SummaryError::SelectionMismatch {
+            framework,
+            detail: format!(
+                "the attempted case set is not the selection; selected but not attempted: \
+                 [{}]; attempted but not selected: [{}]",
+                missing.join(", "),
+                extra.join(", ")
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn tally<'a>(ids: impl Iterator<Item = &'a str>) -> BTreeMap<&'a str, usize> {
+    let mut counts = BTreeMap::new();
+    for id in ids {
+        *counts.entry(id).or_insert(0) += 1;
+    }
+    counts
+}
+
+/// Recompute a block's counters from the cell rows it carries.
+///
+/// `selected` and `attempted` are copied rather than derived: they are the
+/// lane's selection and its work, which `check_selection` and the row-count
+/// check already pin against the recorded case ids.
+fn recount(block: &FrameworkSummary) -> Result<Counters, SummaryError> {
+    let mut counters = Counters {
+        selected: block.counters.selected,
+        attempted: block.counters.attempted,
+        ..Counters::default()
+    };
+    for case in &block.cases {
+        let mut case_clean = true;
+        for cell in &case.cells {
+            if !cell.is_coherent() {
+                return Err(SummaryError::MalformedCell {
+                    probe_id: cell.probe_id.clone(),
+                    dimension: cell.dimension,
+                });
+            }
+            count_cell(&mut counters, cell.evaluation, cell.observed_class);
+            if !cell.succeeded() {
+                case_clean = false;
+            }
+        }
+        if case_clean {
+            counters.passed += 1;
+        }
+    }
+    Ok(counters)
+}
+
+fn compare_counters(
+    framework: &str,
+    declared: &Counters,
+    recounted: &Counters,
+) -> Result<(), SummaryError> {
+    if declared == recounted {
+        return Ok(());
+    }
+    let differing = [
+        ("passed", declared.passed != recounted.passed),
+        (
+            "gated_regressions",
+            declared.gated_regressions != recounted.gated_regressions,
+        ),
+        (
+            "canary_failures",
+            declared.canary_failures != recounted.canary_failures,
+        ),
+        (
+            "known_failures",
+            declared.known_failures != recounted.known_failures,
+        ),
+        (
+            "canary_regressions",
+            declared.canary_regressions != recounted.canary_regressions,
+        ),
+        (
+            "unrelated_regressions",
+            declared.unrelated_regressions != recounted.unrelated_regressions,
+        ),
+        ("skips", declared.skips != recounted.skips),
+        (
+            "xpass_candidates",
+            declared.xpass_candidates != recounted.xpass_candidates,
+        ),
+        ("crashes", declared.crashes != recounted.crashes),
+        ("timeouts", declared.timeouts != recounted.timeouts),
+        (
+            "harness_failures",
+            declared.harness_failures != recounted.harness_failures,
+        ),
+    ];
+    let counter = differing
+        .iter()
+        .find(|(_, differs)| *differs)
+        .map(|(name, _)| *name)
+        .unwrap_or("selected");
+    Err(SummaryError::CounterMismatch {
+        framework: framework.to_string(),
+        counter: counter.to_string(),
+    })
 }
 
 /// One framework's evaluated run, ready to be folded into a summary.
 pub struct FrameworkRun<'a> {
     /// The framework's validated manifest.
     pub manifest: &'a ProbeStateManifest,
+    /// The canonical request template this framework's cases issued, verbatim.
+    ///
+    /// Carried by the RUN, not read from a crate constant inside the builder:
+    /// a summary that stamped one framework's template onto another's block
+    /// would publish a request its cases never sent, with a digest that agreed
+    /// with itself.
+    pub request_template: &'a str,
     /// The case ids the lane selected, in order.
     pub selected: Vec<String>,
     /// Each attempted case's observation, request digest, and elapsed time.
@@ -497,29 +797,29 @@ pub fn build(lane: Lane, runs: &[FrameworkRun<'_>]) -> Result<Summary, SummaryEr
             let evaluated = run
                 .manifest
                 .evaluate_case(&observed.observation)
-                .map_err(|error| SummaryError::Parse(error.to_string()))?;
+                .map_err(|error| SummaryError::Observation(error.to_string()))?;
             let mut cells = Vec::with_capacity(evaluated.len());
-            let mut case_clean = true;
             for (entry, evaluation) in evaluated {
                 let terminal = observed.observation.terminal(entry.dimension);
-                let observed_class = terminal.class();
-                count_cell(&mut counters, entry.expected_state, evaluation, terminal);
-                let cell_succeeded = match terminal {
-                    Terminal::Class { class, .. } => !class.is_failure(),
-                    Terminal::NotApplicable { .. } => true,
-                    Terminal::NotRun { .. } => false,
-                };
-                if !cell_succeeded {
-                    case_clean = false;
-                }
                 cells.push(CellRow {
                     probe_id: entry.probe_id.clone(),
                     dimension: entry.dimension,
                     expected_state: entry.expected_state,
                     expected_class: entry.expected_class,
-                    observed_class,
+                    observed_terminal: ObservedTerminal::of(terminal),
+                    observed_class: terminal.class(),
                     evaluation,
                 });
+            }
+            // Counted from the ROWS, so the published counters and the
+            // published rows cannot disagree — the same derivation
+            // `Summary::validate` re-runs on read.
+            let mut case_clean = true;
+            for cell in &cells {
+                count_cell(&mut counters, cell.evaluation, cell.observed_class);
+                if !cell.succeeded() {
+                    case_clean = false;
+                }
             }
             if case_clean {
                 counters.passed += 1;
@@ -537,8 +837,9 @@ pub fn build(lane: Lane, runs: &[FrameworkRun<'_>]) -> Result<Summary, SummaryEr
         frameworks.push(FrameworkSummary {
             framework: run.manifest.framework,
             external_revision: run.manifest.external_revision.as_str().to_string(),
-            request_template: request::REQUEST_VUE.to_string(),
-            template_digest: request::template_digest(),
+            request_template: run.request_template.to_string(),
+            template_digest: request::sha256_hex(run.request_template.as_bytes()),
+            selected_cases: run.selected.clone(),
             counters,
             cases,
         });
@@ -553,49 +854,43 @@ pub fn build(lane: Lane, runs: &[FrameworkRun<'_>]) -> Result<Summary, SummaryEr
     Ok(summary)
 }
 
+/// Count one cell.
+///
+/// A regression NEVER lands in the expected-failure buckets: they answer "are
+/// the recorded failures still the recorded failures", and a class change is
+/// exactly the thing that question must not absorb. It still never becomes a
+/// gate — only a gate cell does that.
 fn count_cell(
     counters: &mut Counters,
-    expected_state: ExpectedState,
     evaluation: Evaluation,
-    terminal: &Terminal,
+    observed_class: Option<ProbeOutcomeClass>,
 ) {
-    match evaluation {
-        Evaluation::GateRegression => counters.gated_regressions += 1,
-        Evaluation::Skipped => counters.skips += 1,
-        Evaluation::Xpass => counters.xpass_candidates += 1,
-        Evaluation::CanaryExpected => {
-            if let Some(class) = terminal.class() {
-                *counters
-                    .canary_failures
-                    .entry(class.as_str().to_string())
-                    .or_insert(0) += 1;
-            }
+    let bucket = match evaluation {
+        Evaluation::GateRegression => {
+            counters.gated_regressions += 1;
+            None
         }
-        Evaluation::KnownFailExpected => {
-            if let Some(class) = terminal.class() {
-                *counters
-                    .known_failures
-                    .entry(class.as_str().to_string())
-                    .or_insert(0) += 1;
-            }
+        Evaluation::Skipped => {
+            counters.skips += 1;
+            None
         }
-        Evaluation::CanaryRegression | Evaluation::UnrelatedRegression => {
-            // A regression against a non-gate expectation is reported through
-            // its own observed class below; it never becomes a gate here.
-            let bucket = match expected_state {
-                ExpectedState::KnownFail => &mut counters.known_failures,
-                _ => &mut counters.canary_failures,
-            };
-            if let Some(class) = terminal.class() {
-                *bucket.entry(class.as_str().to_string()).or_insert(0) += 1;
-            }
+        Evaluation::Xpass => {
+            counters.xpass_candidates += 1;
+            None
         }
+        Evaluation::CanaryExpected => Some(&mut counters.canary_failures),
+        Evaluation::KnownFailExpected => Some(&mut counters.known_failures),
+        Evaluation::CanaryRegression => Some(&mut counters.canary_regressions),
+        Evaluation::UnrelatedRegression => Some(&mut counters.unrelated_regressions),
         Evaluation::GatePass
         | Evaluation::ObservedPass
         | Evaluation::NotRun
-        | Evaluation::NotApplicable => {}
+        | Evaluation::NotApplicable => None,
+    };
+    if let (Some(bucket), Some(class)) = (bucket, observed_class) {
+        *bucket.entry(class.as_str().to_string()).or_insert(0) += 1;
     }
-    match terminal.class() {
+    match observed_class {
         Some(ProbeOutcomeClass::Crash) => counters.crashes += 1,
         Some(ProbeOutcomeClass::Timeout) => counters.timeouts += 1,
         Some(ProbeOutcomeClass::HarnessFailure) => counters.harness_failures += 1,

--- a/crates/verter_validation_probe/src/summary.rs
+++ b/crates/verter_validation_probe/src/summary.rs
@@ -14,7 +14,7 @@ use std::fmt::Write as _;
 
 use serde::{Deserialize, Serialize};
 
-use crate::evaluate::Evaluation;
+use crate::evaluate::{decide, Evaluation, ObservedOutcome};
 use crate::manifest::{ExpectedState, Framework, ProbeStateManifest};
 use crate::outcome::{CaseObservation, Dimension, ProbeOutcomeClass, Terminal};
 use crate::request;
@@ -172,12 +172,17 @@ impl CellRow {
         }
     }
 
-    /// Whether the row's two observation fields agree. A `class` terminal
-    /// carries its class and the other two carry none; a row that says
-    /// otherwise is malformed, and recomputing counters from it would produce
-    /// a number that looks honest.
-    fn is_coherent(&self) -> bool {
-        self.observed_class.is_some() == (self.observed_terminal == ObservedTerminal::Class)
+    /// What this row observed, or `None` when its two observation fields
+    /// contradict each other. A `class` terminal carries its class and the
+    /// other two carry none; a row that says otherwise is malformed, and
+    /// anything recomputed from it would look honest without being so.
+    fn observed(&self) -> Option<ObservedOutcome> {
+        match (self.observed_terminal, self.observed_class) {
+            (ObservedTerminal::Class, Some(class)) => Some(ObservedOutcome::Class(class)),
+            (ObservedTerminal::NotRun, None) => Some(ObservedOutcome::NotRun),
+            (ObservedTerminal::NotApplicable, None) => Some(ObservedOutcome::NotApplicable),
+            _ => None,
+        }
     }
 }
 
@@ -290,6 +295,18 @@ pub enum SummaryError {
         /// The dimension.
         dimension: Dimension,
     },
+    /// A cell row's evaluation is not the one its own expectation and
+    /// observation decide.
+    EvaluationMismatch {
+        /// The case.
+        probe_id: String,
+        /// The dimension.
+        dimension: Dimension,
+        /// What the row claims.
+        declared: Evaluation,
+        /// What its fields decide.
+        decided: Evaluation,
+    },
     /// An observation could not be evaluated against the manifest that
     /// produced it — a runner defect, not a malformed document.
     Observation(String),
@@ -344,6 +361,16 @@ impl std::fmt::Display for SummaryError {
             } => write!(
                 f,
                 "{probe_id} [{dimension}]: the cell's terminal and observed class disagree"
+            ),
+            SummaryError::EvaluationMismatch {
+                probe_id,
+                dimension,
+                declared,
+                decided,
+            } => write!(
+                f,
+                "{probe_id} [{dimension}]: the cell claims `{declared}`, but its own \
+                 expectation and observation decide `{decided}`"
             ),
             SummaryError::Observation(message) => {
                 write!(f, "an observation could not be evaluated: {message}")
@@ -677,13 +704,30 @@ fn recount(block: &FrameworkSummary) -> Result<Counters, SummaryError> {
     for case in &block.cases {
         let mut case_clean = true;
         for cell in &case.cells {
-            if !cell.is_coherent() {
+            let Some(observed) = cell.observed() else {
                 return Err(SummaryError::MalformedCell {
                     probe_id: cell.probe_id.clone(),
                     dimension: cell.dimension,
                 });
+            };
+            // Re-DECIDED, not re-counted from what the row claims. Counting a
+            // declared evaluation answers "do these counters add up", which a
+            // document that miswrote one cell's verdict and the counters to
+            // match still passes — and a gate cell claiming `gate_pass` beside
+            // observations that say otherwise is exactly what the lane's one
+            // real exit must never read as clean. The evaluation is a pure
+            // function of the three fields beside it, so the rule that wrote
+            // it is the rule that checks it.
+            let decided = decide(cell.expected_state, cell.expected_class, observed);
+            if decided != cell.evaluation {
+                return Err(SummaryError::EvaluationMismatch {
+                    probe_id: cell.probe_id.clone(),
+                    dimension: cell.dimension,
+                    declared: cell.evaluation,
+                    decided,
+                });
             }
-            count_cell(&mut counters, cell.evaluation, cell.observed_class);
+            count_cell(&mut counters, decided, cell.observed_class);
             if !cell.succeeded() {
                 case_clean = false;
             }

--- a/crates/verter_validation_probe/tests/cases/contract.rs
+++ b/crates/verter_validation_probe/tests/cases/contract.rs
@@ -849,3 +849,102 @@ fn terminals_inconsistent_with_their_feeding_dimension_are_rejected() {
         assert_eq!(CaseObservation::new(CASE, terminals), Err(expected));
     }
 }
+
+// ---------------------------------------------------------------------------
+// The smoke slice
+// ---------------------------------------------------------------------------
+
+/// An EMPTIED slice is refused. Otherwise the required pull-request lane could
+/// be silently re-scoped to nothing and still publish a green summary: the one
+/// outcome a bounded lane must never be able to report.
+#[test]
+fn an_emptied_smoke_slice_is_refused() {
+    let planted = planted("smoke = [\"vue/fixtures/App.vue\"]\n", "");
+    assert!(
+        violations(&planted).contains(&ManifestViolation::EmptySmokeSlice),
+        "an empty smoke slice must be refused: {:?}",
+        violations(&planted),
+    );
+}
+
+/// A PADDED slice is refused. The pull-request bound is structural, so a slice
+/// that grew past it has changed what the required job costs without anyone
+/// deciding to.
+#[test]
+fn a_smoke_slice_above_the_bound_is_refused() {
+    let padded: Vec<String> = (0..verter_validation_probe::MAX_SMOKE_CASES + 1)
+        .map(|_| format!("\"{CASE}\""))
+        .collect();
+    let planted = planted(
+        "smoke = [\"vue/fixtures/App.vue\"]",
+        &format!("smoke = [{}]", padded.join(", ")),
+    );
+    assert!(
+        violations(&planted).contains(&ManifestViolation::SmokeSliceTooLarge {
+            listed: verter_validation_probe::MAX_SMOKE_CASES + 1,
+        }),
+        "a slice above the bound must be refused: {:?}",
+        violations(&planted),
+    );
+}
+
+/// A HAND-PICKED slice is refused. The listed slice is what a reviewer reads,
+/// and its derivation is what the strata promise; a slice that is not its own
+/// derivation has quietly replaced the representative coverage with a choice
+/// nobody reviewed.
+#[test]
+fn a_smoke_slice_that_is_not_its_own_derivation_is_refused() {
+    let planted = planted(
+        "smoke = [\"vue/fixtures/App.vue\"]",
+        "smoke = [\"vue/fixtures/Other.vue\"]",
+    );
+    assert!(
+        violations(&planted).contains(&ManifestViolation::SmokeSliceNotDerived {
+            expected: vec![CASE.to_string()],
+            listed: vec!["vue/fixtures/Other.vue".to_string()],
+        }),
+        "a hand-picked slice must be refused: {:?}",
+        violations(&planted),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gate admission
+// ---------------------------------------------------------------------------
+
+/// Only `Route` may gate. Every other dimension's behaviour is owned by an
+/// authority that is not implemented yet, so a gate there would block the
+/// required job on an outcome nobody has promised.
+#[test]
+fn a_gate_outside_route_is_refused() {
+    let planted = planted(
+        "dimension = \"Compile\"\nexpected_state = \"canary\"\nexpected_class = \"pass\"\n\
+         authority = \"vue.runtime-client-product\"\natom = \"product-shape\"",
+        "dimension = \"Compile\"\nexpected_state = \"gate\"\nexpected_class = \"pass\"\n\
+         authority = \"compiler.public-request-route\"\natom = \"route-callable\"",
+    );
+    assert_eq!(
+        violations(&planted),
+        vec![ManifestViolation::GateOutsideRoute {
+            cell: cell(Dimension::Compile)
+        }],
+    );
+}
+
+/// A gate may cite only the implemented route authority. A gate citing a
+/// product authority would turn an unimplemented promise into a required job's
+/// blocking condition.
+#[test]
+fn a_gate_citing_another_authority_is_refused() {
+    let planted = planted(
+        "authority = \"compiler.public-request-route\"\natom = \"route-callable\"",
+        "authority = \"vue.runtime-client-product\"\natom = \"product-shape\"",
+    );
+    assert_eq!(
+        violations(&planted),
+        vec![ManifestViolation::GateAuthorityNotRoute {
+            cell: cell(Dimension::Route),
+            authority: Authority::VueRuntimeClientProduct,
+        }],
+    );
+}

--- a/crates/verter_validation_probe/tests/cases/contract.rs
+++ b/crates/verter_validation_probe/tests/cases/contract.rs
@@ -18,6 +18,8 @@ framework = "vue"
 comparison = "structural"
 external_revision = "0123456789abcdef0123456789abcdef01234567"
 
+smoke = ["vue/fixtures/App.vue"]
+
 [comparator]
 crate = "verter_vue_conformance"
 path = "src/compare.rs"

--- a/crates/verter_validation_probe/tests/cases/lane_contract.rs
+++ b/crates/verter_validation_probe/tests/cases/lane_contract.rs
@@ -1,0 +1,1505 @@
+//! The lane's own contract, exercised hermetically.
+//!
+//! Every case here drives the real runner, the real fold, and the real summary
+//! over SYNTHETIC driver frames, so each one discriminates a boundary the
+//! external lane cannot: a driver that dies at each phase, a frame that
+//! answers the wrong entry, a reference that is absent for the wrong reason,
+//! and a summary that under-reports.
+//!
+//! No corpus is read and no addon is loaded: the canonical hermetic run neither
+//! requires nor provisions either.
+
+use verter_validation_probe::manifest::{Framework, ProbeStateManifest};
+use verter_validation_probe::outcome::{Dimension, NotApplicableReason, ProbeOutcomeClass as C};
+use verter_validation_probe::request;
+use verter_validation_probe::runner::{
+    classify_execution, parse_line, DiagnosticsSnapshot, DriverLine, ExecutionEvent,
+    FrameViolation, Phase, ProbeRun, ReferenceResult, RequestedEntry, RouteDiagnostic, RouteEntry,
+    RouteFailure, RouteNode, RouteProduct, RouteResponse, VirtualNodeKind,
+};
+use verter_validation_probe::summary::{self, FrameworkRun, Lane, ObservedCase, Summary};
+use verter_validation_probe::{Evaluation, Terminal};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CASE: &str = "vue/fixtures/App.vue";
+const SVELTE_CASE: &str = "svelte/fixtures/App.svelte";
+
+/// A module both sides of a comparison can be given so `Structural` is decided
+/// by the comparator rather than by a parse failure.
+const MODULE: &str = "export const value = 1\n";
+
+fn vue_manifest() -> ProbeStateManifest {
+    ProbeStateManifest::from_toml_str(&manifest_toml(
+        "vue",
+        "fixtures/App.vue",
+        "structural",
+        r#"
+[comparator]
+crate = "verter_vue_conformance"
+path = "src/compare.rs"
+function = "compare_modules"
+atom = "product-identity"
+"#,
+    ))
+    .expect("the vue fixture manifest is valid")
+}
+
+fn svelte_manifest() -> ProbeStateManifest {
+    ProbeStateManifest::from_toml_str(&manifest_toml("svelte", "fixtures/App.svelte", "none", ""))
+        .expect("the svelte fixture manifest is valid")
+}
+
+fn manifest_toml(framework: &str, case: &str, comparison: &str, comparator: &str) -> String {
+    let probe_id = format!("{framework}/{case}");
+    let product = format!("{framework}.runtime-client-product");
+    let structural = if comparison == "structural" {
+        format!(
+            r#"
+[[entries]]
+probe_id = "{probe_id}"
+framework = "{framework}"
+case = "{case}"
+dimension = "Structural"
+expected_state = "canary"
+expected_class = "pass"
+authority = "{product}"
+atom = "product-identity"
+"#
+        )
+    } else {
+        format!(
+            r#"
+[[entries]]
+probe_id = "{probe_id}"
+framework = "{framework}"
+case = "{case}"
+dimension = "Structural"
+expected_state = "skip"
+authority = "{product}"
+atom = "product-identity"
+reason = "comparator_absent"
+"#
+        )
+    };
+    format!(
+        r#"
+framework = "{framework}"
+comparison = "{comparison}"
+external_revision = "0123456789abcdef0123456789abcdef01234567"
+smoke = ["{probe_id}"]
+{comparator}
+[applicability]
+runtime = "inapplicable"
+map = "inapplicable"
+
+[[strata]]
+id = "app"
+pattern = "App*"
+min_cases = 1
+
+[[inventory]]
+case_id = "{probe_id}"
+
+[[entries]]
+probe_id = "{probe_id}"
+framework = "{framework}"
+case = "{case}"
+dimension = "Route"
+expected_state = "gate"
+expected_class = "pass"
+authority = "compiler.public-request-route"
+atom = "route-callable"
+
+[[entries]]
+probe_id = "{probe_id}"
+framework = "{framework}"
+case = "{case}"
+dimension = "Compile"
+expected_state = "canary"
+expected_class = "pass"
+authority = "{product}"
+atom = "product-shape"
+{structural}
+[[entries]]
+probe_id = "{probe_id}"
+framework = "{framework}"
+case = "{case}"
+dimension = "Runtime"
+expected_state = "skip"
+authority = "{product}"
+atom = "runtime-behavior"
+reason = "runtime_executor_absent"
+
+[[entries]]
+probe_id = "{probe_id}"
+framework = "{framework}"
+case = "{case}"
+dimension = "Map"
+expected_state = "skip"
+authority = "{product}"
+atom = "source-map"
+reason = "map_validator_absent"
+
+[[entries]]
+probe_id = "{probe_id}"
+framework = "{framework}"
+case = "{case}"
+dimension = "Performance"
+expected_state = "canary"
+expected_class = "pass"
+authority = "compiler.equivalent-work-ledger"
+atom = "equivalent-work-ledger"
+"#
+    )
+}
+
+fn requested(case_id: &str) -> Vec<RequestedEntry> {
+    vec![RequestedEntry {
+        canonical_id: case_id.to_string(),
+        source: "<template><div/></template>\n".to_string(),
+        request_digest: request::request_digest("fixtures/App.vue"),
+    }]
+}
+
+fn ok_entry(case_id: &str) -> RouteEntry {
+    RouteEntry {
+        canonical_id: case_id.to_string(),
+        response: Some(RouteResponse {
+            diagnostics: DiagnosticsSnapshot::default(),
+            products: vec![RouteProduct {
+                kind: "runtimeClient".to_string(),
+                nodes: Some(vec![RouteNode {
+                    node: VirtualNodeKind {
+                        kind: "main".to_string(),
+                    },
+                    code: MODULE.to_string(),
+                }]),
+            }],
+        }),
+        failure: None,
+    }
+}
+
+fn failure_entry(case_id: &str, kind: &str, severity: Option<&str>) -> RouteEntry {
+    RouteEntry {
+        canonical_id: case_id.to_string(),
+        response: None,
+        failure: Some(RouteFailure {
+            kind: kind.to_string(),
+            message: "refused".to_string(),
+            diagnostics: DiagnosticsSnapshot {
+                diagnostics: severity
+                    .map(|severity| RouteDiagnostic {
+                        severity: severity.to_string(),
+                        code: "E1".to_string(),
+                        message: "boom".to_string(),
+                    })
+                    .into_iter()
+                    .collect(),
+            },
+        }),
+    }
+}
+
+fn compile_frame(case_id: &str, entries: Vec<RouteEntry>) -> DriverLine {
+    DriverLine::Compile {
+        probe_id: case_id.to_string(),
+        elapsed_ns: 1_000,
+        entries,
+    }
+}
+
+fn reference_frame(case_id: &str, reference: Vec<ReferenceResult>) -> DriverLine {
+    DriverLine::Reference {
+        probe_id: case_id.to_string(),
+        reference,
+    }
+}
+
+fn phase(case_id: &str, phase: Phase) -> DriverLine {
+    DriverLine::Phase {
+        probe_id: case_id.to_string(),
+        phase,
+    }
+}
+
+/// Fold one probe and return its single observation's terminals.
+fn observe(
+    manifest: &ProbeStateManifest,
+    case_id: &str,
+    lines: Vec<DriverLine>,
+    terminated: Option<ExecutionEvent>,
+) -> std::collections::BTreeMap<Dimension, Terminal> {
+    let mut run = ProbeRun::new(case_id, requested(case_id));
+    for line in lines {
+        let _ = run.ingest_frame(line);
+    }
+    let mut folded = run.finish(manifest, terminated);
+    folded
+        .remove(0)
+        .unwrap_or_else(|error| panic!("the observation is representable: {error}"))
+        .terminals()
+        .clone()
+}
+
+fn class_at(
+    terminals: &std::collections::BTreeMap<Dimension, Terminal>,
+    dimension: Dimension,
+) -> Option<C> {
+    terminals[&dimension].class()
+}
+
+// ---------------------------------------------------------------------------
+// Execution classification
+// ---------------------------------------------------------------------------
+
+/// A reference that hangs, an addon that will not load, and a compiler that
+/// crashes are three DIFFERENT causes. Collapsing any pair would make the lane
+/// unable to say whether Verter or its harness failed.
+#[test]
+fn a_reference_hang_an_addon_load_failure_and_a_compiler_crash_are_distinct_classes() {
+    assert_eq!(
+        classify_execution(ExecutionEvent::SpawnFailed),
+        C::HarnessFailure,
+    );
+    assert_eq!(
+        classify_execution(ExecutionEvent::TimedOut { phase: None }),
+        C::HarnessFailure,
+    );
+    assert_eq!(
+        classify_execution(ExecutionEvent::TimedOut {
+            phase: Some(Phase::Load)
+        }),
+        C::HarnessFailure,
+    );
+    assert_eq!(
+        classify_execution(ExecutionEvent::TimedOut {
+            phase: Some(Phase::Compile)
+        }),
+        C::Timeout,
+    );
+    assert_eq!(
+        classify_execution(ExecutionEvent::Signaled {
+            phase: Some(Phase::Compile)
+        }),
+        C::Crash,
+    );
+    assert_eq!(
+        classify_execution(ExecutionEvent::TimedOut {
+            phase: Some(Phase::Reference)
+        }),
+        C::ReferenceFailure,
+    );
+    assert_eq!(
+        classify_execution(ExecutionEvent::Signaled {
+            phase: Some(Phase::Reference)
+        }),
+        C::ReferenceFailure,
+    );
+}
+
+/// A non-zero exit maps by the phase it happened in, exactly as a signal or a
+/// timeout does; a clean exit decides nothing on its own.
+#[test]
+fn a_non_zero_exit_maps_by_phase_and_a_clean_exit_decides_nothing() {
+    assert_eq!(
+        classify_execution(ExecutionEvent::Exited {
+            phase: Some(Phase::Load),
+            code: 3
+        }),
+        C::HarnessFailure,
+    );
+    assert_eq!(
+        classify_execution(ExecutionEvent::Exited {
+            phase: Some(Phase::Compile),
+            code: 3
+        }),
+        C::Crash,
+    );
+    assert_eq!(
+        classify_execution(ExecutionEvent::Exited {
+            phase: Some(Phase::Reference),
+            code: 3
+        }),
+        C::ReferenceFailure,
+    );
+    assert_eq!(
+        classify_execution(ExecutionEvent::Exited {
+            phase: Some(Phase::Compile),
+            code: 0
+        }),
+        C::Pass,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Frame authentication
+// ---------------------------------------------------------------------------
+
+/// A reordered batch must never attach one case's product to another case.
+#[test]
+fn a_reordered_batch_is_refused_rather_than_paired_positionally() {
+    let mut run = ProbeRun::new(
+        CASE,
+        vec![
+            requested(CASE).remove(0),
+            RequestedEntry {
+                canonical_id: "vue/fixtures/Other.vue".to_string(),
+                source: String::new(),
+                request_digest: String::new(),
+            },
+        ],
+    );
+    let violation = run
+        .ingest_frame(compile_frame(
+            CASE,
+            vec![ok_entry("vue/fixtures/Other.vue"), ok_entry(CASE)],
+        ))
+        .expect_err("a reordered batch is refused");
+    assert!(
+        matches!(
+            violation,
+            FrameViolation::IdentityMismatch { position: 0, .. }
+        ),
+        "expected a position-0 identity mismatch, got {violation:?}",
+    );
+    assert!(
+        !run.has_compile_frame(),
+        "a frame that failed its own identity check must not be retained",
+    );
+}
+
+/// A reference frame with no compile frame is the protocol breaking, not a
+/// comparison that can be paired against something.
+#[test]
+fn a_reference_frame_without_its_compile_frame_is_refused() {
+    let mut run = ProbeRun::new(CASE, requested(CASE));
+    let violation = run
+        .ingest_frame(reference_frame(
+            CASE,
+            vec![ReferenceResult::Produced {
+                code: MODULE.to_string(),
+            }],
+        ))
+        .expect_err("a reference frame without a compile frame is refused");
+    assert!(matches!(
+        violation,
+        FrameViolation::ReferenceWithoutCompile { .. }
+    ));
+}
+
+/// A second compile frame, and a frame answering the wrong number of entries,
+/// are both refused whole.
+#[test]
+fn a_duplicate_or_miscounted_frame_is_refused() {
+    let mut run = ProbeRun::new(CASE, requested(CASE));
+    run.ingest_frame(compile_frame(CASE, vec![ok_entry(CASE)]))
+        .expect("the first compile frame is accepted");
+    assert!(matches!(
+        run.ingest_frame(compile_frame(CASE, vec![ok_entry(CASE)]))
+            .expect_err("a second compile frame is refused"),
+        FrameViolation::DuplicateCompileFrame { .. }
+    ));
+
+    let mut run = ProbeRun::new(CASE, requested(CASE));
+    assert!(matches!(
+        run.ingest_frame(compile_frame(CASE, vec![ok_entry(CASE), ok_entry(CASE)]))
+            .expect_err("a miscounted frame is refused"),
+        FrameViolation::CountMismatch {
+            requested: 1,
+            answered: 2,
+            ..
+        }
+    ));
+}
+
+/// A refused frame leaves the probe a harness failure, never a verdict about
+/// the compiler it could not observe.
+#[test]
+fn a_refused_frame_makes_the_probe_a_harness_failure() {
+    let manifest = vue_manifest();
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![ok_entry("vue/fixtures/Other.vue")]),
+        ],
+        Some(ExecutionEvent::Exited {
+            phase: Some(Phase::Compile),
+            code: 0,
+        }),
+    );
+    assert_eq!(
+        class_at(&terminals, Dimension::Route),
+        Some(C::HarnessFailure)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Protocol finalization
+// ---------------------------------------------------------------------------
+
+/// A driver that exits cleanly without sending a compile frame leaves the
+/// Route dimension unanswered — a harness failure, never a pass.
+#[test]
+fn a_clean_exit_before_the_compile_frame_is_a_harness_failure_at_route() {
+    let manifest = vue_manifest();
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![phase(CASE, Phase::Load)],
+        Some(ExecutionEvent::Exited {
+            phase: Some(Phase::Load),
+            code: 0,
+        }),
+    );
+    assert_eq!(
+        class_at(&terminals, Dimension::Route),
+        Some(C::HarnessFailure)
+    );
+}
+
+/// A driver that exits cleanly AFTER the compile frame but before the
+/// reference frame keeps its already-observed Route and Compile terminals and
+/// loses only the Structural cell. The reference frame is required for EVERY
+/// probe, so its absence is a harness failure even for a framework with no
+/// registered producer.
+#[test]
+fn a_clean_exit_after_the_compile_frame_costs_only_the_structural_cell() {
+    let manifest = vue_manifest();
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![ok_entry(CASE)]),
+            phase(CASE, Phase::Reference),
+        ],
+        Some(ExecutionEvent::Exited {
+            phase: Some(Phase::Reference),
+            code: 0,
+        }),
+    );
+    assert_eq!(class_at(&terminals, Dimension::Route), Some(C::Pass));
+    assert_eq!(class_at(&terminals, Dimension::Compile), Some(C::Pass));
+    assert_eq!(
+        class_at(&terminals, Dimension::Structural),
+        Some(C::HarnessFailure),
+        "a probe whose reference frame never arrived has an incomplete protocol",
+    );
+    assert_eq!(class_at(&terminals, Dimension::Performance), Some(C::Pass));
+}
+
+/// The same holds for a framework with no registered producer: `comparison =
+/// none` makes an `inapplicable` reference ACCEPTABLE, but it does not make the
+/// reference frame optional.
+#[test]
+fn a_clean_exit_after_compile_is_a_harness_failure_for_an_unregistered_producer_too() {
+    let manifest = svelte_manifest();
+    let mut run = ProbeRun::new(
+        SVELTE_CASE,
+        vec![RequestedEntry {
+            canonical_id: SVELTE_CASE.to_string(),
+            source: String::new(),
+            request_digest: String::new(),
+        }],
+    );
+    let _ = run.ingest_frame(phase(SVELTE_CASE, Phase::Compile));
+    let _ = run.ingest_frame(compile_frame(SVELTE_CASE, vec![ok_entry(SVELTE_CASE)]));
+    let observation = run
+        .finish(
+            &manifest,
+            Some(ExecutionEvent::Exited {
+                phase: Some(Phase::Compile),
+                code: 0,
+            }),
+        )
+        .remove(0)
+        .expect("the observation is representable");
+    // `comparison = none` makes Structural NOT APPLICABLE for this framework,
+    // so the missing reference frame cannot be reported there. What must not
+    // happen is the probe reporting a clean pass, and it does not: the Route
+    // and Compile terminals are the ones the compile frame earned.
+    assert_eq!(
+        observation.terminal(Dimension::Structural),
+        &Terminal::NotApplicable {
+            reason: NotApplicableReason::ComparatorAbsent
+        },
+    );
+    assert_eq!(
+        observation.terminal(Dimension::Route).class(),
+        Some(C::Pass)
+    );
+}
+
+/// A driver-level exception line is the harness failing, whatever phase it
+/// happened in.
+#[test]
+fn a_pre_native_driver_exception_is_a_harness_failure() {
+    let manifest = vue_manifest();
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            DriverLine::Error {
+                probe_id: Some(CASE.to_string()),
+                error: "TypeError: source is not a string".to_string(),
+            },
+        ],
+        None,
+    );
+    assert_eq!(
+        class_at(&terminals, Dimension::Route),
+        Some(C::HarnessFailure)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Reference applicability
+// ---------------------------------------------------------------------------
+
+/// Removing a framework's reference producer must turn its Structural cells
+/// RED, not silently not-applicable. `inapplicable` is accepted only when that
+/// framework's own manifest declares `comparison = none`.
+#[test]
+fn a_missing_producer_is_a_reference_failure_under_structural_comparison() {
+    let manifest = vue_manifest();
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![ok_entry(CASE)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Inapplicable {
+                    inapplicable: "vue".to_string(),
+                }],
+            ),
+        ],
+        None,
+    );
+    assert_eq!(
+        class_at(&terminals, Dimension::Structural),
+        Some(C::ReferenceFailure),
+    );
+}
+
+/// A framework whose manifest declares `comparison = none` records the
+/// dimension as not applicable, and the manifest's own applicability check
+/// accepts that observation.
+#[test]
+fn an_unregistered_producer_is_not_applicable_when_the_manifest_declares_no_comparison() {
+    let manifest = svelte_manifest();
+    let mut run = ProbeRun::new(
+        SVELTE_CASE,
+        vec![RequestedEntry {
+            canonical_id: SVELTE_CASE.to_string(),
+            source: String::new(),
+            request_digest: String::new(),
+        }],
+    );
+    let _ = run.ingest_frame(phase(SVELTE_CASE, Phase::Compile));
+    let _ = run.ingest_frame(compile_frame(SVELTE_CASE, vec![ok_entry(SVELTE_CASE)]));
+    let _ = run.ingest_frame(phase(SVELTE_CASE, Phase::Reference));
+    let _ = run.ingest_frame(reference_frame(
+        SVELTE_CASE,
+        vec![ReferenceResult::Inapplicable {
+            inapplicable: "svelte".to_string(),
+        }],
+    ));
+    let observation = run
+        .finish(&manifest, None)
+        .remove(0)
+        .expect("the observation is representable");
+    assert_eq!(
+        observation.terminal(Dimension::Structural),
+        &Terminal::NotApplicable {
+            reason: NotApplicableReason::ComparatorAbsent
+        },
+    );
+    manifest
+        .check_applicability(&observation)
+        .expect("the observation agrees with the manifest's applicability");
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+/// A successful Vue case is TOTAL across all six dimensions: nothing is left
+/// unreached, and `Runtime`/`Map` are owned not-applicable rather than
+/// silently absent.
+#[test]
+fn a_successful_vue_case_is_total_across_every_dimension() {
+    let manifest = vue_manifest();
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![ok_entry(CASE)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+        None,
+    );
+    assert_eq!(class_at(&terminals, Dimension::Route), Some(C::Pass));
+    assert_eq!(class_at(&terminals, Dimension::Compile), Some(C::Pass));
+    assert_eq!(class_at(&terminals, Dimension::Structural), Some(C::Pass));
+    assert_eq!(
+        terminals[&Dimension::Runtime],
+        Terminal::NotApplicable {
+            reason: NotApplicableReason::RuntimeExecutorAbsent
+        },
+    );
+    assert_eq!(
+        terminals[&Dimension::Map],
+        Terminal::NotApplicable {
+            reason: NotApplicableReason::MapValidatorAbsent
+        },
+    );
+    assert_eq!(class_at(&terminals, Dimension::Performance), Some(C::Pass));
+}
+
+/// A typed binding or framework refusal is a PUBLIC-boundary outcome at
+/// `Route`, never hidden as a harness defect.
+#[test]
+fn a_typed_binding_or_framework_refusal_is_a_route_refusal_not_a_harness_failure() {
+    let manifest = vue_manifest();
+    for kind in ["binding", "frameworkMismatch"] {
+        let terminals = observe(
+            &manifest,
+            CASE,
+            vec![
+                phase(CASE, Phase::Compile),
+                compile_frame(CASE, vec![failure_entry(CASE, kind, None)]),
+                phase(CASE, Phase::Reference),
+                reference_frame(
+                    CASE,
+                    vec![ReferenceResult::Produced {
+                        code: MODULE.to_string(),
+                    }],
+                ),
+            ],
+            None,
+        );
+        assert_eq!(
+            class_at(&terminals, Dimension::Route),
+            Some(C::RequestRefused),
+            "{kind} must be a typed route refusal",
+        );
+    }
+}
+
+/// A `refused` failure carrying an error diagnostic folds to the diagnostic —
+/// the route ANSWERED, so `Route` still passes. A `refused` carrying none is
+/// unexplained and fails closed.
+#[test]
+fn a_refused_failure_folds_to_its_diagnostic_and_fails_closed_without_one() {
+    let manifest = vue_manifest();
+    let with_diagnostic = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![failure_entry(CASE, "refused", Some("error"))]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+        None,
+    );
+    assert_eq!(class_at(&with_diagnostic, Dimension::Route), Some(C::Pass));
+    assert_eq!(
+        class_at(&with_diagnostic, Dimension::Compile),
+        Some(C::VerterDiagnostic),
+    );
+
+    let without = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![failure_entry(CASE, "refused", None)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+        None,
+    );
+    assert_eq!(
+        class_at(&without, Dimension::Compile),
+        Some(C::HarnessFailure),
+        "an unexplained refusal must fail closed",
+    );
+}
+
+/// A host failure is a `Route` outcome, and at `Compile` it OUTRANKS the
+/// diagnostic it carried while retaining it as secondary evidence.
+///
+/// The failing shape this pins: leaving the host failure to propagate would
+/// let the lower-precedence diagnostic win the Compile cell, so a host failure
+/// carrying an error diagnostic would satisfy a diagnostic expectation.
+#[test]
+fn a_host_failure_outranks_its_diagnostic_and_retains_it_as_evidence() {
+    let manifest = vue_manifest();
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![failure_entry(CASE, "host", Some("error"))]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+        None,
+    );
+    // `Route` does not admit a diagnostic class at all, so the host failure is
+    // the whole of that cell.
+    assert_eq!(class_at(&terminals, Dimension::Route), Some(C::HostFailure));
+    // `Compile` admits both, and the fold's precedence puts the host failure
+    // first with the diagnostic retained beneath it.
+    assert_eq!(
+        class_at(&terminals, Dimension::Compile),
+        Some(C::HostFailure)
+    );
+    let Terminal::Class { secondary, .. } = &terminals[&Dimension::Compile] else {
+        panic!("the compile terminal is a class")
+    };
+    assert!(
+        secondary.contains(&C::VerterDiagnostic),
+        "the diagnostic must be retained as secondary evidence, found {secondary:?}",
+    );
+}
+
+/// The same holds for a typed refusal that carried an error diagnostic: the
+/// refusal outranks it rather than being replaced by it.
+#[test]
+fn a_typed_refusal_outranks_a_diagnostic_it_carried() {
+    let manifest = vue_manifest();
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![failure_entry(CASE, "binding", Some("error"))]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+        None,
+    );
+    assert_eq!(
+        class_at(&terminals, Dimension::Route),
+        Some(C::RequestRefused)
+    );
+    assert_eq!(
+        class_at(&terminals, Dimension::Compile),
+        Some(C::RequestRefused),
+    );
+}
+
+/// Product extraction is EXACT: the request asks for one product with one
+/// `main` node, so anything else is absent or malformed rather than searched
+/// through for something usable.
+#[test]
+fn product_extraction_is_exact() {
+    let manifest = vue_manifest();
+    let cases: [(Vec<RouteProduct>, C); 4] = [
+        (Vec::new(), C::ProductNotProduced),
+        (
+            vec![RouteProduct {
+                kind: "ideCompanion".to_string(),
+                nodes: None,
+            }],
+            C::ProductMalformed,
+        ),
+        (
+            vec![RouteProduct {
+                kind: "runtimeClient".to_string(),
+                nodes: Some(Vec::new()),
+            }],
+            C::ProductNotProduced,
+        ),
+        (
+            vec![RouteProduct {
+                kind: "runtimeClient".to_string(),
+                nodes: Some(vec![
+                    RouteNode {
+                        node: VirtualNodeKind {
+                            kind: "main".to_string(),
+                        },
+                        code: MODULE.to_string(),
+                    },
+                    RouteNode {
+                        node: VirtualNodeKind {
+                            kind: "main".to_string(),
+                        },
+                        code: MODULE.to_string(),
+                    },
+                ]),
+            }],
+            C::ProductMalformed,
+        ),
+    ];
+    for (products, expected) in cases {
+        let entry = RouteEntry {
+            canonical_id: CASE.to_string(),
+            response: Some(RouteResponse {
+                diagnostics: DiagnosticsSnapshot::default(),
+                products,
+            }),
+            failure: None,
+        };
+        let terminals = observe(
+            &manifest,
+            CASE,
+            vec![
+                phase(CASE, Phase::Compile),
+                compile_frame(CASE, vec![entry]),
+                phase(CASE, Phase::Reference),
+                reference_frame(
+                    CASE,
+                    vec![ReferenceResult::Produced {
+                        code: MODULE.to_string(),
+                    }],
+                ),
+            ],
+            None,
+        );
+        assert_eq!(class_at(&terminals, Dimension::Compile), Some(expected));
+    }
+}
+
+/// A product that does not parse and build is malformed, and no comparison is
+/// emitted for it — comparison evidence never exists without both inputs.
+#[test]
+fn an_unparseable_product_is_malformed_and_emits_no_comparison() {
+    let manifest = vue_manifest();
+    let entry = RouteEntry {
+        canonical_id: CASE.to_string(),
+        response: Some(RouteResponse {
+            diagnostics: DiagnosticsSnapshot::default(),
+            products: vec![RouteProduct {
+                kind: "runtimeClient".to_string(),
+                nodes: Some(vec![RouteNode {
+                    node: VirtualNodeKind {
+                        kind: "main".to_string(),
+                    },
+                    code: "const = ;".to_string(),
+                }]),
+            }],
+        }),
+        failure: None,
+    };
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![entry]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+        None,
+    );
+    assert_eq!(
+        class_at(&terminals, Dimension::Compile),
+        Some(C::ProductMalformed),
+    );
+    assert_eq!(
+        class_at(&terminals, Dimension::Structural),
+        Some(C::ProductMalformed),
+        "no comparison may be reported when one of its inputs is absent",
+    );
+}
+
+/// A differing product is a structural mismatch and nothing more: the route
+/// answered and the product is valid.
+#[test]
+fn a_differing_product_is_a_structural_mismatch_alone() {
+    let manifest = vue_manifest();
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![ok_entry(CASE)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: "export const value = 2\n".to_string(),
+                }],
+            ),
+        ],
+        None,
+    );
+    assert_eq!(class_at(&terminals, Dimension::Route), Some(C::Pass));
+    assert_eq!(class_at(&terminals, Dimension::Compile), Some(C::Pass));
+    assert_eq!(
+        class_at(&terminals, Dimension::Structural),
+        Some(C::SemanticMismatch),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Driver protocol parsing
+// ---------------------------------------------------------------------------
+
+/// The line shapes the driver actually writes, parsed structurally.
+#[test]
+fn driver_lines_are_parsed_by_shape_and_an_unknown_shape_is_refused() {
+    assert!(matches!(
+        parse_line(r#"{"probe_id":"a","phase":"compile"}"#),
+        Ok(DriverLine::Phase {
+            phase: Phase::Compile,
+            ..
+        })
+    ));
+    assert!(matches!(
+        parse_line(r#"{"probe_id":"a","error":"boom","phase":"compile","stage":"pre-native"}"#),
+        Ok(DriverLine::Error { .. })
+    ));
+    assert!(matches!(
+        parse_line(
+            r#"{"probe_id":"a","frame":"reference","reference":[{"inapplicable":"svelte"}]}"#
+        ),
+        Ok(DriverLine::Reference { .. })
+    ));
+    assert!(parse_line(r#"{"probe_id":"a","frame":"compile","entries":[]}"#).is_err());
+    assert!(parse_line(r#"{"probe_id":"a"}"#).is_err());
+    assert!(parse_line("not json").is_err());
+}
+
+// ---------------------------------------------------------------------------
+// The canonical request
+// ---------------------------------------------------------------------------
+
+/// The template is canonical JSON with sorted keys at every level, and its
+/// only substitution is the filename.
+#[test]
+fn the_request_template_is_canonical_and_substitutes_only_the_filename() {
+    let value: serde_json::Value =
+        serde_json::from_str(request::REQUEST_VUE).expect("the template is JSON");
+    assert_sorted(&value, "$");
+    assert!(
+        !request::REQUEST_VUE.contains(' ') || request::REQUEST_VUE.contains("case relative path"),
+        "the template carries no incidental whitespace",
+    );
+
+    let substituted = request::substitute("tests/fixtures/App.vue");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&substituted).expect("the substituted request is JSON");
+    assert_eq!(
+        parsed["identity"]["filename"],
+        serde_json::json!("tests/fixtures/App.vue"),
+    );
+    assert_eq!(parsed["framework"], serde_json::json!("vue"));
+    assert_eq!(
+        parsed["products"][0]["kind"],
+        serde_json::json!("runtimeClient")
+    );
+
+    // Everything but the filename is untouched.
+    let mut expected: serde_json::Value =
+        serde_json::from_str(request::REQUEST_VUE).expect("the template is JSON");
+    expected["identity"]["filename"] = serde_json::json!("tests/fixtures/App.vue");
+    assert_eq!(parsed, expected);
+}
+
+/// A path carrying a quote produces an escaped string, never a request whose
+/// shape the corpus decided.
+#[test]
+fn a_hostile_path_is_escaped_rather_than_interpolated() {
+    let substituted = request::substitute(r#"a"/,"framework":"svelte"."#);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&substituted).expect("the substituted request is still JSON");
+    assert_eq!(parsed["framework"], serde_json::json!("vue"));
+    assert_eq!(
+        parsed["identity"]["filename"],
+        serde_json::json!(r#"a"/,"framework":"svelte"."#),
+    );
+}
+
+/// Digests are stable and distinguish cases.
+#[test]
+fn digests_are_stable_and_case_distinguishing() {
+    assert_eq!(request::template_digest(), request::template_digest());
+    assert_eq!(request::template_digest().len(), 64);
+    assert_ne!(
+        request::request_digest("a/App.vue"),
+        request::request_digest("b/App.vue"),
+    );
+    assert_eq!(
+        request::request_digest("a/App.vue"),
+        request::request_digest("a/App.vue"),
+    );
+}
+
+fn assert_sorted(value: &serde_json::Value, path: &str) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let keys: Vec<&String> = map.keys().collect();
+            let mut sorted = keys.clone();
+            sorted.sort();
+            assert_eq!(keys, sorted, "{path}: keys are not sorted");
+            for (key, child) in map {
+                assert_sorted(child, &format!("{path}.{key}"));
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                assert_sorted(child, &format!("{path}[{index}]"));
+            }
+        }
+        _ => {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The summary
+// ---------------------------------------------------------------------------
+
+fn one_case_summary(manifest: &ProbeStateManifest, lines: Vec<DriverLine>) -> Summary {
+    let mut run = ProbeRun::new(CASE, requested(CASE));
+    for line in lines {
+        let _ = run.ingest_frame(line);
+    }
+    let observation = run
+        .finish(manifest, None)
+        .remove(0)
+        .expect("the observation is representable");
+    let framework_run = FrameworkRun {
+        manifest,
+        selected: vec![CASE.to_string()],
+        observed: vec![ObservedCase {
+            case_id: CASE.to_string(),
+            request_digest: request::request_digest("fixtures/App.vue"),
+            elapsed_ns: Some(1_000),
+            observation,
+        }],
+    };
+    summary::build(Lane::Smoke, std::slice::from_ref(&framework_run))
+        .expect("the summary is consistent")
+}
+
+/// The summary carries every required counter, and reports the lane's real
+/// work rather than its intention.
+#[test]
+fn the_summary_carries_every_required_counter_and_its_real_work() {
+    let manifest = vue_manifest();
+    let summary = one_case_summary(
+        &manifest,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![ok_entry(CASE)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+    );
+    assert_eq!(summary.totals.selected, 1);
+    assert_eq!(summary.totals.attempted, 1);
+    assert_eq!(summary.totals.passed, 1);
+    assert_eq!(summary.totals.gated_regressions, 0);
+    assert_eq!(summary.totals.skips, 2);
+    assert_eq!(
+        summary.disposition(),
+        verter_validation_probe::Disposition::Clean
+    );
+
+    let json = summary.to_json();
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("the summary is JSON");
+    for counter in verter_validation_probe::Counters::REQUIRED {
+        assert!(
+            parsed["totals"].get(counter).is_some(),
+            "the totals omit `{counter}`",
+        );
+        assert!(
+            parsed["frameworks"][0]["counters"].get(counter).is_some(),
+            "the vue block omits `{counter}`",
+        );
+    }
+    assert!(
+        Summary::from_json_str(&json).is_ok(),
+        "a complete summary round-trips",
+    );
+
+    let markdown = summary.to_markdown();
+    for header in [
+        "attempted",
+        "passed",
+        "gated regressions",
+        "canary failures",
+        "known failures",
+        "skips",
+        "XPASS candidates",
+        "crashes",
+        "timeouts",
+        "harness failures",
+    ] {
+        assert!(
+            markdown.contains(header),
+            "the job summary omits `{header}`"
+        );
+    }
+}
+
+/// A summary missing a counter is REFUSED, not read as an honest zero. Without
+/// this, "no gate regressions" and "the lane forgot to count them" are the same
+/// document.
+#[test]
+fn a_summary_missing_a_counter_is_refused_rather_than_read_as_zero() {
+    let manifest = vue_manifest();
+    let summary = one_case_summary(
+        &manifest,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![ok_entry(CASE)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+    );
+    let json = summary.to_json();
+    for counter in verter_validation_probe::Counters::REQUIRED {
+        let mut parsed: serde_json::Value = serde_json::from_str(&json).expect("summary is JSON");
+        parsed["totals"]
+            .as_object_mut()
+            .expect("totals is an object")
+            .remove(counter);
+        let planted = parsed.to_string();
+        assert!(
+            planted != json,
+            "the plant for `{counter}` must actually change the document",
+        );
+        assert!(
+            Summary::from_json_str(&planted).is_err(),
+            "a summary missing `{counter}` must be refused",
+        );
+    }
+}
+
+/// A gate regression is a REAL non-zero disposition, and it is computed from
+/// gate cells alone — a canary or a known-fail never blocks.
+#[test]
+fn a_gate_regression_disposes_non_zero_and_a_canary_never_does() {
+    let manifest = vue_manifest();
+    // A host failure at Route does not meet the manifest's `pass` gate.
+    let regressed = one_case_summary(
+        &manifest,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![failure_entry(CASE, "host", None)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+    );
+    assert_eq!(regressed.totals.gated_regressions, 1);
+    assert_eq!(
+        regressed.disposition(),
+        verter_validation_probe::Disposition::GateRegressed { count: 1 },
+    );
+    assert_eq!(regressed.disposition().exit_code(), 1);
+
+    // A differing product regresses the Structural CANARY and nothing else.
+    let canary = one_case_summary(
+        &manifest,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![ok_entry(CASE)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: "export const value = 2\n".to_string(),
+                }],
+            ),
+        ],
+    );
+    assert_eq!(canary.totals.gated_regressions, 0);
+    assert_eq!(
+        canary.disposition(),
+        verter_validation_probe::Disposition::Clean,
+    );
+    assert_eq!(canary.disposition().exit_code(), 0);
+}
+
+/// A framework that attempted fewer or more cases than it selected is refused:
+/// the inventory check runs in BOTH directions.
+#[test]
+fn a_summary_whose_attempted_set_differs_from_its_selection_is_refused() {
+    let manifest = vue_manifest();
+    let mut run = ProbeRun::new(CASE, requested(CASE));
+    let _ = run.ingest_frame(phase(CASE, Phase::Compile));
+    let _ = run.ingest_frame(compile_frame(CASE, vec![ok_entry(CASE)]));
+    let _ = run.ingest_frame(phase(CASE, Phase::Reference));
+    let _ = run.ingest_frame(reference_frame(
+        CASE,
+        vec![ReferenceResult::Produced {
+            code: MODULE.to_string(),
+        }],
+    ));
+    let observation = run
+        .finish(&manifest, None)
+        .remove(0)
+        .expect("the observation is representable");
+
+    let under = FrameworkRun {
+        manifest: &manifest,
+        selected: vec![CASE.to_string(), "vue/fixtures/Other.vue".to_string()],
+        observed: vec![ObservedCase {
+            case_id: CASE.to_string(),
+            request_digest: String::new(),
+            elapsed_ns: None,
+            observation,
+        }],
+    };
+    assert!(
+        summary::build(Lane::Smoke, std::slice::from_ref(&under)).is_err(),
+        "a lane that attempted fewer cases than it selected must be refused",
+    );
+
+    let empty = FrameworkRun {
+        manifest: &manifest,
+        selected: Vec::new(),
+        observed: Vec::new(),
+    };
+    assert!(
+        summary::build(Lane::Smoke, std::slice::from_ref(&empty)).is_err(),
+        "a lane that selected nothing must be refused, not published green",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The committed manifest
+// ---------------------------------------------------------------------------
+
+fn committed_vue_manifest_text() -> String {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("manifest")
+        .join("vue.toml");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("reading {}: {error}", path.display()))
+}
+
+/// The committed manifest is valid, bounded, and carries no classless canary.
+#[test]
+fn the_committed_vue_manifest_is_valid_bounded_and_fully_classified() {
+    let manifest =
+        ProbeStateManifest::from_manifest_file("vue.toml", &committed_vue_manifest_text())
+            .unwrap_or_else(|error| panic!("the committed vue manifest is invalid: {error}"));
+
+    assert_eq!(manifest.framework, Framework::Vue);
+    assert!(
+        !manifest.smoke.is_empty(),
+        "the smoke slice selects no case"
+    );
+    assert!(
+        manifest.smoke.len() <= verter_validation_probe::MAX_SMOKE_CASES,
+        "the smoke slice lists {} cases",
+        manifest.smoke.len(),
+    );
+    assert_eq!(
+        manifest.smoke,
+        manifest.derived_smoke_slice(),
+        "the smoke slice is not its own deterministic derivation",
+    );
+
+    let inventory: std::collections::BTreeSet<&str> = manifest
+        .inventory
+        .iter()
+        .map(|case| case.case_id.as_str())
+        .collect();
+    for case_id in &manifest.smoke {
+        assert!(
+            inventory.contains(case_id.as_str()),
+            "the smoke slice selects `{case_id}`, which is not inventoried",
+        );
+    }
+
+    for entry in &manifest.entries {
+        if matches!(
+            entry.expected_state,
+            verter_validation_probe::ExpectedState::Canary
+                | verter_validation_probe::ExpectedState::KnownFail
+                | verter_validation_probe::ExpectedState::Gate
+        ) {
+            assert!(
+                entry.expected_class.is_some(),
+                "{} [{}] is classless",
+                entry.probe_id,
+                entry.dimension,
+            );
+        }
+    }
+}
+
+/// Only `Route` may gate, and only on the outcomes the implemented route
+/// authority actually owns.
+#[test]
+fn only_the_implemented_route_authority_gates() {
+    let manifest =
+        ProbeStateManifest::from_manifest_file("vue.toml", &committed_vue_manifest_text())
+            .expect("the committed vue manifest is valid");
+    for entry in &manifest.entries {
+        if entry.expected_state != verter_validation_probe::ExpectedState::Gate {
+            continue;
+        }
+        assert_eq!(
+            entry.dimension,
+            Dimension::Route,
+            "{} gates at {}",
+            entry.probe_id,
+            entry.dimension,
+        );
+        assert_eq!(
+            entry.authority,
+            Some(verter_validation_probe::Authority::CompilerPublicRequestRoute),
+        );
+        assert!(
+            matches!(
+                entry.expected_class,
+                Some(C::Pass) | Some(C::RequestRefused)
+            ),
+            "{} gates on {:?}, which the route authority's atoms do not own",
+            entry.probe_id,
+            entry.expected_class,
+        );
+    }
+}
+
+/// The lane is table-driven: the workflow declares exactly ONE probe job, and
+/// there is no per-fixture job or per-fixture test definition.
+#[test]
+fn the_workflow_declares_exactly_one_probe_job() {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|crates| crates.parent())
+        .expect("the crate lives at <root>/crates/verter_validation_probe")
+        .join(".github")
+        .join("workflows")
+        .join("validation-probe.yml");
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+
+    let mut in_jobs = false;
+    let mut jobs = Vec::new();
+    for line in text.lines() {
+        if line.starts_with("jobs:") {
+            in_jobs = true;
+            continue;
+        }
+        if !in_jobs {
+            continue;
+        }
+        if !line.starts_with(' ') && !line.trim().is_empty() {
+            break;
+        }
+        let indent = line.len() - line.trim_start().len();
+        let trimmed = line.trim_start();
+        if indent == 2 && trimmed.ends_with(':') && !trimmed.starts_with('-') {
+            jobs.push(trimmed.trim_end_matches(':').to_string());
+        }
+    }
+    assert_eq!(
+        jobs,
+        vec!["probe".to_string()],
+        "the workflow declares {jobs:?}"
+    );
+
+    // The lane's disposition is a real exit, taken AFTER publication. Only the
+    // STEPS are read: the file's own header prose mentions each of these, and
+    // matching it would let the steps be reordered without failing here.
+    let steps = &text[text.find("jobs:").expect("the workflow declares jobs")..];
+    let dispose = steps
+        .find("--dispose")
+        .expect("the workflow disposes the lane");
+    let upload = steps
+        .find("upload-artifact")
+        .expect("the workflow uploads the summary artifact");
+    let markdown = steps
+        .find("--markdown")
+        .expect("the workflow renders the summary");
+    assert!(
+        upload < dispose && markdown < dispose,
+        "the disposition must run after the artifact and the rendered summary are published",
+    );
+}
+
+/// A `not_run` cell never counts as a pass, and a skip never counts as work.
+#[test]
+fn unreached_and_skipped_cells_are_never_counted_as_passes() {
+    let manifest = vue_manifest();
+    let summary = one_case_summary(
+        &manifest,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![failure_entry(CASE, "host", None)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+    );
+    assert_eq!(summary.totals.passed, 0);
+    assert_eq!(summary.totals.skips, 2);
+    let cells = &summary.frameworks[0].cases[0].cells;
+    let performance = cells
+        .iter()
+        .find(|cell| cell.dimension == Dimension::Performance)
+        .expect("the performance cell is present");
+    assert_eq!(performance.evaluation, Evaluation::NotRun);
+    assert_eq!(performance.observed_class, None);
+}

--- a/crates/verter_validation_probe/tests/cases/lane_contract.rs
+++ b/crates/verter_validation_probe/tests/cases/lane_contract.rs
@@ -1260,6 +1260,61 @@ fn a_summary_whose_counters_disagree_with_its_cell_rows_is_refused() {
     );
 }
 
+/// A cell whose EVALUATION is not what its own fields decide is refused.
+///
+/// Recomputing the counters from the evaluations the rows declare answers only
+/// "do these numbers add up", and a document that miswrote one verdict and the
+/// counters to match adds up perfectly. The evaluation is a pure function of
+/// the expectation and the observation printed beside it, so the read-back
+/// re-decides it through the same rule that wrote it: a gate cell claiming
+/// `gate_pass` over observations that say otherwise is exactly what the lane's
+/// one real exit must never read as clean.
+#[test]
+fn a_summary_whose_cell_evaluation_is_not_what_its_own_fields_decide_is_refused() {
+    let manifest = vue_manifest();
+    let regressed = one_case_summary(
+        &manifest,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![failure_entry(CASE, "host", None)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+    );
+    assert_eq!(regressed.totals.gated_regressions, 1);
+    assert_ne!(regressed.disposition().exit_code(), 0);
+
+    // Claim the gate PASSED, and zero the counter so the arithmetic still
+    // agrees with the rows. Only re-deciding the cell can catch this.
+    let mut parsed: serde_json::Value =
+        serde_json::from_str(&regressed.to_json()).expect("summary is JSON");
+    let cells = parsed["frameworks"][0]["cases"][0]["cells"]
+        .as_array_mut()
+        .expect("the case carries cells");
+    let gate = cells
+        .iter_mut()
+        .find(|cell| cell["evaluation"] == serde_json::json!("gate_regression"))
+        .expect("the planted regression is a gate cell");
+    gate["evaluation"] = serde_json::json!("gate_pass");
+    parsed["totals"]["gated_regressions"] = serde_json::json!(0);
+    parsed["frameworks"][0]["counters"]["gated_regressions"] = serde_json::json!(0);
+
+    let refused = Summary::from_json_str(&parsed.to_string())
+        .expect_err("a cell claiming a verdict its own fields refuse must be rejected");
+    assert!(
+        matches!(
+            refused,
+            verter_validation_probe::SummaryError::EvaluationMismatch { .. }
+        ),
+        "expected an evaluation mismatch, got {refused}",
+    );
+}
+
 /// A cell row whose terminal and class contradict each other is refused: the
 /// counters are recomputed from those two fields, so an incoherent row would
 /// produce numbers that look honest.
@@ -2184,6 +2239,245 @@ fn a_pause_after_the_compile_frame_is_not_a_compiler_timeout() {
         Some(C::Pass),
         "a pause before the reference marker must not be read as a compiler timeout: {:?}",
         observation.terminal(Dimension::Structural),
+    );
+}
+
+/// A HANG after the compile frame is a reference failure, not a compiler
+/// timeout.
+///
+/// The reference deadline is what bounds the probe from the moment that frame
+/// arrives, and the cause it is attributed to has to move with it: the frame is
+/// written only once the native call has returned, so nothing of the compiler
+/// is still running. Stamping the timeout with the last phase MARKER instead
+/// would report the class that means "the compiler hung" for a hang that
+/// provably happened after the compiler had finished — the taxonomy's most
+/// load-bearing distinction, decided wrongly.
+#[test]
+fn a_hang_after_the_compile_frame_is_a_reference_failure_not_a_compiler_timeout() {
+    let manifest = vue_manifest();
+    let (script, driver) = synthetic_driver(
+        "driver-hang-after-compile",
+        r#"
+  write({ probe_id: id, phase: "load" });
+  write({ probe_id: id, phase: "compile" });
+  write({ probe_id: id, frame: "compile", elapsed_ns: 1, entries: [product(canonicalId)] });
+  // No reference phase marker, and no reference frame: the hang strikes while
+  // the last marker still says `compile`.
+  await sleep(30_000);
+"#,
+    );
+    let cases = [planned(CASE)];
+    let results = runner::run_cases(
+        &manifest,
+        &driver,
+        &cases,
+        PhaseDeadlines {
+            load: std::time::Duration::from_secs(30),
+            compile: std::time::Duration::from_secs(30),
+            reference: std::time::Duration::from_millis(300),
+        },
+    )
+    .unwrap_or_else(|error| panic!("the synthetic driver could not be run: {error}"));
+    let _ = std::fs::remove_file(&script);
+
+    let observation = results[0]
+        .observation
+        .as_ref()
+        .expect("the observation is representable");
+    assert_eq!(
+        observation.terminal(Dimension::Compile).class(),
+        Some(C::Pass),
+        "the compile frame was already ingested, so its terminal stands",
+    );
+    assert_eq!(
+        observation.terminal(Dimension::Structural).class(),
+        Some(C::ReferenceFailure),
+        "a hang after the compile frame must not be attributed to the compiler: {:?}",
+        observation.terminal(Dimension::Structural),
+    );
+}
+
+/// A broken stdout stream is the HARNESS failing, never the compiler.
+///
+/// The runner could not read what the driver said; the driver itself may be
+/// alive and well. Running that through the phase map — which exists to say
+/// which step was executing when a PROCESS ended — would report a crash or a
+/// timeout the compiler never had, and it would say so for every case after it
+/// too.
+#[test]
+fn a_broken_stdout_stream_is_a_harness_failure_not_a_compiler_crash() {
+    let manifest = vue_manifest();
+    let (script, driver) = synthetic_driver(
+        "driver-broken-stream",
+        r#"
+  write({ probe_id: id, phase: "load" });
+  write({ probe_id: id, phase: "compile" });
+  // Bytes that are not a UTF-8 line: the transport, not the compiler.
+  process.stdout.write(Buffer.from([0xff, 0xfe, 0x0a]));
+  await sleep(30_000);
+"#,
+    );
+    let cases = [planned(CASE), planned(CASE)];
+    let results = runner::run_cases(
+        &manifest,
+        &driver,
+        &cases,
+        generous(std::time::Duration::from_secs(30)),
+    )
+    .unwrap_or_else(|error| panic!("the synthetic driver could not be run: {error}"));
+    let _ = std::fs::remove_file(&script);
+
+    for (position, result) in results.iter().enumerate() {
+        let observation = result
+            .observation
+            .as_ref()
+            .expect("the observation is representable");
+        let class = observation.terminal(Dimension::Route).class();
+        assert_eq!(
+            class,
+            Some(C::HarnessFailure),
+            "case {position} must report the harness, not the compiler: {:?}",
+            observation.terminal(Dimension::Route),
+        );
+        assert_ne!(class, Some(C::Crash));
+        assert_ne!(class, Some(C::Timeout));
+    }
+}
+
+/// A frame naming ANOTHER probe stops the lane deliberately, even when the
+/// stream would otherwise carry on perfectly.
+///
+/// The protocol is one probe at a time, so a foreign frame means the stream and
+/// the runner are out of step and the next probe's lines can no longer be told
+/// from this one's. The driver here goes on to answer BOTH probes correctly, so
+/// a runner that merely recorded the refusal and read on would report the
+/// second case as a clean pass — a verdict read off a stream it had already
+/// caught lying about which case it was describing. Evidence that describes a
+/// different case is worse than no evidence, so the driver is killed and every
+/// case after it says so.
+#[test]
+fn a_frame_naming_another_probe_stops_the_lane_and_the_rest_report_it() {
+    let manifest = vue_manifest();
+    let (script, driver) = synthetic_driver(
+        "driver-foreign-frame",
+        r#"
+  write({ probe_id: id, phase: "load" });
+  write({ probe_id: id, phase: "compile" });
+  if (seen === 1) {
+    write({ probe_id: "vue/fixtures/Other.vue", frame: "compile", elapsed_ns: 1,
+            entries: [product(canonicalId)] });
+  }
+  write({ probe_id: id, frame: "compile", elapsed_ns: 1, entries: [product(canonicalId)] });
+  write({ probe_id: id, phase: "reference" });
+  write({ probe_id: id, frame: "reference", reference: [{ code: "export const value = 1\n" }] });
+"#,
+    );
+    let cases = [planned(CASE), planned(CASE)];
+    let results = runner::run_cases(
+        &manifest,
+        &driver,
+        &cases,
+        generous(std::time::Duration::from_secs(30)),
+    )
+    .unwrap_or_else(|error| panic!("the synthetic driver could not be run: {error}"));
+    let _ = std::fs::remove_file(&script);
+
+    let first = results[0]
+        .observation
+        .as_ref()
+        .expect("the observation is representable");
+    assert_eq!(
+        first.terminal(Dimension::Route).class(),
+        Some(C::HarnessFailure),
+        "the refused frame is the probe's own harness failure",
+    );
+    let second = results[1]
+        .observation
+        .as_ref()
+        .expect("the observation is representable");
+    assert_eq!(
+        second.terminal(Dimension::Route).class(),
+        Some(C::HarnessFailure),
+        "the lane must stop rather than read a desynchronised stream: {:?}",
+        second.terminal(Dimension::Route),
+    );
+    assert_ne!(
+        second.terminal(Dimension::Compile).class(),
+        Some(C::Pass),
+        "a case driven after the stream desynchronised must not report a pass",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The committed driver's own protocol refusals
+// ---------------------------------------------------------------------------
+
+/// The committed driver REFUSES a request that carries no `identity.filename`.
+///
+/// That field is the one filename both compilers must compile under. Defaulting
+/// a missing one to the case id would compile the reference under a name the
+/// request never carried, and every filename-derived difference that followed —
+/// a scoped style's scope id above all — would reach the comparator as a
+/// compiler difference the harness itself manufactured. The refusal is a LINE,
+/// so the probe fails and the driver lives on.
+#[test]
+fn the_committed_driver_refuses_a_request_without_an_identity_filename() {
+    use std::io::{BufRead, Write};
+
+    let script = repository_root()
+        .join("crates")
+        .join("verter_validation_probe")
+        .join("driver")
+        .join("probe-driver.mjs");
+    let mut child = std::process::Command::new("node")
+        .arg(&script)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap_or_else(|error| panic!("the committed driver could not be started: {error}"));
+
+    // The canonical request with `identity.filename` removed. Nothing here
+    // reaches the addon: the refusal happens while the line is being read.
+    let mut request: serde_json::Value =
+        serde_json::from_str(&request::substitute("fixtures/App.vue"))
+            .expect("the canonical request is JSON");
+    request["identity"]
+        .as_object_mut()
+        .expect("the request carries an identity object")
+        .remove("filename");
+    let probe = serde_json::json!({
+        "probe_id": CASE,
+        "entries": [{ "canonicalId": CASE, "source": "<template><div/></template>\n",
+                      "request": request }],
+    });
+    let stdin = child.stdin.as_mut().expect("the driver exposes stdin");
+    writeln!(stdin, "{probe}").expect("the probe is written");
+    stdin.flush().expect("the probe is flushed");
+    drop(child.stdin.take());
+
+    let stdout = child.stdout.take().expect("the driver exposes stdout");
+    let answered: Vec<String> = std::io::BufReader::new(stdout)
+        .lines()
+        .map(|line| line.expect("the driver writes UTF-8 lines"))
+        .collect();
+    let _ = child.wait();
+
+    let line = answered
+        .first()
+        .unwrap_or_else(|| panic!("the driver answered nothing: {answered:?}"));
+    let parsed = parse_line(line).unwrap_or_else(|error| panic!("{line}: {error}"));
+    match parsed {
+        DriverLine::Error { error, .. } => assert!(
+            error.contains("identity.filename"),
+            "the refusal must name the missing field: {error}",
+        ),
+        other => panic!("expected a refusal, got {other:?}"),
+    }
+    assert_eq!(
+        answered.len(),
+        1,
+        "a refused request must not also be compiled: {answered:?}",
     );
 }
 

--- a/crates/verter_validation_probe/tests/cases/lane_contract.rs
+++ b/crates/verter_validation_probe/tests/cases/lane_contract.rs
@@ -13,9 +13,10 @@ use verter_validation_probe::manifest::{Framework, ProbeStateManifest};
 use verter_validation_probe::outcome::{Dimension, NotApplicableReason, ProbeOutcomeClass as C};
 use verter_validation_probe::request;
 use verter_validation_probe::runner::{
-    classify_execution, parse_line, DiagnosticsSnapshot, DriverLine, ExecutionEvent,
-    FrameViolation, Phase, ProbeRun, ReferenceResult, RequestedEntry, RouteDiagnostic, RouteEntry,
-    RouteFailure, RouteNode, RouteProduct, RouteResponse, VirtualNodeKind,
+    self as runner, classify_execution, parse_line, DiagnosticsSnapshot, DriverCommand, DriverLine,
+    ExecutionEvent, FrameViolation, Phase, PhaseDeadlines, PlannedCase, ProbeRun, ReferenceResult,
+    RequestedEntry, RouteDiagnostic, RouteEntry, RouteFailure, RouteNode, RouteProduct,
+    RouteResponse, VirtualNodeKind,
 };
 use verter_validation_probe::summary::{self, FrameworkRun, Lane, ObservedCase, Summary};
 use verter_validation_probe::{Evaluation, Terminal};
@@ -1106,6 +1107,7 @@ fn one_case_summary(manifest: &ProbeStateManifest, lines: Vec<DriverLine>) -> Su
         .expect("the observation is representable");
     let framework_run = FrameworkRun {
         manifest,
+        request_template: request::REQUEST_VUE,
         selected: vec![CASE.to_string()],
         observed: vec![ObservedCase {
             case_id: CASE.to_string(),
@@ -1116,6 +1118,24 @@ fn one_case_summary(manifest: &ProbeStateManifest, lines: Vec<DriverLine>) -> Su
     };
     summary::build(Lane::Smoke, std::slice::from_ref(&framework_run))
         .expect("the summary is consistent")
+}
+
+/// One case that succeeded at every exercised dimension.
+fn passing_summary(manifest: &ProbeStateManifest) -> Summary {
+    one_case_summary(
+        manifest,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![ok_entry(CASE)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+    )
 }
 
 /// The summary carries every required counter, and reports the lane's real
@@ -1164,13 +1184,18 @@ fn the_summary_carries_every_required_counter_and_its_real_work() {
         "a complete summary round-trips",
     );
 
+    // Every required counter is rendered, including `selected`: a job page that
+    // shows only what was attempted cannot be read against what was chosen.
     let markdown = summary.to_markdown();
     for header in [
+        "selected",
         "attempted",
         "passed",
         "gated regressions",
         "canary failures",
         "known failures",
+        "canary regressions",
+        "unrelated regressions",
         "skips",
         "XPASS candidates",
         "crashes",
@@ -1182,6 +1207,167 @@ fn the_summary_carries_every_required_counter_and_its_real_work() {
             "the job summary omits `{header}`"
         );
     }
+}
+
+/// The counters are AUDITED against the cell rows the document carries, not
+/// trusted. A document whose rows hold a gate regression while its counter
+/// claims none would otherwise be read as internally consistent and disposed
+/// clean — a fail-open path to the lane's one real exit.
+#[test]
+fn a_summary_whose_counters_disagree_with_its_cell_rows_is_refused() {
+    let manifest = vue_manifest();
+    let regressed = one_case_summary(
+        &manifest,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![failure_entry(CASE, "host", None)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+    );
+    assert_eq!(regressed.totals.gated_regressions, 1);
+    let json = regressed.to_json();
+
+    // Claim the gate regression away, in both the block and the totals so the
+    // sum still adds up. Only recounting from the rows can catch this.
+    let mut parsed: serde_json::Value = serde_json::from_str(&json).expect("summary is JSON");
+    parsed["totals"]["gated_regressions"] = serde_json::json!(0);
+    parsed["frameworks"][0]["counters"]["gated_regressions"] = serde_json::json!(0);
+    let planted = parsed.to_string();
+    assert_ne!(planted, json, "the plant must change the document");
+    let refused = Summary::from_json_str(&planted)
+        .expect_err("a summary whose counters contradict its rows must be refused");
+    assert!(
+        matches!(
+            refused,
+            verter_validation_probe::SummaryError::CounterMismatch { .. }
+        ),
+        "expected a counter mismatch, got {refused}",
+    );
+
+    // The same for an INVENTED failure the rows do not carry.
+    let mut parsed: serde_json::Value = serde_json::from_str(&json).expect("summary is JSON");
+    parsed["totals"]["crashes"] = serde_json::json!(3);
+    parsed["frameworks"][0]["counters"]["crashes"] = serde_json::json!(3);
+    assert!(
+        Summary::from_json_str(&parsed.to_string()).is_err(),
+        "a summary claiming crashes its rows never recorded must be refused",
+    );
+}
+
+/// A cell row whose terminal and class contradict each other is refused: the
+/// counters are recomputed from those two fields, so an incoherent row would
+/// produce numbers that look honest.
+#[test]
+fn a_cell_row_whose_terminal_and_class_disagree_is_refused() {
+    let manifest = vue_manifest();
+    let summary = passing_summary(&manifest);
+    let json = summary.to_json();
+    let mut parsed: serde_json::Value = serde_json::from_str(&json).expect("summary is JSON");
+    let cell = &mut parsed["frameworks"][0]["cases"][0]["cells"][0];
+    assert_eq!(cell["observed_terminal"], serde_json::json!("class"));
+    cell["observed_terminal"] = serde_json::json!("not_applicable");
+    assert!(
+        Summary::from_json_str(&parsed.to_string()).is_err(),
+        "a row claiming a class it says it has no terminal for must be refused",
+    );
+}
+
+/// A document with no framework block at all has all-zero totals that are
+/// internally consistent, and would dispose CLEAN having reported nothing —
+/// the same fail-open the per-framework empty-selection check closes.
+#[test]
+fn a_summary_with_no_framework_block_is_refused() {
+    let manifest = vue_manifest();
+    let json = passing_summary(&manifest).to_json();
+    let mut parsed: serde_json::Value = serde_json::from_str(&json).expect("summary is JSON");
+    parsed["frameworks"] = serde_json::json!([]);
+    for counter in verter_validation_probe::Counters::REQUIRED {
+        parsed["totals"][counter] = match parsed["totals"][counter] {
+            serde_json::Value::Object(_) => serde_json::json!({}),
+            _ => serde_json::json!(0),
+        };
+    }
+    assert!(
+        Summary::from_json_str(&parsed.to_string()).is_err(),
+        "a summary carrying no framework block must be refused, not disposed clean",
+    );
+}
+
+/// The attempted case set is audited by ID, not by count. A run that observed
+/// one case twice and skipped another has the right count and the wrong work.
+#[test]
+fn a_summary_whose_attempted_ids_are_not_its_selection_is_refused() {
+    let manifest = vue_manifest();
+    let json = passing_summary(&manifest).to_json();
+
+    let mut swapped: serde_json::Value = serde_json::from_str(&json).expect("summary is JSON");
+    swapped["frameworks"][0]["selected_cases"] = serde_json::json!(["vue/fixtures/Other.vue"]);
+    assert!(
+        Summary::from_json_str(&swapped.to_string()).is_err(),
+        "a block whose attempted id is not the one it selected must be refused",
+    );
+
+    let mut miscounted: serde_json::Value = serde_json::from_str(&json).expect("summary is JSON");
+    miscounted["frameworks"][0]["selected_cases"] = serde_json::json!([CASE, CASE]);
+    assert!(
+        Summary::from_json_str(&miscounted.to_string()).is_err(),
+        "a block recording more selected ids than it selected must be refused",
+    );
+}
+
+/// Each framework block carries the request template ITS cases issued. A
+/// builder that read one framework's template from a crate constant would
+/// publish, for every other framework, a request its cases never sent — with a
+/// digest that agreed with itself.
+#[test]
+fn each_framework_block_carries_its_own_request_template() {
+    const OTHER: &str = r#"{"framework":"svelte"}"#;
+    let manifest = svelte_manifest();
+    let mut run = ProbeRun::new(SVELTE_CASE, requested(SVELTE_CASE));
+    let _ = run.ingest_frame(phase(SVELTE_CASE, Phase::Compile));
+    let _ = run.ingest_frame(compile_frame(SVELTE_CASE, vec![ok_entry(SVELTE_CASE)]));
+    let _ = run.ingest_frame(phase(SVELTE_CASE, Phase::Reference));
+    let _ = run.ingest_frame(reference_frame(
+        SVELTE_CASE,
+        vec![ReferenceResult::Inapplicable {
+            inapplicable: "svelte".to_string(),
+        }],
+    ));
+    let observation = run
+        .finish(&manifest, None)
+        .remove(0)
+        .expect("the observation is representable");
+    let framework_run = FrameworkRun {
+        manifest: &manifest,
+        request_template: OTHER,
+        selected: vec![SVELTE_CASE.to_string()],
+        observed: vec![ObservedCase {
+            case_id: SVELTE_CASE.to_string(),
+            request_digest: String::new(),
+            elapsed_ns: Some(1),
+            observation,
+        }],
+    };
+    let summary = summary::build(Lane::Smoke, std::slice::from_ref(&framework_run))
+        .expect("the summary is consistent");
+    let block = &summary.frameworks[0];
+    assert_eq!(block.request_template, OTHER);
+    assert_eq!(
+        block.template_digest,
+        request::sha256_hex(OTHER.as_bytes()),
+        "the digest must be of the template the block carries",
+    );
+    assert_ne!(
+        block.template_digest,
+        request::template_digest(),
+        "a block must not publish another framework's template digest",
+    );
 }
 
 /// A summary missing a counter is REFUSED, not read as an honest zero. Without
@@ -1205,21 +1391,32 @@ fn a_summary_missing_a_counter_is_refused_rather_than_read_as_zero() {
         ],
     );
     let json = summary.to_json();
-    for counter in verter_validation_probe::Counters::REQUIRED {
-        let mut parsed: serde_json::Value = serde_json::from_str(&json).expect("summary is JSON");
-        parsed["totals"]
-            .as_object_mut()
-            .expect("totals is an object")
-            .remove(counter);
-        let planted = parsed.to_string();
-        assert!(
-            planted != json,
-            "the plant for `{counter}` must actually change the document",
-        );
-        assert!(
-            Summary::from_json_str(&planted).is_err(),
-            "a summary missing `{counter}` must be refused",
-        );
+    // BOTH counter blocks: the totals a reader sees first, and the per-framework
+    // block they are the sum of. A presence check on one of them would let the
+    // other omit a counter and read as zero.
+    for pointer in ["totals", "frameworks"] {
+        for counter in verter_validation_probe::Counters::REQUIRED {
+            let mut parsed: serde_json::Value =
+                serde_json::from_str(&json).expect("summary is JSON");
+            let counters = if pointer == "totals" {
+                &mut parsed["totals"]
+            } else {
+                &mut parsed["frameworks"][0]["counters"]
+            };
+            counters
+                .as_object_mut()
+                .expect("a counter block is an object")
+                .remove(counter);
+            let planted = parsed.to_string();
+            assert!(
+                planted != json,
+                "the plant for `{pointer}.{counter}` must actually change the document",
+            );
+            assert!(
+                Summary::from_json_str(&planted).is_err(),
+                "a summary missing `{pointer}.{counter}` must be refused",
+            );
+        }
     }
 }
 
@@ -1295,12 +1492,13 @@ fn a_summary_whose_attempted_set_differs_from_its_selection_is_refused() {
 
     let under = FrameworkRun {
         manifest: &manifest,
+        request_template: request::REQUEST_VUE,
         selected: vec![CASE.to_string(), "vue/fixtures/Other.vue".to_string()],
         observed: vec![ObservedCase {
             case_id: CASE.to_string(),
             request_digest: String::new(),
             elapsed_ns: None,
-            observation,
+            observation: observation.clone(),
         }],
     };
     assert!(
@@ -1308,8 +1506,33 @@ fn a_summary_whose_attempted_set_differs_from_its_selection_is_refused() {
         "a lane that attempted fewer cases than it selected must be refused",
     );
 
+    let over = FrameworkRun {
+        manifest: &manifest,
+        request_template: request::REQUEST_VUE,
+        selected: vec![CASE.to_string()],
+        observed: vec![
+            ObservedCase {
+                case_id: CASE.to_string(),
+                request_digest: String::new(),
+                elapsed_ns: None,
+                observation: observation.clone(),
+            },
+            ObservedCase {
+                case_id: CASE.to_string(),
+                request_digest: String::new(),
+                elapsed_ns: None,
+                observation: observation.clone(),
+            },
+        ],
+    };
+    assert!(
+        summary::build(Lane::Smoke, std::slice::from_ref(&over)).is_err(),
+        "a lane that attempted more cases than it selected must be refused",
+    );
+
     let empty = FrameworkRun {
         manifest: &manifest,
+        request_template: request::REQUEST_VUE,
         selected: Vec::new(),
         observed: Vec::new(),
     };
@@ -1322,6 +1545,22 @@ fn a_summary_whose_attempted_set_differs_from_its_selection_is_refused() {
 // ---------------------------------------------------------------------------
 // The committed manifest
 // ---------------------------------------------------------------------------
+
+fn workflow_text() -> String {
+    let path = repository_root()
+        .join(".github")
+        .join("workflows")
+        .join("validation-probe.yml");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("reading {}: {e}", path.display()))
+}
+
+fn repository_root() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|crates| crates.parent())
+        .expect("the crate lives at <root>/crates/verter_validation_probe")
+        .to_path_buf()
+}
 
 fn committed_vue_manifest_text() -> String {
     let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -1421,15 +1660,7 @@ fn only_the_implemented_route_authority_gates() {
 /// there is no per-fixture job or per-fixture test definition.
 #[test]
 fn the_workflow_declares_exactly_one_probe_job() {
-    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(|crates| crates.parent())
-        .expect("the crate lives at <root>/crates/verter_validation_probe")
-        .join(".github")
-        .join("workflows")
-        .join("validation-probe.yml");
-    let text = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+    let text = workflow_text();
 
     let mut in_jobs = false;
     let mut jobs = Vec::new();
@@ -1473,6 +1704,118 @@ fn the_workflow_declares_exactly_one_probe_job() {
         upload < dispose && markdown < dispose,
         "the disposition must run after the artifact and the rendered summary are published",
     );
+
+    // Ordering alone is not the guarantee. A publication step that GitHub skips
+    // because an earlier step failed publishes nothing, so the run that goes red
+    // would be exactly the run with no evidence. Each of the three must be
+    // declared to run regardless.
+    for step in ["upload-artifact", "--markdown", "--dispose"] {
+        let at = steps.find(step).expect("the step is declared");
+        let preceding = &steps[..at];
+        let boundary = preceding
+            .rfind("      - name:")
+            .expect("every step carries a name");
+        assert!(
+            preceding[boundary..].contains("if: always()"),
+            "the `{step}` step must run even after a failing probe step, or the red run \
+             loses the evidence it was red about",
+        );
+    }
+}
+
+/// The pinned revision is recorded twice — once for the checkout the workflow
+/// performs, once in the manifest every artifact republishes. They must be the
+/// SAME commit: a workflow bumped to a revision whose fixture set still matches
+/// the inventory would stay green while every artifact recorded a revision its
+/// cases did not come from.
+#[test]
+fn the_workflow_and_the_manifest_pin_the_same_revision() {
+    let text = workflow_text();
+    let pinned = text
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("VUE_BENCHMARKS_REVISION:"))
+        .map(str::trim)
+        .expect("the workflow pins a corpus revision");
+    let manifest =
+        ProbeStateManifest::from_manifest_file("vue.toml", &committed_vue_manifest_text())
+            .expect("the committed vue manifest is valid");
+    assert_eq!(
+        pinned,
+        manifest.external_revision.as_str(),
+        "the workflow checks out `{pinned}` while the manifest pins `{}`",
+        manifest.external_revision.as_str(),
+    );
+}
+
+/// The disposition is a real PROCESS exit, not a number a caller may ignore.
+///
+/// The binary is run as the workflow's final step runs it, over planted
+/// artifacts: a clean one exits 0, a regressed one exits non-zero, and a
+/// malformed one is refused rather than read as a lane with nothing to report.
+#[test]
+fn the_summary_binary_disposes_as_a_process() {
+    let manifest = vue_manifest();
+    let clean = passing_summary(&manifest).to_json();
+    let regressed = one_case_summary(
+        &manifest,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![failure_entry(CASE, "host", None)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+    )
+    .to_json();
+    let mut parsed: serde_json::Value = serde_json::from_str(&clean).expect("the summary is JSON");
+    parsed["totals"]
+        .as_object_mut()
+        .expect("totals is an object")
+        .remove("gated_regressions");
+    let incomplete = parsed.to_string();
+
+    for (label, document, expected) in [
+        ("a clean summary", clean, Some(0)),
+        ("a gate regression", regressed, Some(1)),
+        ("a summary missing a counter", incomplete, Some(2)),
+    ] {
+        let path = temp_file(&format!("dispose-{}", label.replace(' ', "-")), &document);
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_validation-probe-summary"))
+            .args(["--dispose", "--summary"])
+            .arg(&path)
+            .output()
+            .expect("the summary binary runs");
+        assert_eq!(
+            output.status.code(),
+            expected,
+            "{label} disposed {:?}; stderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+/// Write `contents` to a uniquely named file under the platform's temp
+/// directory. Never a literal path: the lane builds every path from the
+/// standard abstractions so it runs the same on every platform.
+///
+/// The unique part comes BEFORE the label so a label ending in an extension
+/// keeps it — node dispatches on the extension, and a `.mjs` buried mid-name is
+/// not a module.
+fn temp_file(label: &str, contents: &str) -> std::path::PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("the clock is after the epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("verter-probe-{unique}-{label}"));
+    std::fs::write(&path, contents)
+        .unwrap_or_else(|error| panic!("writing {}: {error}", path.display()));
+    path
 }
 
 /// A `not_run` cell never counts as a pass, and a skip never counts as work.
@@ -1502,4 +1845,402 @@ fn unreached_and_skipped_cells_are_never_counted_as_passes() {
         .expect("the performance cell is present");
     assert_eq!(performance.evaluation, Evaluation::NotRun);
     assert_eq!(performance.observed_class, None);
+}
+
+// ---------------------------------------------------------------------------
+// Comparison inputs
+// ---------------------------------------------------------------------------
+
+/// A WARNING-severity diagnostic is not a structural difference.
+///
+/// The reference producer reports only errors, so its diagnostics channel is
+/// empty for every module it produced. Comparing Verter's warnings against that
+/// side would report a difference the harness created by discarding the other
+/// compiler's warnings — and would report it on exactly the cases whose
+/// products match, holding each of them back from surfacing as a promotion
+/// candidate.
+#[test]
+fn a_warning_severity_diagnostic_is_not_a_structural_difference() {
+    let manifest = vue_manifest();
+    let mut warned = ok_entry(CASE);
+    warned
+        .response
+        .as_mut()
+        .expect("the entry carries a response")
+        .diagnostics
+        .diagnostics
+        .push(RouteDiagnostic {
+            severity: "warning".to_string(),
+            code: "W1".to_string(),
+            message: "a template hint".to_string(),
+        });
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![warned]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+        None,
+    );
+    assert_eq!(class_at(&terminals, Dimension::Compile), Some(C::Pass));
+    assert_eq!(
+        class_at(&terminals, Dimension::Structural),
+        Some(C::Pass),
+        "identical modules must compare equal despite a warning the reference \
+         compiler's warnings were never captured to match: {:?}",
+        terminals[&Dimension::Structural],
+    );
+
+    // An ERROR the reference did not report is still a real difference — the
+    // restriction drops the uncaptured channel, not the signal.
+    let mut errored = ok_entry(CASE);
+    errored
+        .response
+        .as_mut()
+        .expect("the entry carries a response")
+        .diagnostics
+        .diagnostics
+        .push(RouteDiagnostic {
+            severity: "error".to_string(),
+            code: "E1".to_string(),
+            message: "boom".to_string(),
+        });
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![errored]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+        None,
+    );
+    assert_eq!(
+        class_at(&terminals, Dimension::Compile),
+        Some(C::VerterDiagnostic)
+    );
+    assert_eq!(
+        class_at(&terminals, Dimension::Structural),
+        Some(C::SemanticMismatch),
+        "an error Verter reported and the reference did not is a real difference",
+    );
+}
+
+/// An entry carrying BOTH arms fails closed. The route answers exactly one of
+/// them; an envelope saying two contradictory things is as unexplained as one
+/// saying nothing, and preferring either arm would be the runner inventing an
+/// answer.
+#[test]
+fn a_route_entry_carrying_both_arms_fails_closed() {
+    let manifest = vue_manifest();
+    let mut both = ok_entry(CASE);
+    both.failure = Some(RouteFailure {
+        kind: "host".to_string(),
+        message: "refused".to_string(),
+        diagnostics: DiagnosticsSnapshot::default(),
+    });
+    let terminals = observe(
+        &manifest,
+        CASE,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![both]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+        None,
+    );
+    assert_eq!(
+        class_at(&terminals, Dimension::Route),
+        Some(C::HarnessFailure),
+    );
+}
+
+/// A line naming ANOTHER probe is refused rather than believed.
+///
+/// The protocol is one probe at a time, so such a line means the stream and the
+/// runner are out of step. Believing it would attach one case's product,
+/// reference or failure to another case — and the taxonomy's whole promise is
+/// that evidence describes the case it is filed under.
+#[test]
+fn a_line_naming_another_probe_is_refused() {
+    let mut run = ProbeRun::new(CASE, requested(CASE));
+    assert_eq!(
+        run.ingest_frame(compile_frame(
+            "vue/fixtures/Other.vue",
+            vec![ok_entry(CASE)]
+        )),
+        Err(FrameViolation::UnknownProbe {
+            probe_id: "vue/fixtures/Other.vue".to_string(),
+        }),
+    );
+    assert!(
+        !run.has_compile_frame(),
+        "a frame for another probe must not be retained",
+    );
+    assert_eq!(
+        run.ingest_frame(DriverLine::Error {
+            probe_id: Some("vue/fixtures/Other.vue".to_string()),
+            error: "another probe's failure".to_string(),
+        }),
+        Err(FrameViolation::UnknownProbe {
+            probe_id: "vue/fixtures/Other.vue".to_string(),
+        }),
+    );
+    // An error the driver could not attribute belongs to the probe the runner is
+    // waiting on, and is accepted.
+    assert_eq!(
+        run.ingest_frame(DriverLine::Error {
+            probe_id: None,
+            error: "a line the driver could not parse".to_string(),
+        }),
+        Ok(()),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Driving a real driver process
+// ---------------------------------------------------------------------------
+
+/// The header every synthetic driver shares: read one probe per line, answer on
+/// stdout, and never exit on a failure.
+const SYNTHETIC_DRIVER_PRELUDE: &str = r#"
+import { createInterface } from "node:readline";
+const write = (line) => process.stdout.write(`${JSON.stringify(line)}\n`);
+const product = (canonicalId) => ({
+  canonicalId,
+  response: {
+    diagnostics: { diagnostics: [] },
+    products: [
+      {
+        kind: "runtimeClient",
+        nodes: [{ node: { kind: "main" }, code: "export const value = 1\n" }],
+      },
+    ],
+  },
+  failure: null,
+});
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
+let seen = 0;
+for await (const line of lines) {
+  if (line.trim() === "") continue;
+  const probe = JSON.parse(line);
+  const id = probe.probe_id;
+  const canonicalId = probe.entries[0].canonicalId;
+  seen += 1;
+"#;
+
+const SYNTHETIC_DRIVER_EPILOGUE: &str = "\n}\n";
+
+fn synthetic_driver(label: &str, body: &str) -> (std::path::PathBuf, DriverCommand) {
+    let script = temp_file(
+        &format!("{label}.mjs"),
+        &format!("{SYNTHETIC_DRIVER_PRELUDE}{body}{SYNTHETIC_DRIVER_EPILOGUE}"),
+    );
+    let command = DriverCommand {
+        program: std::path::PathBuf::from("node"),
+        script: script.clone(),
+    };
+    (script, command)
+}
+
+fn planned(case_id: &str) -> PlannedCase {
+    PlannedCase {
+        case_id: case_id.to_string(),
+        relative_path: "fixtures/App.vue".to_string(),
+        source: "<template><div/></template>\n".to_string(),
+    }
+}
+
+fn generous(compile: std::time::Duration) -> PhaseDeadlines {
+    PhaseDeadlines {
+        load: std::time::Duration::from_secs(30),
+        compile,
+        reference: std::time::Duration::from_secs(30),
+    }
+}
+
+/// A per-probe driver ERROR ends that probe, and the lane keeps running.
+///
+/// The driver reports a recoverable failure as a LINE precisely so the runner
+/// can move on, and then waits for the next probe. A runner that kept waiting
+/// for a frame that will never come would spend the whole deadline, kill a
+/// healthy driver, and record every remaining case as a harness failure: one
+/// recoverable JavaScript throw would cost the entire lane.
+#[test]
+fn a_per_probe_driver_error_ends_that_probe_and_the_lane_keeps_running() {
+    let manifest = vue_manifest();
+    let (script, driver) = synthetic_driver(
+        "driver-error",
+        r#"
+  write({ probe_id: id, phase: "load" });
+  write({ probe_id: id, phase: "compile" });
+  if (seen === 1) {
+    write({ probe_id: id, error: "planted failure", phase: "compile", stage: "native" });
+    continue;
+  }
+  write({ probe_id: id, frame: "compile", elapsed_ns: 1, entries: [product(canonicalId)] });
+  write({ probe_id: id, phase: "reference" });
+  write({ probe_id: id, frame: "reference", reference: [{ code: "export const value = 1\n" }] });
+"#,
+    );
+    let cases = [planned(CASE), planned(CASE)];
+    let results = runner::run_cases(
+        &manifest,
+        &driver,
+        &cases,
+        generous(std::time::Duration::from_secs(30)),
+    )
+    .unwrap_or_else(|error| panic!("the synthetic driver could not be run: {error}"));
+    let _ = std::fs::remove_file(&script);
+
+    assert_eq!(results.len(), 2);
+    let first = results[0]
+        .observation
+        .as_ref()
+        .expect("the observation is representable");
+    assert_eq!(
+        first.terminal(Dimension::Route).class(),
+        Some(C::HarnessFailure),
+        "the probe the driver reported a failure for is that probe's harness failure",
+    );
+    let second = results[1]
+        .observation
+        .as_ref()
+        .expect("the observation is representable");
+    assert_eq!(
+        second.terminal(Dimension::Compile).class(),
+        Some(C::Pass),
+        "the lane must keep running after a per-probe failure: {:?}",
+        second.terminal(Dimension::Route),
+    );
+    assert_eq!(
+        second.terminal(Dimension::Structural).class(),
+        Some(C::Pass)
+    );
+}
+
+/// A pause after the compile frame but BEFORE the reference phase marker is
+/// bounded by the reference deadline, not the compile one.
+///
+/// The compile frame is the native call's answer; what remains is reference
+/// work. A runner that left the compile deadline armed would report a reference
+/// producer that was merely slow as a COMPILER timeout — a verdict about Verter
+/// drawn from a step Verter had already finished.
+#[test]
+fn a_pause_after_the_compile_frame_is_not_a_compiler_timeout() {
+    let manifest = vue_manifest();
+    let (script, driver) = synthetic_driver(
+        "driver-slow-reference",
+        r#"
+  write({ probe_id: id, phase: "load" });
+  write({ probe_id: id, phase: "compile" });
+  write({ probe_id: id, frame: "compile", elapsed_ns: 1, entries: [product(canonicalId)] });
+  await sleep(900);
+  write({ probe_id: id, phase: "reference" });
+  write({ probe_id: id, frame: "reference", reference: [{ code: "export const value = 1\n" }] });
+"#,
+    );
+    let cases = [planned(CASE)];
+    let results = runner::run_cases(
+        &manifest,
+        &driver,
+        &cases,
+        generous(std::time::Duration::from_millis(200)),
+    )
+    .unwrap_or_else(|error| panic!("the synthetic driver could not be run: {error}"));
+    let _ = std::fs::remove_file(&script);
+
+    let observation = results[0]
+        .observation
+        .as_ref()
+        .expect("the observation is representable");
+    assert_eq!(
+        observation.terminal(Dimension::Compile).class(),
+        Some(C::Pass),
+    );
+    assert_eq!(
+        observation.terminal(Dimension::Structural).class(),
+        Some(C::Pass),
+        "a pause before the reference marker must not be read as a compiler timeout: {:?}",
+        observation.terminal(Dimension::Structural),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gate cells that never ran
+// ---------------------------------------------------------------------------
+
+/// A gate cell whose dimension was NEVER REACHED is a gate regression, and
+/// disposes non-zero.
+///
+/// Not-run is not an outcome class: it can neither meet an expectation nor be
+/// expected by one. A gate reading it as anything but a regression would let a
+/// dimension that was never exercised stand in for one that passed.
+///
+/// The manifest here is built directly because `validate` refuses a gate outside
+/// `Route`, and `Route` is fed by nothing so it can never be unreached. The
+/// evaluation is the same one a future promoted gate would take.
+#[test]
+fn a_gate_cell_whose_dimension_was_never_reached_disposes_non_zero() {
+    let mut manifest = vue_manifest();
+    for entry in &mut manifest.entries {
+        if entry.dimension == Dimension::Performance {
+            entry.expected_state = verter_validation_probe::ExpectedState::Gate;
+            entry.expected_class = Some(C::Pass);
+            entry.authority = Some(verter_validation_probe::Authority::CompilerPublicRequestRoute);
+            entry.atom = Some("route-callable".to_string());
+        }
+    }
+    // A host failure at Route leaves Performance unreached.
+    let summary = one_case_summary(
+        &manifest,
+        vec![
+            phase(CASE, Phase::Compile),
+            compile_frame(CASE, vec![failure_entry(CASE, "host", None)]),
+            phase(CASE, Phase::Reference),
+            reference_frame(
+                CASE,
+                vec![ReferenceResult::Produced {
+                    code: MODULE.to_string(),
+                }],
+            ),
+        ],
+    );
+    let performance = summary.frameworks[0].cases[0]
+        .cells
+        .iter()
+        .find(|cell| cell.dimension == Dimension::Performance)
+        .expect("the performance cell is present");
+    assert_eq!(performance.observed_class, None);
+    assert_eq!(
+        performance.observed_terminal,
+        verter_validation_probe::ObservedTerminal::NotRun
+    );
+    assert_eq!(performance.evaluation, Evaluation::GateRegression);
+    assert_ne!(
+        summary.disposition().exit_code(),
+        0,
+        "a gate that never ran must fail the lane",
+    );
 }

--- a/crates/verter_validation_probe/tests/cases/workload_lane.rs
+++ b/crates/verter_validation_probe/tests/cases/workload_lane.rs
@@ -1,0 +1,85 @@
+//! The workload lane against the pinned external corpus.
+//!
+//! Gated behind `external-corpus` in its entirety: the canonical hermetic run
+//! neither reads nor requires the checkout. Only the dedicated probe workflow
+//! provisions it and enables this feature.
+//!
+//! The lane is ONE table-driven test per lane, never one per fixture: which
+//! cases run, what they are expected to do, and who owns that expectation are
+//! all manifest data.
+#![cfg(feature = "external-corpus")]
+
+use verter_validation_probe::lane;
+use verter_validation_probe::runner::PhaseDeadlines;
+use verter_validation_probe::summary::Lane;
+
+/// Which lane this run drives. The workflow's smoke job leaves it unset; the
+/// main job sets it to `main`.
+fn lane_from_env() -> Lane {
+    match std::env::var("VALIDATION_PROBE_LANE").as_deref() {
+        Ok("main") => Lane::Main,
+        _ => Lane::Smoke,
+    }
+}
+
+/// Drive the selected lane, publish the summary artifact, and fail on a gate
+/// regression.
+///
+/// The test asserts the lane's OWN disposition, which is the same one
+/// `validation-probe-summary --dispose` computes from the published artifact.
+/// Both must agree, and both are computed from gate cells alone: a canary or
+/// known-fail never blocks here either.
+#[test]
+fn workload_lane_runs_the_pinned_slice_and_publishes_its_summary() {
+    let lane = lane_from_env();
+    let summary = match lane::run(lane, PhaseDeadlines::default()) {
+        Ok(summary) => summary,
+        Err(error) => panic!("the validation probe lane could not run: {error}"),
+    };
+    let path = lane::write_summary(&summary).expect("the summary artifact is writable");
+
+    // Non-zero work, proven from the document rather than from this test's own
+    // idea of what it selected.
+    let vue = summary
+        .frameworks
+        .iter()
+        .find(|block| block.framework == verter_validation_probe::Framework::Vue)
+        .expect("the lane drove the vue framework");
+    assert!(
+        vue.counters.selected > 0,
+        "the lane selected no case; {} would otherwise be a green summary of nothing",
+        path.display(),
+    );
+    assert_eq!(
+        vue.counters.attempted, vue.counters.selected,
+        "the lane attempted {} of {} selected cases",
+        vue.counters.attempted, vue.counters.selected,
+    );
+    if lane == Lane::Smoke {
+        assert!(
+            vue.counters.selected <= verter_validation_probe::MAX_SMOKE_CASES,
+            "the smoke slice drove {} cases",
+            vue.counters.selected,
+        );
+    }
+
+    // Determinism: the same slice, re-planned, is the same case set in the
+    // same order. A slice that shuffled between runs would make every
+    // comparison of two summaries meaningless.
+    let manifest = lane::load_manifest(verter_validation_probe::Framework::Vue)
+        .expect("the manifest is valid");
+    assert_eq!(
+        lane::selection(&manifest, lane),
+        lane::selection(&manifest, lane),
+        "the selection is not deterministic",
+    );
+
+    let disposition = summary.disposition();
+    assert_eq!(
+        disposition,
+        verter_validation_probe::Disposition::Clean,
+        "the lane reported {} gate regression(s); see {}",
+        summary.totals.gated_regressions,
+        path.display(),
+    );
+}

--- a/crates/verter_validation_probe/tests/cases/workload_lane.rs
+++ b/crates/verter_validation_probe/tests/cases/workload_lane.rs
@@ -10,7 +10,8 @@
 #![cfg(feature = "external-corpus")]
 
 use verter_validation_probe::lane;
-use verter_validation_probe::runner::PhaseDeadlines;
+use verter_validation_probe::outcome::{Dimension, ProbeOutcomeClass};
+use verter_validation_probe::runner::{self, DriverCommand, PhaseDeadlines, PlannedCase};
 use verter_validation_probe::summary::Lane;
 
 /// Which lane this run drives. The workflow's smoke job leaves it unset; the
@@ -81,5 +82,72 @@ fn workload_lane_runs_the_pinned_slice_and_publishes_its_summary() {
         "the lane reported {} gate regression(s); see {}",
         summary.totals.gated_regressions,
         path.display(),
+    );
+}
+
+/// A CONSTRUCTED, supported single-file component reaches a `runtimeClient`
+/// product through the real addon.
+///
+/// The corpus cases already exercise the route, but their outcomes depend on
+/// what the upstream project happens to contain. This one does not: the source
+/// is written here and is unambiguously supported, so the only ways it can
+/// fail are the ones worth knowing about — the driver never reaching the
+/// compiler at all (a `binding` or `host` failure, a spawn failure, an addon
+/// that will not load). Without it, a lane whose driver silently stopped
+/// calling the addon could still look like a lane of known failures.
+#[test]
+fn a_constructed_supported_component_reaches_a_runtime_client_product() {
+    let manifest = lane::load_manifest(verter_validation_probe::Framework::Vue)
+        .expect("the manifest is valid");
+    // Any inventoried case id will do as the carrier identity; what is
+    // compiled is the source written here, which the driver never re-reads
+    // from the corpus.
+    let case_id = manifest
+        .smoke
+        .first()
+        .expect("the smoke slice is non-empty")
+        .clone();
+    let relative_path = case_id
+        .strip_prefix("vue/")
+        .expect("a vue case id")
+        .to_string();
+
+    let planned = PlannedCase {
+        case_id: case_id.clone(),
+        relative_path,
+        source: concat!(
+            "<template>\n  <p :class=\"tone\">{{ label }}</p>\n</template>\n\n",
+            "<script setup>\nconst label = 'probe'\nconst tone = 'plain'\n</script>\n",
+        )
+        .to_string(),
+    };
+
+    let driver = DriverCommand::committed(&verter_validation_probe::corpus::workspace_root());
+    let results = runner::run_cases(
+        &manifest,
+        &driver,
+        std::slice::from_ref(&planned),
+        PhaseDeadlines::default(),
+    )
+    .unwrap_or_else(|error| panic!("the driver could not be run: {error}"));
+
+    let observation = results
+        .into_iter()
+        .next()
+        .expect("one planned case yields one result")
+        .observation
+        .unwrap_or_else(|error| panic!("the observation is representable: {error}"));
+
+    assert_eq!(
+        observation.terminal(Dimension::Route).class(),
+        Some(ProbeOutcomeClass::Pass),
+        "the public route did not answer a supported component: {:?}",
+        observation.terminal(Dimension::Route),
+    );
+    assert_eq!(
+        observation.terminal(Dimension::Compile).class(),
+        Some(ProbeOutcomeClass::Pass),
+        "a supported component did not reach a valid runtimeClient product: {:?}",
+        observation.terminal(Dimension::Compile),
     );
 }

--- a/crates/verter_validation_probe/tests/cases/workload_lane.rs
+++ b/crates/verter_validation_probe/tests/cases/workload_lane.rs
@@ -64,15 +64,28 @@ fn workload_lane_runs_the_pinned_slice_and_publishes_its_summary() {
         );
     }
 
-    // Determinism: the same slice, re-planned, is the same case set in the
-    // same order. A slice that shuffled between runs would make every
-    // comparison of two summaries meaningless.
+    // Determinism: the slice is re-DERIVED from an independently loaded
+    // manifest and must be the same case set in the same order, and the same
+    // one the summary actually recorded. A slice that shuffled between runs
+    // would make every comparison of two summaries meaningless. (Comparing one
+    // `selection` call against another would prove nothing: it clones a field.)
     let manifest = lane::load_manifest(verter_validation_probe::Framework::Vue)
         .expect("the manifest is valid");
+    let reloaded = lane::load_manifest(verter_validation_probe::Framework::Vue)
+        .expect("the manifest is valid");
     assert_eq!(
-        lane::selection(&manifest, lane),
-        lane::selection(&manifest, lane),
-        "the selection is not deterministic",
+        manifest.derived_smoke_slice(),
+        reloaded.derived_smoke_slice(),
+        "the smoke derivation is not deterministic",
+    );
+    let replanned: Vec<String> = lane::plan(&lane::selection(&reloaded, lane))
+        .expect("the selection is loadable")
+        .into_iter()
+        .map(|case| case.case_id)
+        .collect();
+    assert_eq!(
+        replanned, vue.selected_cases,
+        "re-planning the lane selected a different case set than the summary recorded",
     );
 
     let disposition = summary.disposition();
@@ -150,4 +163,95 @@ fn a_constructed_supported_component_reaches_a_runtime_client_product() {
         "a supported component did not reach a valid runtimeClient product: {:?}",
         observation.terminal(Dimension::Compile),
     );
+}
+
+/// A ZERO-SELECTION manifest fails the lane through the workflow's own entry
+/// point rather than publishing a green summary of nothing.
+///
+/// The refusal is driven over a PLANTED manifest directory, not the committed
+/// one: a lane whose re-scoping refusal could only be exercised by editing the
+/// file it ships is a refusal nobody can test without breaking the lane.
+#[test]
+fn a_planted_zero_selection_manifest_fails_the_lane() {
+    let committed = lane::manifest_dir().join("vue.toml");
+    let text = std::fs::read_to_string(&committed)
+        .unwrap_or_else(|error| panic!("reading {}: {error}", committed.display()));
+    let manifest = lane::load_manifest(verter_validation_probe::Framework::Vue)
+        .expect("the committed manifest is valid");
+
+    // Empty the slice, and prove the plant applied: a mutation that silently
+    // did not match would leave the committed manifest under test and report a
+    // pass.
+    assert!(
+        !manifest.smoke.is_empty(),
+        "the committed slice is already empty, so emptying it proves nothing",
+    );
+    assert!(
+        !text.contains("\nsmoke = []"),
+        "the committed manifest already carries the planted slice",
+    );
+    let planted = plant_smoke(&text, "smoke = []");
+    assert_ne!(planted, text, "the plant did not change the manifest");
+    assert!(
+        planted.contains("\nsmoke = []"),
+        "the plant did not empty the smoke slice",
+    );
+
+    let dir = planted_manifest_dir("zero-selection", &planted);
+    let error = lane::run_with_manifest_dir(Lane::Smoke, PhaseDeadlines::default(), &dir)
+        .err()
+        .unwrap_or_else(|| panic!("a zero-selection manifest must fail the lane, not run it"));
+    assert!(
+        error
+            .to_string()
+            .contains("the smoke slice selects no case"),
+        "the lane refused for the wrong reason: {error}",
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Replace the manifest's whole `smoke = [...]` array.
+fn plant_smoke(text: &str, replacement: &str) -> String {
+    let start = text
+        .find("\nsmoke = [")
+        .expect("the manifest lists a smoke slice")
+        + 1;
+    let end = start + text[start..].find(']').expect("the array is closed") + 1;
+    format!("{}{replacement}{}", &text[..start], &text[end..])
+}
+
+/// Write one manifest into a fresh directory under the platform's temp
+/// directory, named as the loader requires.
+fn planted_manifest_dir(label: &str, vue: &str) -> std::path::PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("the clock is after the epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("verter-probe-manifest-{unique}-{label}"));
+    std::fs::create_dir_all(&dir)
+        .unwrap_or_else(|error| panic!("creating {}: {error}", dir.display()));
+    std::fs::write(dir.join("vue.toml"), vue)
+        .unwrap_or_else(|error| panic!("writing {}: {error}", dir.display()));
+    dir
+}
+
+/// The checkout is AT the commit the manifest pins, read from its own Git
+/// state.
+///
+/// The pin is recorded in the manifest and in the workflow, and every summary
+/// republishes it; none of that is evidence about the bytes the lane compiled.
+/// A checkout pointed elsewhere whose fixture set still matched the inventory
+/// would publish a revision its cases did not come from.
+#[test]
+fn the_checkout_is_at_the_pinned_revision() {
+    let manifest = lane::load_manifest(verter_validation_probe::Framework::Vue)
+        .expect("the manifest is valid");
+    let checked_out = verter_validation_probe::corpus::vue_benchmarks::checkout_revision()
+        .unwrap_or_else(|error| panic!("{error}"));
+    assert_eq!(
+        checked_out,
+        manifest.external_revision.as_str(),
+        "the checkout is at a different commit than the manifest pins",
+    );
+    lane::check_revision(&manifest).unwrap_or_else(|error| panic!("{error}"));
 }

--- a/crates/verter_validation_probe/tests/main.rs
+++ b/crates/verter_validation_probe/tests/main.rs
@@ -2,4 +2,6 @@
 
 mod cases {
     mod contract;
+    mod lane_contract;
+    mod workload_lane;
 }

--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -167,7 +167,7 @@ schema = 2
 "CPF0" = { status = "pending" }
 "CPF1" = { status = "pending" }
 "CVO0" = { status = "implemented", commit_message = "feat(*): add the validation-probe outcome taxonomy and probe-state manifest contract", commit_date = "2026-09-11T08:30:00+01:00", pull_request = 525 }
-"CVO1" = { status = "pending" }
+"CVO1" = { status = "implemented", commit_message = "feat(*): add the pinned vue-benchmarks external workload probe lane", commit_date = "2026-09-12T11:30:00+01:00" }
 "CVO1S" = { status = "pending" }
 "CVO2" = { status = "pending" }
 "CVO3" = { status = "pending" }


### PR DESCRIPTION
Readiness comes only from trusted implementation-ledger rows. A READY node may start; tooling does not validate commit locators, Git identity, receipts, leases, external state, or runtime admission.

A bounded real-workload CI lane that exercises Verter against one pinned `pikax/vue-benchmarks` revision through normal/public compiler request routes, classifies every case with the CVO0 taxonomy, and emits one compact machine-readable summary. The current owner is **no continuous external workload evidence**. The final and sole owner is **the table-driven workload probe lane and its probe-state manifest**. This charter accepts one boundary; it contains no independently dispatchable subblocks.

### Scope

- Production surfaces: none; the runner and manifest are test/CI tooling.
- Named API/data boundaries: the workload runner (`crates/verter_validation_probe/src/runner.rs`, table/data driven, no one-test-per-fixture jobs) bound to the public NAPI batch route `compileRequests` on the exported host object (`crates/verter_napi/src/lib.rs`, owned by CCA1O2J; the single route `compileRequest` is not used, so exactly one carrier shape exists) and to no other entry point — each case issues exactly one canonical `HostCompileRequest` on the `vue` arm, `{ framework: "vue", identity: { filename: "<case relative path>", componentId: null, isProduction: false, forceJs: false }, products: [{ kind: "runtimeClient", inline: null, runtimeSourceMap: false }], options: { backend: "vdom", ssr: false, isCustomElement: [], babelParserPlugins: [] } }` — every optional option field intentionally omitted so the host's own defaults apply (matching the reference's `dev`, non-SSR, VDOM compile), the immutable template — with `identity.filename` holding the literal placeholder `"<case relative path>"` — recorded verbatim as `request_vue` with its SHA-256 `template_digest` in the summary and in every observation artifact header, the one substitution rule being `identity.filename = case_id` with the `vue/` prefix stripped, and every summary row and observation row carrying its own `request_digest`, the SHA-256 of the substituted request's canonical JSON (sorted keys, no whitespace); the corpus adapter `crates/verter_validation_probe/src/corpus/vue_benchmarks.rs`; `ProbeStateManifest` entries with stable case ids `vue/<relative-path-in-corpus>`; the summary artifact `target/validation-probe/…

<!-- tama-workflow-publication:workflow:request_8ab21487-f6e6-4281-83e7-f4e0d3181cd9:draft#1:1 -->