### PR TITLE
fix(core): delete the Vue combined-compiler compatibility trait impl

### DIFF
--- a/crates/verter_compiler/src/framework_common/carrier_compiler.rs
+++ b/crates/verter_compiler/src/framework_common/carrier_compiler.rs
@@ -828,41 +828,6 @@ impl RuntimeCompileOutput {
     }
 }
 
-/// Test-only convenience over [`CarrierCompiler::compile_bundle`] for fixtures
-/// whose carrier is known to PRODUCE.
-///
-/// Deliberately test-only: production code matches the outcome exhaustively, so
-/// a refusal can never be unwrapped into "some bundle" there. A test that is
-/// ABOUT the refusal calls `compile_bundle` directly and matches the arm.
-#[cfg(test)]
-pub(crate) trait CompileBundleProducedExt {
-    fn compile_bundle_expect_produced(
-        &self,
-        source: &str,
-        artifact: &FrameworkParseArtifact,
-        opts: &RuntimeCompileOptions,
-        alloc: &oxc_allocator::Allocator,
-    ) -> Result<RuntimeCompileOutput, CompileUnsupported>;
-}
-
-#[cfg(test)]
-impl<T: CarrierCompiler + ?Sized> CompileBundleProducedExt for T {
-    fn compile_bundle_expect_produced(
-        &self,
-        source: &str,
-        artifact: &FrameworkParseArtifact,
-        opts: &RuntimeCompileOptions,
-        alloc: &oxc_allocator::Allocator,
-    ) -> Result<RuntimeCompileOutput, CompileUnsupported> {
-        self.compile_bundle(source, artifact, opts, alloc)
-            .map(|outcome| {
-                outcome
-                    .into_produced()
-                    .expect("this fixture's carrier produces a runtime surface")
-            })
-    }
-}
-
 /// Why a carrier FAIL-CLOSED on the runtime surface a request asked for.
 ///
 /// The reason is carried STRUCTURALLY — a stable code plus its message and

--- a/crates/verter_compiler/src/framework_common/carrier_compiler.rs
+++ b/crates/verter_compiler/src/framework_common/carrier_compiler.rs
@@ -1,7 +1,6 @@
 //! Carrier-compiler trait and framework-neutral I/O.
 //!
-//! One trait per carrier: parse, IDE codegen, runtime bundle.
-//! Vue is the reference (`vue_bridge::VueCarrierCompiler`). Eval-source
+//! Parse, IDE codegen, runtime bundle. Eval-source
 //! and template facts belong to
 //! [`super::capability::FrameworkSemanticAuthority`]. Script facts go
 //! through the host `ScriptFactProvider` seam — not this trait.

--- a/crates/verter_compiler/src/framework_common/mod.rs
+++ b/crates/verter_compiler/src/framework_common/mod.rs
@@ -13,10 +13,11 @@
 //! framework substrate: the [`CarrierCompiler`] trait (parse / IDE /
 //! runtime) and the immutable per-capability catalogs
 //! (`registered_carrier_projection::built_in_frontend_catalog` and
-//! friends) production selectors dispatch through. Vue is the reference
-//! implementation ([`vue_bridge::VueCarrierCompiler`]), delegating
-//! call-for-call to the existing Vue pipeline with ZERO edits to any Vue
-//! parser/codegen module.
+//! friends) production selectors dispatch through.
+//! [`vue_bridge::VueCarrierCompiler`] exposes the equivalent typed
+//! capabilities as inherent methods, delegating call-for-call to the
+//! existing Vue pipeline with ZERO edits to any Vue parser/codegen
+//! module.
 
 pub mod capability;
 pub mod carrier_compiler;

--- a/crates/verter_compiler/src/framework_common/registered_carrier_projection.rs
+++ b/crates/verter_compiler/src/framework_common/registered_carrier_projection.rs
@@ -19,8 +19,7 @@ use super::capability::{
     CarrierFrontend, FrameworkEpochId, FrameworkSemanticAuthority, ProjectionBackend,
 };
 use super::carrier_compiler::{
-    CarrierCompiler, CompileUnsupported, RuntimeBlockContentInputs, RuntimeDiagnostic,
-    RuntimeDiagnosticSeverity,
+    CompileUnsupported, RuntimeBlockContentInputs, RuntimeDiagnostic, RuntimeDiagnosticSeverity,
 };
 use super::catalog::{CatalogCapability, CatalogRow, ImmutableCapabilityCatalog};
 use super::vue_bridge::VueCarrierCompiler;

--- a/crates/verter_compiler/src/framework_common/sourcemap_e2e_helpers.rs
+++ b/crates/verter_compiler/src/framework_common/sourcemap_e2e_helpers.rs
@@ -5,9 +5,10 @@
 //! `(generated_code, source_map_json)` pair plus the original carrier
 //! source, so EVERY carrier vertical (Vue today; Svelte / React / Astro
 //! later) re-runs the SAME e2e correctness assertions against its own
-//! [`CarrierCompiler::compile_ide`](super::CarrierCompiler::compile_ide)
-//! output. A token that maps to mismatched source text is the bug class
-//! these helpers catch.
+//! typed `compile_ide` output (e.g.
+//! [`VueCarrierCompiler::compile_ide`](super::vue_bridge::VueCarrierCompiler::compile_ide)).
+//! A token that maps to mismatched source text is the bug class these
+//! helpers catch.
 //!
 //! Test-only: gated behind `#[cfg(test)]` so the helpers never ship in a
 //! release artifact, but `pub` so a later vertical's `#[cfg(test)]`
@@ -231,7 +232,7 @@ pub fn assert_token_maps_to_source_line(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::framework_common::carrier_compiler::{CarrierCompiler, IdeCompileOptions};
+    use crate::framework_common::carrier_compiler::IdeCompileOptions;
     use crate::framework_common::vue_bridge::VueCarrierCompiler;
 
     #[test]

--- a/crates/verter_compiler/src/framework_common/vue_bridge.rs
+++ b/crates/verter_compiler/src/framework_common/vue_bridge.rs
@@ -921,10 +921,12 @@ mod tests {
     use verter_language::{ExternalLinkKind, ScriptRegionKind};
 
     /// Test-only convenience over [`VueCarrierCompiler::compile_bundle`] for
-    /// fixtures whose carrier is known to PRODUCE — mirrors the crate's
-    /// `CompileBundleProducedExt`, scoped to `VueCarrierCompiler`'s own
-    /// inherent `compile_bundle` now that Vue no longer implements the
-    /// shared `CarrierCompiler` trait.
+    /// fixtures whose carrier is known to PRODUCE.
+    ///
+    /// Deliberately test-only: production code matches the outcome
+    /// exhaustively, so a refusal can never be unwrapped into "some bundle"
+    /// there. A test that is ABOUT the refusal calls `compile_bundle`
+    /// directly and matches the arm.
     trait VueCompileBundleProducedExt {
         fn compile_bundle_expect_produced(
             &self,

--- a/crates/verter_compiler/src/framework_common/vue_bridge.rs
+++ b/crates/verter_compiler/src/framework_common/vue_bridge.rs
@@ -2951,7 +2951,7 @@ mod tests {
         assert!(artifact.diagnostics().is_empty());
     }
 
-    // ── Vue CarrierCompiler impl ───────────────────────────────────
+    // ── Vue carrier compiler inherent methods ───────────────────────
 
     #[test]
     fn vue_compiler_parse_stamps_the_parse_key_and_vue_identity() {

--- a/crates/verter_compiler/src/framework_common/vue_bridge.rs
+++ b/crates/verter_compiler/src/framework_common/vue_bridge.rs
@@ -26,10 +26,10 @@ use crate::compile_request::{
     IdeProductRequest, VueBackendRequest, VueCompileRequest,
 };
 use crate::framework_common::carrier_compiler::{
-    CarrierCompileOutcome, CarrierCompiler, CompileUnsupported, IdeCompileOptions, IdeOutput,
-    RuntimeCompileOptions, RuntimeCompileOutput, RuntimeCustomBlock, RuntimeDiagnostic,
-    RuntimeMainModule, RuntimeOutputDescriptor, RuntimeScriptBlock, RuntimeStyleBlock,
-    RuntimeTemplateBlock, SourceMapFidelity,
+    CarrierCompileOutcome, CompileUnsupported, IdeCompileOptions, IdeOutput, RuntimeCompileOptions,
+    RuntimeCompileOutput, RuntimeCustomBlock, RuntimeDiagnostic, RuntimeMainModule,
+    RuntimeOutputDescriptor, RuntimeScriptBlock, RuntimeStyleBlock, RuntimeTemplateBlock,
+    SourceMapFidelity,
 };
 use crate::framework_common::FrameworkParseArtifact;
 use verter_language::ParseOptions;
@@ -198,7 +198,7 @@ pub fn build_vue_parse_artifact(
     ))
 }
 
-/// The Vue carrier compiler — the reference [`CarrierCompiler`].
+/// The Vue carrier compiler — the reference typed carrier compiler.
 ///
 /// Delegates call-for-call to the existing Vue pipeline (`parse_sfc` +
 /// `compile_from_parsed`): it edits NO Vue parser or codegen module and
@@ -324,19 +324,25 @@ pub fn resolve_vue_backend_for_audit(
     Some(request.resolve_vue_backend(parsed.is_vapor()))
 }
 
-impl CarrierCompiler for VueCarrierCompiler {
-    fn adapter_id(&self) -> FrameworkAdapterId {
+impl VueCarrierCompiler {
+    /// The adapter identity this compiler answers to in the immutable
+    /// capability catalog.
+    #[must_use]
+    pub fn adapter_id(&self) -> FrameworkAdapterId {
         FrameworkAdapterId::vue()
     }
 
-    fn carrier_language_id(&self) -> LanguageId {
+    /// The carrier LANGUAGE id this compiler serves.
+    #[must_use]
+    pub fn carrier_language_id(&self) -> LanguageId {
         // The `.vue` SFC carrier language. A same-adapter non-carrier row
         // (e.g. an external Vue template) is NOT this language and is not
         // routed through the SFC parse path.
         LanguageId::new("vue")
     }
 
-    fn parse(
+    /// Parse carrier `source` into the framework-neutral artifact.
+    pub fn parse(
         &self,
         source: &str,
         opts: &ParseOptions,
@@ -374,7 +380,7 @@ impl CarrierCompiler for VueCarrierCompiler {
         Ok(build_vue_parse_artifact(source, parsed, opts))
     }
 
-    fn compile_ide(
+    pub fn compile_ide(
         &self,
         source: &str,
         artifact: &FrameworkParseArtifact,
@@ -414,7 +420,7 @@ impl CarrierCompiler for VueCarrierCompiler {
         .map(|companion| companion.ide)
     }
 
-    fn compile_bundle(
+    pub fn compile_bundle(
         &self,
         source: &str,
         artifact: &FrameworkParseArtifact,
@@ -433,8 +439,8 @@ impl CarrierCompiler for VueCarrierCompiler {
 
 /// The one Vue bundle orchestration over an admitted parse: ordered
 /// runtime, IDE-projection, and template-fact capability calls with shared
-/// prerequisites and deduplicated diagnostics. Shared by the compatibility
-/// [`CarrierCompiler::compile_bundle`] route and the Vue host-integration
+/// prerequisites and deduplicated diagnostics. Shared by
+/// [`VueCarrierCompiler::compile_bundle`] and the Vue host-integration
 /// backend so both drive the identical single-population pass.
 ///
 /// Every product-backend leg requires — and consumes — its own
@@ -904,7 +910,6 @@ fn exact_slice_source_map(source: &str, source_start: u32, output: &str) -> Stri
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::framework_common::carrier_compiler::CompileBundleProducedExt;
     use crate::framework_common::{
         carrier_compiler::OutputSourceSpaceKind, FrameworkSemanticAuthority,
         RuntimeBlockContentInput, RuntimeBlockContentInputs,
@@ -914,6 +919,38 @@ mod tests {
     use std::process::Command;
     use verter_css_syntax::CssDialect;
     use verter_language::{ExternalLinkKind, ScriptRegionKind};
+
+    /// Test-only convenience over [`VueCarrierCompiler::compile_bundle`] for
+    /// fixtures whose carrier is known to PRODUCE — mirrors the crate's
+    /// `CompileBundleProducedExt`, scoped to `VueCarrierCompiler`'s own
+    /// inherent `compile_bundle` now that Vue no longer implements the
+    /// shared `CarrierCompiler` trait.
+    trait VueCompileBundleProducedExt {
+        fn compile_bundle_expect_produced(
+            &self,
+            source: &str,
+            artifact: &FrameworkParseArtifact,
+            opts: &RuntimeCompileOptions,
+            alloc: &oxc_allocator::Allocator,
+        ) -> Result<RuntimeCompileOutput, CompileUnsupported>;
+    }
+
+    impl VueCompileBundleProducedExt for VueCarrierCompiler {
+        fn compile_bundle_expect_produced(
+            &self,
+            source: &str,
+            artifact: &FrameworkParseArtifact,
+            opts: &RuntimeCompileOptions,
+            alloc: &oxc_allocator::Allocator,
+        ) -> Result<RuntimeCompileOutput, CompileUnsupported> {
+            self.compile_bundle(source, artifact, opts, alloc)
+                .map(|outcome| {
+                    outcome
+                        .into_produced()
+                        .expect("this fixture's carrier produces a runtime surface")
+                })
+        }
+    }
 
     /// Stand in for the host's identity for the tool that produced the bytes
     /// these tests supply.

--- a/crates/verter_compiler/src/framework_common/vue_carrier_frontend.rs
+++ b/crates/verter_compiler/src/framework_common/vue_carrier_frontend.rs
@@ -15,7 +15,6 @@ use verter_language::{
 use super::capability::{CarrierFrontend, FrameworkEpoch, Present};
 use super::catalog::{FrontendCap, TypedCapabilityRegistration};
 use super::vue_bridge::VueCarrierCompiler;
-use super::CarrierCompiler;
 
 /// Vue carrier frontend: parse, typed reject, adapter identity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/verter_compiler/src/framework_common/vue_host_integration.rs
+++ b/crates/verter_compiler/src/framework_common/vue_host_integration.rs
@@ -44,7 +44,7 @@ use super::registered_carrier_projection::{
 use super::vue_bridge::{vue_carrier_bundle, VueCarrierCompiler};
 use super::vue_carrier_frontend::{VueCarrierFrontend, VueParseAdmission, VueSfcV3};
 use super::vue_semantic_authority::{VueSemanticAdmission, VueSemanticAuthority};
-use super::{CarrierCompiler, FrameworkParseArtifact};
+use super::FrameworkParseArtifact;
 
 /// Vue host-integration backend for the native host epoch.
 ///

--- a/crates/verter_compiler/src/framework_common/vue_projection_backend.rs
+++ b/crates/verter_compiler/src/framework_common/vue_projection_backend.rs
@@ -24,7 +24,7 @@ use crate::framework_common::generated_chunk::{
 };
 use crate::framework_common::vue_bridge::VueCarrierCompiler;
 use crate::framework_common::vue_carrier_frontend::VueSfcV3;
-use crate::framework_common::{CarrierCompiler, FrameworkParseArtifact};
+use crate::framework_common::FrameworkParseArtifact;
 use crate::standalone::{DirectCompileError, StandaloneCompiler};
 
 /// Vue IDE projection backend.

--- a/crates/verter_compiler/src/framework_common/vue_runtime_backend.rs
+++ b/crates/verter_compiler/src/framework_common/vue_runtime_backend.rs
@@ -21,7 +21,7 @@ use crate::framework_common::carrier_compiler::RuntimeBlockContentInputs;
 use crate::framework_common::catalog::{RuntimeCap, TypedCapabilityRegistration};
 use crate::framework_common::vue_bridge::VueCarrierCompiler;
 use crate::framework_common::vue_carrier_frontend::VueSfcV3;
-use crate::framework_common::{CarrierCompiler, FrameworkParseArtifact};
+use crate::framework_common::FrameworkParseArtifact;
 use crate::standalone::{
     compile_vue_parsed_runtime, DirectCompileError, DirectCompileOutput, VueParsedRuntimeError,
 };

--- a/crates/verter_compiler/src/framework_common/vue_semantic_authority.rs
+++ b/crates/verter_compiler/src/framework_common/vue_semantic_authority.rs
@@ -14,7 +14,7 @@ use crate::compile::types::{
 use crate::compile::{compile_from_parsed_legacy, RawTemplateData};
 
 use super::capability::{FrameworkSemanticAuthority, Present};
-use super::carrier_compiler::{CarrierCompiler, RuntimeDiagnostic};
+use super::carrier_compiler::RuntimeDiagnostic;
 use super::catalog::{SemanticCap, TypedCapabilityRegistration};
 use super::registered_carrier_projection::TemplateFactsProduct;
 use super::vue_bridge::VueCarrierCompiler;

--- a/crates/verter_compiler/src/svelte/carrier.rs
+++ b/crates/verter_compiler/src/svelte/carrier.rs
@@ -622,9 +622,9 @@ mod tests {
         )
     }
 
-    /// Test-only convenience for fixtures whose carrier is known to PRODUCE —
-    /// mirrors the crate's `CompileBundleProducedExt`, over the free
-    /// [`compile_bundle_direct`] rather than a `CarrierCompiler` impl.
+    /// Test-only convenience for fixtures whose carrier is known to
+    /// PRODUCE, over the free [`compile_bundle_direct`] rather than a
+    /// `CarrierCompiler` impl.
     fn compile_bundle_expect_produced(
         source: &str,
         artifact: &FrameworkParseArtifact,

--- a/crates/verter_compiler/tests/cases/parse_diagnostic_determinism.rs
+++ b/crates/verter_compiler/tests/cases/parse_diagnostic_determinism.rs
@@ -3,7 +3,6 @@ use verter_compiler::diagnostics::{
     sort_diagnostics, Diagnostic, SyntaxPluginContext, SyntaxPluginOptions,
 };
 use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
-use verter_compiler::framework_common::CarrierCompiler;
 use verter_compiler::parser::Syntax;
 use verter_compiler::svelte::SvelteCarrierCompiler;
 use verter_language::{sort_language_diagnostics, LanguageDiagnostic, ParseOptions};

--- a/crates/verter_compiler/tests/cases/projection_catalog.rs
+++ b/crates/verter_compiler/tests/cases/projection_catalog.rs
@@ -17,9 +17,9 @@ use verter_compiler::framework_common::registered_carrier_projection::{
 };
 use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
 use verter_compiler::framework_common::{
-    CarrierCompileOutcome, CarrierCompiler, CatalogCapability, CompileUnsupported,
-    FrameworkParseArtifact, IdeCompileOptions, ProjectionBackend, RuntimeCompileOptions,
-    RuntimeDiagnostic, VueProjectionBackend, VueProjectionInputs,
+    CarrierCompileOutcome, CatalogCapability, CompileUnsupported, FrameworkParseArtifact,
+    IdeCompileOptions, ProjectionBackend, RuntimeCompileOptions, RuntimeDiagnostic,
+    VueProjectionBackend, VueProjectionInputs,
 };
 use verter_compiler::svelte::{SvelteProjectionBackend, SvelteProjectionInputs};
 use verter_language::carrier_grammar::{
@@ -120,7 +120,7 @@ fn svelte_ide_request(filename: &str) -> CompileRequest {
 }
 
 fn produced_bundle(
-    compiler: &impl CarrierCompiler,
+    compiler: &VueCarrierCompiler,
     source: &str,
     artifact: &FrameworkParseArtifact,
     opts: &RuntimeCompileOptions,

--- a/crates/verter_compiler/tests/cases/style_codetransform_map_coverage.rs
+++ b/crates/verter_compiler/tests/cases/style_codetransform_map_coverage.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use oxc_allocator::Allocator;
 use verter_compiler::framework_common::carrier_compiler::{
-    CarrierCompiler, RuntimeBlockContentInput, RuntimeBlockContentInputs, RuntimeCompileOptions,
+    RuntimeBlockContentInput, RuntimeBlockContentInputs, RuntimeCompileOptions,
 };
 use verter_compiler::framework_common::registered_carrier_projection::project_registered_accepted;
 use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;

--- a/crates/verter_compiler/tests/cases/vue_carrier_frontend.rs
+++ b/crates/verter_compiler/tests/cases/vue_carrier_frontend.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
 use verter_compiler::framework_common::{
-    vue_carrier_frontend_registration, CarrierCompiler, CarrierFrontend, CatalogCapability,
-    CatalogRow, FrameworkEpoch, ImmutableCapabilityCatalog, VueCarrierFrontend, VueSfcV3,
+    vue_carrier_frontend_registration, CarrierFrontend, CatalogCapability, CatalogRow,
+    FrameworkEpoch, ImmutableCapabilityCatalog, VueCarrierFrontend, VueSfcV3,
 };
 use verter_language::{
     parse_key_for, syntax_profile_id_for, FileLanguage, FrameworkAdapterId, LanguageId,

--- a/crates/verter_compiler/tests/cases/vue_projection_backend.rs
+++ b/crates/verter_compiler/tests/cases/vue_projection_backend.rs
@@ -10,11 +10,11 @@ use verter_compiler::compile_request::{
 };
 use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
 use verter_compiler::framework_common::{
-    vue_projection_backend_registration, CarrierCompiler, CatalogCapability, CatalogRow,
-    CompileUnsupported, FrameworkEpoch, FrameworkParseArtifact, IdeCompileOptions,
-    ImmutableCapabilityCatalog, ProjectionBackend, RuntimeBlockContentInput,
-    RuntimeBlockContentInputs, RuntimeCompileOptions, RuntimeOutputDescriptor,
-    VueProjectionBackend, VueProjectionError, VueProjectionInputs, VueSfcV3,
+    vue_projection_backend_registration, CatalogCapability, CatalogRow, CompileUnsupported,
+    FrameworkEpoch, FrameworkParseArtifact, IdeCompileOptions, ImmutableCapabilityCatalog,
+    ProjectionBackend, RuntimeBlockContentInput, RuntimeBlockContentInputs, RuntimeCompileOptions,
+    RuntimeOutputDescriptor, VueProjectionBackend, VueProjectionError, VueProjectionInputs,
+    VueSfcV3,
 };
 use verter_compiler::standalone::StandaloneCompiler;
 use verter_language::carrier_grammar::{

--- a/crates/verter_compiler/tests/cases/vue_runtime_backend.rs
+++ b/crates/verter_compiler/tests/cases/vue_runtime_backend.rs
@@ -15,8 +15,8 @@ use verter_compiler::compile_request::{
 };
 use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
 use verter_compiler::framework_common::{
-    vue_runtime_backend_registration, CarrierCompiler, CatalogCapability, CatalogRow,
-    FrameworkEpoch, FrameworkParseArtifact, ImmutableCapabilityCatalog, RuntimeBlockContentInput,
+    vue_runtime_backend_registration, CatalogCapability, CatalogRow, FrameworkEpoch,
+    FrameworkParseArtifact, ImmutableCapabilityCatalog, RuntimeBlockContentInput,
     RuntimeBlockContentInputs, RuntimeCompileOptions, RuntimeCompilerBackend, VueRuntimeBackend,
     VueRuntimeError, VueRuntimeExecutionFacts, VueRuntimeInputs, VueSfcV3,
 };

--- a/crates/verter_session/src/compile/compile_tests.rs
+++ b/crates/verter_session/src/compile/compile_tests.rs
@@ -464,7 +464,7 @@ fn assemble_main_module_render_function_binding() {
 fn assemble_main_module_template_only_sfc() {
     use oxc_allocator::Allocator;
     use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
-    use verter_compiler::framework_common::{CarrierCompiler, RuntimeCompileOptions};
+    use verter_compiler::framework_common::RuntimeCompileOptions;
 
     // Drive the Vue CARRIER `compile_bundle` (the registry-routed producer)
     // so this end-to-end assembly test exercises the neutral bundle path.
@@ -534,7 +534,7 @@ fn assemble_main_module_template_only_sfc() {
 fn assemble_main_module_inline_topology() {
     use oxc_allocator::Allocator;
     use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
-    use verter_compiler::framework_common::{CarrierCompiler, RuntimeCompileOptions};
+    use verter_compiler::framework_common::RuntimeCompileOptions;
 
     let source = "<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hello')\n</script>\n<template><div>{{ msg }}</div></template>";
     let alloc = Allocator::new();
@@ -615,7 +615,7 @@ fn assemble_main_module_inline_topology() {
 fn assemble_passes_compiler_returned_bindings_verbatim() {
     use oxc_allocator::Allocator;
     use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
-    use verter_compiler::framework_common::{CarrierCompiler, RuntimeCompileOptions};
+    use verter_compiler::framework_common::RuntimeCompileOptions;
 
     // UnusedSetupImport must be elided by the COMPILER (not by any
     // assembly-level text filtering); `msg` is template-used and stays.

--- a/crates/verter_session/src/compile/compile_tests.rs
+++ b/crates/verter_session/src/compile/compile_tests.rs
@@ -466,8 +466,8 @@ fn assemble_main_module_template_only_sfc() {
     use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
     use verter_compiler::framework_common::RuntimeCompileOptions;
 
-    // Drive the Vue CARRIER `compile_bundle` (the registry-routed producer)
-    // so this end-to-end assembly test exercises the neutral bundle path.
+    // Drive the Vue carrier `compile_bundle` producer so this end-to-end
+    // assembly test exercises the neutral bundle path.
     let source = "<template><div>hello</div></template>";
     let alloc = Allocator::new();
     let compiler = VueCarrierCompiler;

--- a/crates/verter_session/src/compile/map_equality_tests.rs
+++ b/crates/verter_session/src/compile/map_equality_tests.rs
@@ -2256,7 +2256,7 @@ struct CompileAxes {
 fn compile_fixture(fixture: &str, axes: CompileAxes) -> RealCompile {
     use oxc_allocator::Allocator;
     use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
-    use verter_compiler::framework_common::{CarrierCompiler, RuntimeCompileOptions};
+    use verter_compiler::framework_common::RuntimeCompileOptions;
 
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../packages/framework-conformance-harness/fixtures/vue")
@@ -2602,7 +2602,7 @@ fn genuine_compiler_output_agrees_across_implementations() {
 fn filename_none_is_not_a_real_host_shape_and_the_carrier_defect_it_exposes_is_tracked() {
     use oxc_allocator::Allocator;
     use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
-    use verter_compiler::framework_common::{CarrierCompiler, RuntimeCompileOptions};
+    use verter_compiler::framework_common::RuntimeCompileOptions;
 
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../../packages/framework-conformance-harness/fixtures/vue")

--- a/crates/verter_session/src/compile/map_equality_tests/nested_v_for_runtime_proof.rs
+++ b/crates/verter_session/src/compile/map_equality_tests/nested_v_for_runtime_proof.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use oxc_allocator::Allocator;
 use serde_json::Value;
 use verter_compiler::framework_common::vue_bridge::VueCarrierCompiler;
-use verter_compiler::framework_common::{CarrierCompiler, RuntimeCompileOptions};
+use verter_compiler::framework_common::RuntimeCompileOptions;
 
 use super::bf2_seed_matrix::run_bounded;
 use super::{assemble_vue_main_module, CompileProfile, HmrStrategy};

--- a/crates/verter_session/tests/cases/carrier_compile_routing_gate.rs
+++ b/crates/verter_session/tests/cases/carrier_compile_routing_gate.rs
@@ -947,7 +947,7 @@ fn concurrent_ensure_ide_compiled_and_get_virtual_file_main_share_one_published_
     // observation:
     //
     // 1. ONE parsed carrier artifact. `carrier_parses` is the framework-neutral
-    //    parse-once rail (one increment per `CarrierCompiler::parse`); a
+    //    parse-once rail (one increment per Vue carrier parse); a
     //    regression where each request RE-PARSED the carrier independently
     //    would bump it to >= 2. The carrier is parsed once at `upsert`, and
     //    BOTH the Ide and the Main demand reuse that one cached artifact (no


### PR DESCRIPTION
Delete the unused Vue `impl CarrierCompiler` and Vue-only compatibility helpers after every Vue production route uses typed capabilities. Current compatibility ownership is `VueCarrierCompiler`; final execution ownership is the five Vue typed backends. Svelte's implementation and the shared trait remain valid for separate deletion.

### Scope

- `crates/verter_compiler/src/framework_common/vue_bridge.rs` — delete the combined trait implementation and compatibility-only wrappers, imports, and tests.
- `crates/verter_compiler/src/framework_common/sourcemap_e2e_helpers.rs` — delete or retarget only helpers whose sole consumer is the Vue combined implementation; durable generic map helpers remain.
- Focused compiler direct-result and Vue adapter tests may be retargeted to typed backends; they are evidence, not extra production surfaces.

Do not touch `svelte/carrier.rs`, `svelte/mod.rs`, the `CarrierCompiler` declaration/harness, mixed option/output DTOs, registry authority already deleted by CCA1T1, or staged artifacts.

### Acceptance

Characterize typed-versus-compatibility bytes/maps/diagnostics and work counts, remove the implementation/helper population atomically, then prove the typed route alone. No shadow adapter or fallback may remain.

- **CCA1T2V-AC1:** no Vue `CarrierCompiler` implementation, compatibility wrapper, production call, or Vue-only trait helper remains.
- **CCA1T2V-AC2:** Vue frontend/semantic/projection/runtime/host outputs, maps, diagnostics, refusals, and ordering remain equivalent.
- **CCA1T2V-AC3:** fresh/incremental/cancelled behavior and complete-only admission remain unchanged.
- **CCA1T2V-AC4:** no duplicate parse, semantic, projection, compile, assembly, map, or copy work appears; inapplicable products stay zero-work.

Ceiling: 500 production LOC, 4 production files, 1 crate. Abort on a live Vue trait consumer, Svelte mutation, shared-trait deletion, cross-crate migration, or staged-artifact need. Run focused Vue compiler/capability/map suites and `targeted-domain`; CCA1T2 joins this with CCA1T2S.

Closes #150

<!-- tama-workflow-publication:status:node_70e30190b775f69e2d44c8c6025432b7:node-landing:1789228001057:publish#1:1 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified framework compilation interfaces and streamlined Vue compilation access.
  - Removed unused abstractions and test-only convenience utilities.
  - Updated integrations to use the streamlined compilation interfaces.

- **Documentation**
  - Clarified framework compilation and Vue integration guidance.

- **Tests**
  - Updated test coverage, diagnostics, and terminology to reflect the revised compilation interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->