### PR TITLE
fix(session): retire guard facts a clause rewrote and unmask case

### DIFF
--- a/crates/verter_session/src/project_semantic_dispatch/flow_return.rs
+++ b/crates/verter_session/src/project_semantic_dispatch/flow_return.rs
@@ -5708,15 +5708,69 @@ fn narrowing_facts_of(products: &FlowProductStore) -> Vec<FlowNarrowingFact> {
         .collect()
 }
 
-/// Replace `into`'s whole narrowing overlay with `from`'s.
-fn replace_narrowings(from: &FlowProductStore, into: &mut FlowProductStore) {
+/// Replace `into`'s whole narrowing overlay with `from`'s, EXCEPT for the
+/// roots in `retyped`, which lose their facts entirely.
+///
+/// A clause boundary restores the ENTERING overlay, which is what keeps a
+/// narrow established inside a `try` or a sibling `case` from leaking out.
+/// A binding the clause WROTE is not a candidate for that restore: the
+/// entering fact describes the value the write REPLACED, so reinstating it
+/// would revive a guard the write killed (`typeof p === "string"` before
+/// `try { p = 1 } finally {}` does not describe `p` past the statement).
+/// Both halves of the boundary hold at once — the clause's own facts do
+/// not escape, and the entry's facts about a replaced value do not return.
+///
+/// `retyped` is keyed on the writes the clause EXECUTED, never on the
+/// subset whose reaching type changed: an unchanged write still replaces
+/// the value the entering fact was about, so it retires that fact too. A
+/// state DIFF cannot decide this either, because a clause that writes and
+/// then re-asserts the entering guard ends with the overlay it started
+/// with while having PROVED the fact from the write rather than inherited
+/// it — and that re-established fact is clause-scoped like any other.
+fn replace_narrowings(
+    from: &FlowProductStore,
+    into: &mut FlowProductStore,
+    retyped: &[FlowProductSubject],
+) {
     for subject in into.subjects_in(super::flow_solve::FlowDomain::Narrowing) {
         into.remove(super::flow_solve::FlowDomain::Narrowing, &subject);
     }
     for subject in from.subjects_in(super::flow_solve::FlowDomain::Narrowing) {
+        if retyped.contains(&subject) {
+            continue;
+        }
         if let Some(product) = from.narrowing(&subject) {
             into.set_narrowing(&subject, product.clone());
         }
+    }
+}
+
+/// Drop the fact at exactly `path` under `root`, removing the product when
+/// that was its last fact.
+///
+/// The counterpart of [`push_narrowing_into`]: a whole-binding narrow that
+/// rides the reaching-TYPE layer must RETIRE the overlay fact it
+/// supersedes. A read consults the overlay before the reaching layers and
+/// returns the first answer it finds, so a surviving older fact would mask
+/// the newer, strictly narrower value the baked edge proved.
+fn retire_narrowing_at_path(
+    products: &mut FlowProductStore,
+    root: &FlowProductSubject,
+    path: &Arc<[Arc<str>]>,
+) {
+    let Some(product) = products.narrowing(root) else {
+        return;
+    };
+    let facts: Vec<FlowNarrowingFact> = product
+        .facts()
+        .iter()
+        .filter(|fact| fact.path != *path)
+        .cloned()
+        .collect();
+    if facts.is_empty() {
+        products.remove(super::flow_solve::FlowDomain::Narrowing, root);
+    } else {
+        products.set_narrowing(root, NarrowingProduct::new(facts));
     }
 }
 
@@ -8606,6 +8660,19 @@ impl<'d, 'b> FlowEvaluator<'d, 'b> {
         // A whole-binding fact rides the reaching-TYPE product, keeping
         // the binding's own literal-widening provenance: a narrow
         // replaces the value, never the freshness the value carries.
+        //
+        // The overlay's own whole-binding fact for this root is RETIRED in
+        // the same step. The two layers both answer for the whole binding,
+        // and a read takes the overlay's answer first, so leaving an
+        // enclosing guard's broader fact standing would mask the value
+        // baked here — `if (typeof p === "string") switch (p) { case "a":
+        // … }` would read `string` on an edge that proved `"a"`. Retiring
+        // is sound in this direction and no other: the baked node was
+        // computed FROM the overlay-preferred current value, so it is
+        // never broader than the fact it replaces.
+        let retire_overlay = |products: &mut FlowProductStore, target: &FlowProductSubject| {
+            retire_narrowing_at_path(products, target, &subject.path);
+        };
         let rebind = |products: &mut FlowProductStore, target: &FlowProductSubject| {
             let widening = products.widening(target).cloned();
             products.set_reaching_type(
@@ -8619,11 +8686,20 @@ impl<'d, 'b> FlowEvaluator<'d, 'b> {
                 binding,
                 ..
             } => {
-                rebind(&mut state.products, &FlowProductSubject::Local(*binding));
+                let target = FlowProductSubject::Local(*binding);
+                rebind(&mut state.products, &target);
+                retire_overlay(
+                    &mut state.products,
+                    &self.canonical_runtime_subject(&target),
+                );
             }
             crate::flow_slice_content::SliceNarrowRoot::Local { binding, .. } => {
                 if state.products.reaching(binding).is_some() {
                     rebind(&mut state.products, binding);
+                    retire_overlay(
+                        &mut state.products,
+                        &self.canonical_runtime_subject(binding),
+                    );
                 }
             }
         }
@@ -10275,6 +10351,24 @@ impl<'d, 'b> FlowEvaluator<'d, 'b> {
                     if !exit_states.is_empty() {
                         self.flag_conditionally_defined_bindings(&mut pre_finally, &exit_states);
                     }
+                    // Every binding a clause RETYPED by writing it, in the
+                    // overlay's own subject vocabulary. The clause-entry
+                    // overlay restores around these, never onto them: the
+                    // entering fact was about the value the write replaced.
+                    // Keyed on the EXECUTED writes, so an unchanged write
+                    // retires the entering fact exactly as a changing one
+                    // does — the write replaced the value either way.
+                    let clause_retyped: Vec<FlowProductSubject> = try_writes
+                        .executed
+                        .0
+                        .iter()
+                        .chain(
+                            catch_writes
+                                .iter()
+                                .flat_map(|written| written.executed.0.iter()),
+                        )
+                        .map(|subject| self.canonical_runtime_subject(subject))
+                        .collect();
                     match finally {
                         Some(finally) => {
                             // The finally BODY runs on every completion:
@@ -10303,7 +10397,11 @@ impl<'d, 'b> FlowEvaluator<'d, 'b> {
                             let mut normal_inputs = exit_states.clone();
                             normal_inputs.push(entry.clone());
                             for state in &mut normal_inputs {
-                                replace_narrowings(&entry.products, &mut state.products);
+                                replace_narrowings(
+                                    &entry.products,
+                                    &mut state.products,
+                                    &clause_retyped,
+                                );
                                 self.flag_clause_type_changes(state, &try_writes.type_changes);
                                 if let Some(written) = &catch_writes {
                                     self.flag_clause_type_changes(state, &written.type_changes);
@@ -10345,7 +10443,11 @@ impl<'d, 'b> FlowEvaluator<'d, 'b> {
                             // the entry's overlay) plus exactly the
                             // finally's own writes.
                             let mut post = pre_finally.clone();
-                            replace_narrowings(&entry.products, &mut post.products);
+                            replace_narrowings(
+                                &entry.products,
+                                &mut post.products,
+                                &clause_retyped,
+                            );
                             for subject in &finally_writes.executed.0 {
                                 post.products
                                     .apply_executed_write_from(subject, &finally_end.products);
@@ -10378,13 +10480,26 @@ impl<'d, 'b> FlowEvaluator<'d, 'b> {
                                         }
                                     }
                                 }
-                                let entry_facts = narrowing_facts_of(&entry.products);
+                                // A fact EQUAL to one the entry carried is
+                                // re-established like any other. The try
+                                // PROVED it on the only path that reaches
+                                // here, and whether the entering overlay
+                                // happened to hold the same fact says
+                                // nothing about that: when the clause also
+                                // WROTE the binding, the entering fact was
+                                // retired as stale and this proof is the
+                                // only thing standing. Re-pushing a fact
+                                // the restore already reinstated replaces
+                                // it with itself, so the general case
+                                // costs nothing. (The same reason
+                                // `standing_narrowings` counts a
+                                // re-establishment over the write ledger
+                                // instead of diffing the overlay: a state
+                                // diff cannot tell a proof from an
+                                // untouched position.)
                                 let restored: Vec<FlowNarrowingFact> = try_narrowings
                                     .iter()
-                                    .filter(|fact| {
-                                        !entry_facts.contains(fact)
-                                            && !killed.contains(&fact.binding)
-                                    })
+                                    .filter(|fact| !killed.contains(&fact.binding))
                                     .cloned()
                                     .collect();
                                 for fact in restored {
@@ -10463,7 +10578,11 @@ impl<'d, 'b> FlowEvaluator<'d, 'b> {
                             // the statement, so no clause-established
                             // narrow survives — even when the catch itself
                             // returns (tsgo, measured).
-                            replace_narrowings(&entry.products, &mut pre_finally.products);
+                            replace_narrowings(
+                                &entry.products,
+                                &mut pre_finally.products,
+                                &clause_retyped,
+                            );
                             self.restore_layer_state(pre_finally);
                             path_alive = !exit_states.is_empty();
                         }

--- a/crates/verter_session/src/project_semantic_dispatch/flow_return_tests.rs
+++ b/crates/verter_session/src/project_semantic_dispatch/flow_return_tests.rs
@@ -8999,3 +8999,99 @@ fn flow_return_type_query_argument_keeps_current_narrowing() {
         verter_type_expr::TypeExpr::Primitive(verter_type_expr::PrimitiveName::String)
     );
 }
+
+/// A switch case's dispatch-edge refinement rides the reaching-TYPE
+/// layer, while an enclosing `typeof` guard's fact rides the narrowing
+/// overlay. The case's own `"a"` is what the read must publish: it is the
+/// newer fact and the strictly narrower one, so the enclosing guard's
+/// broader `string` may not outrank it merely for living in the layer a
+/// read consults first. tsgo 7.0.0-dev: the case arm is `{ v: "a" }`, the
+/// default arm `{ v: string }`, and the trailing return `{ v: number }`.
+#[test]
+fn flow_return_switch_case_refinement_outranks_enclosing_guard_fact() {
+    let (expr, degradation) = flow_expr_for_script(
+        "function makeProps(p: string | number) { if (typeof p === \"string\") { switch (p) { case \"a\": return { v: p }; default: return { v: p } } } return { v: 0 } }",
+    );
+    assert_eq!(degradation, None);
+    assert_eq!(
+        member_types(&expr, "v"),
+        vec![
+            string_literal("a"),
+            verter_type_expr::TypeExpr::Primitive(verter_type_expr::PrimitiveName::Number),
+            verter_type_expr::TypeExpr::Primitive(verter_type_expr::PrimitiveName::String),
+        ]
+    );
+}
+
+/// The clause-entry overlay restore is keyed on the writes the clause
+/// EXECUTED, so the two halves of clause scoping hold at once: a narrow
+/// established inside the clause does not escape, and an entering fact
+/// about a value the clause REPLACED does not come back.
+///
+/// The rows separate that rule from the cheaper ones it would be easy to
+/// mistake it for. Restoring the entry overlay unconditionally fails the
+/// changing-write row; keying on the type-CHANGE subset fails the
+/// unchanged-write row; diffing the clause's end overlay against its
+/// entry fails the write-then-equal-assertion row, because that clause
+/// ends holding exactly the overlay it started with while having PROVED
+/// the fact from the write rather than inherited it. The
+/// strengthening-without-a-write row holds the rule's other edge: only a
+/// write retires an entering fact.
+#[test]
+fn flow_return_clause_entry_restore_excludes_every_executed_write() {
+    const PRELUDE: &str = "declare function mayThrow(): void\nfunction assertA(v: unknown): asserts v is \"a\" { if (v !== \"a\") throw 0 }\nfunction assertOne(v: unknown): asserts v is 1 { if (v !== 1) throw 0 }\n";
+    let boolean = verter_type_expr::TypeExpr::Primitive(verter_type_expr::PrimitiveName::Boolean);
+    let number = verter_type_expr::TypeExpr::Primitive(verter_type_expr::PrimitiveName::Number);
+    for (case, body, expected) in [
+        // A CHANGING write: past the statement the binding holds the
+        // written value, never the pre-try `typeof p === "string"` fact
+        // about the value the write replaced.
+        (
+            "changing write",
+            "function makeProps(p: string | number) { if (typeof p === \"string\") { try { p = 1 } finally { mayThrow() } return { v: p } } return { v: true } }",
+            vec![boolean.clone(), number.clone()],
+        ),
+        // STRENGTHENING WITHOUT A WRITE: with no catch, reaching past the
+        // statement PROVES the try completed normally, so the clause's
+        // stronger `"a"` holds. Nothing was written, so there is no stale
+        // entering fact to retire and nothing for the write-keyed rule to
+        // do — the strengthening is what survives.
+        (
+            "strengthening without a write",
+            "function makeProps(p: string | number) { if (typeof p === \"string\") { try { assertA(p) } finally { mayThrow() } return { v: p } } return { v: true } }",
+            vec![string_literal("a"), boolean.clone()],
+        ),
+        // An UNCHANGED write: `p` already reaches `number`, so writing
+        // `q` leaves the reaching type exactly where it was and there is
+        // no type CHANGE to key on. The write still replaced the value
+        // the entering `1` fact described, so that fact is retired and
+        // the binding reads `number`. Keying the restore on the
+        // type-change subset instead would revive the literal.
+        (
+            "unchanged write",
+            "function makeProps(p: string | number, q: number) { p = q; if (p === 1) { try { p = q } finally { mayThrow() } return { v: p } } return { v: true } }",
+            vec![boolean.clone(), number.clone()],
+        ),
+        // A write followed by an assertion proving EXACTLY the entering
+        // fact. The write retires that fact as stale, and the assertion
+        // then re-proves it on the only path reaching past the statement,
+        // so the literal stands on the assertion's own proof rather than
+        // on the entering guard. The clause therefore ENDS holding the
+        // overlay it entered with: an overlay diff reads that as "nothing
+        // happened", and dropping the proof for coinciding with the
+        // retired fact publishes the written `number` on an edge that
+        // proved `1`.
+        (
+            "write then assertion equal to the entry guard",
+            "function makeProps(p: string | number, q: number) { p = q; if (p === 1) { try { p = q; assertOne(p) } finally { mayThrow() } return { v: p } } return { v: true } }",
+            vec![
+                verter_type_expr::TypeExpr::Literal(verter_type_expr::LiteralValue::Number(1.0)),
+                boolean.clone(),
+            ],
+        ),
+    ] {
+        let (expr, degradation) = flow_expr_for_script(&format!("{PRELUDE}{body}"));
+        assert_eq!(degradation, None, "{case}");
+        assert_eq!(member_types(&expr, "v"), expected, "{case}");
+    }
+}

--- a/roadmap/0.1.0-tama/authority/state/implemented.toml
+++ b/roadmap/0.1.0-tama/authority/state/implemented.toml
@@ -181,7 +181,7 @@ schema = 2
 "D3I" = { status = "implemented", commit_message = "feat(flowslice): complete stable binding identity", commit_date = "2026-09-05T11:21:01Z", pull_request = 503 }
 "D3P" = { status = "implemented", commit_message = "feat(session): flow product lattice substrate", commit_date = "2026-09-05T12:00:00+01:00" }
 "D3R" = { status = "implemented", commit_message = "feat(session): nominal relation authority for unique-symbol identity and comparability", commit_date = "2026-09-04T02:30:00+01:00" }
-"D4" = { status = "pending" }
+"D4" = { status = "implemented", commit_message = "fix(session): retire guard facts a clause rewrote and unmask case refinements", commit_date = "2026-09-12T16:30:00+01:00" }
 "D5" = { status = "implemented", commit_message = "feat(session): key closure capture obligations to the callback", commit_date = "2026-09-09T12:00:00+01:00", pull_request = 521 }
 "D6" = { status = "implemented", commit_message = "fix(session): close the flow-completion carrier set and end a divergent loop's normal path", commit_date = "2026-09-12T11:30:00+01:00", pull_request = 532 }
 "D7" = { status = "pending" }


### PR DESCRIPTION
Readiness comes only from trusted implementation-ledger rows. A READY node may start; tooling does not validate commit locators, Git identity, receipts, leases, external state, or runtime admission.

Narrowing and structural returns. The current owner is already the **sole shared flow authority**: `ProjectSemanticDispatch` / `execute_function_return_source` (`crates/verter_session/src/project_semantic_dispatch/flow_return.rs`) over the flow substrate in `crates/verter_semantic/src/analysis/flow`, with `crates/verter_session/src/flow_slice_content.rs` as its content-lowering half — no legacy parallel resolver exists (A5 owner rows; A6 implementation lock record). The final and sole owner is **sole shared flow authority**. This charter accepts one authority/migration/cutover boundary; it contains no independently dispatchable subblocks.

### Scope

- Production surfaces: `crates/verter_semantic/src`, `crates/verter_session/src`.
- Named API/data boundaries: `FlowSliceIR`, `SemanticQueryKey` (including the non-producing `FlowNarrowingAt` / `ContextualTypeAt` variants, which return `Miss`). The earlier `FlowSlice` / `ResultContract` names were disproven by source and are retracted.
- Mutation boundary: only the production surfaces and named API/data boundaries above; every changed path must be inside both that charter surface and the acquired conflict domain, and sibling ownership is excluded.

### Acceptance

Preflight evidence selection: preserve all four acceptance outcomes below, then select the smallest evidence set that actually discriminates the touched contract. Existing behavioral coverage, compiler/type/capability enforcement, static validation, canonical gates, bounded inspection, and benchmarks are valid when accompanied by a terse rationale.

- **D4-AC1 — sole-owner outcome:** the named final owner must be sole and every displaced route named below must be deleted or structurally rejected. Prefer existing type, capability, dependency, compiler, or static enforcement. Add a negative or mutation test only for a plausible critical fail-closed/correctness boundary or a reproduced defect that existing evidence does not discriminate.
- **D4-AC2 — positive contract:** the named API/data boundary must preserve exact identities, provenance, completeness, and deterministic ordering. Reuse existing coverage or extend/table-drive one test before creating a new…

Closes #176

<!-- tama-workflow-publication:workflow:request_366a1866-cade-47bb-850b-9b1eacd19a08:draft#1:1 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type narrowing across `try`, `catch`, and `finally` control-flow boundaries.
  - Preserved valid guard facts while discarding facts invalidated by clause writes.
  - Ensured case-specific refinements take precedence over broader enclosing guards.
  - Corrected narrowing restoration when `finally` clauses execute without a `catch`.

- **Tests**
  - Added coverage for clause writes, whole-binding refinements, and overlapping narrowing facts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->